### PR TITLE
make single instance check more accurate

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -322,7 +322,7 @@ def single_instance() -> bool:
         f = open(lockfile, 'r')
         pid = f.read()
         f.close()
-        cmdline_file = os.path.join('/proc/' + pid + '/cmdline')
+        cmdline_file = os.path.join('/proc/', pid, 'cmdline')
         if os.path.exists(cmdline_file):
             f = open(cmdline_file, 'r')
             cmdline = f.read()

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 import webbrowser
 import requests
 from configparser import ConfigParser
+import psutil, setproctitle
 
 import PySide6
 from PySide6.QtWidgets import *
@@ -317,12 +318,14 @@ def single_instance() -> bool:
     Creates a lockfile to detect other instances of the app. Returns False if another instance is found
     Return Type: bool
     """
+    proctitle = 'pupgui2'
+    setproctitle.setproctitle(proctitle)
     lockfile = os.path.join(TEMP_DIR, 'lockfile')
     if os.path.exists(lockfile):
         f = open(lockfile, 'r')
-        pid = f.read()
+        pid = int(f.read())
         f.close()
-        if os.path.isdir('/proc/' + pid):
+        if psutil.pid_exists(pid) and psutil.Process(pid).name() == proctitle:
             return False
     try:
         os.mkdir(TEMP_DIR)

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -6,7 +6,6 @@ from typing import Dict, List
 import webbrowser
 import requests
 from configparser import ConfigParser
-import psutil, setproctitle
 
 import PySide6
 from PySide6.QtWidgets import *
@@ -318,15 +317,18 @@ def single_instance() -> bool:
     Creates a lockfile to detect other instances of the app. Returns False if another instance is found
     Return Type: bool
     """
-    proctitle = 'pupgui2'
-    setproctitle.setproctitle(proctitle)
     lockfile = os.path.join(TEMP_DIR, 'lockfile')
     if os.path.exists(lockfile):
         f = open(lockfile, 'r')
-        pid = int(f.read())
+        pid = f.read()
         f.close()
-        if psutil.pid_exists(pid) and psutil.Process(pid).name() == proctitle:
-            return False
+        cmdline_file = os.path.join('/proc/' + pid + '/cmdline')
+        if os.path.exists(cmdline_file):
+            f = open(cmdline_file, 'r')
+            cmdline = f.read()
+            f.close()
+            if 'pupgui2' in cmdline:
+                return False
     try:
         os.mkdir(TEMP_DIR)
         f = open(lockfile, 'w')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ inputs==0.5
 pyxdg==0.28
 steam==1.3.0
 PyYAML==6.0
+psutil==5.9.1
+setproctitle==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,3 @@ inputs==0.5
 pyxdg==0.28
 steam==1.3.0
 PyYAML==6.0
-psutil==5.9.1
-setproctitle==1.3.2


### PR DESCRIPTION
after a reboot, the previous pid written in the lockfile can be taken by other process, in this case, user will keep getting the "Second instance of ProtonUp-Qt found!" but actually there's no other instance. Setting custom process name and checking the process name will make it more accurate.