### PR TITLE
readme: change run command to run python module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Also available on AUR, maintained by yochananmarqos: https://aur.archlinux.org/p
 ### Install dependencies
 `pip3 install -r ./requirements.txt`
 ### Run ProtonUp-Qt
-`python3 pupgui2/pupgui2.py`
+`python3 -m pupgui2`
 
 ## Build AppImage
 ### Install dependencies


### PR DESCRIPTION
In #62 you converted ProtonUp-Qt to a Python module, but in README the command to run from source is still using old method (doesn't work anymore).