### PR TITLE
Lutris: Fix some games not being found

### DIFF
--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -141,7 +141,7 @@ class LutrisGame:
 
         fn = ''
         for lutris_cfg in os.listdir(os.path.join(os.path.expanduser(lutris_config_dir), 'games')):
-            if self.slug in lutris_cfg or str(self.installer_slug) in lutris_cfg:
+            if str(self.installer_slug) in lutris_cfg or self.slug in lutris_cfg:
                 fn = lutris_cfg
                 break
 

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -136,14 +136,19 @@ class LutrisGame:
     def get_game_config(self):
         lutris_config_dir = self.install_loc.get('config_dir')
         if not lutris_config_dir:
-            print('no config dir')
             return {}
-
+    
+        # search a *.yml game configuration file that contains either the install_slug+installed_at or, if not found, the game slug
         fn = ''
-        for lutris_cfg in os.listdir(os.path.join(os.path.expanduser(lutris_config_dir), 'games')):
-            if str(self.installer_slug) in lutris_cfg or self.slug in lutris_cfg:
-                fn = lutris_cfg
+        for game_cfg_file in os.listdir(os.path.join(os.path.expanduser(lutris_config_dir), 'games')):
+            if str(self.installer_slug) in game_cfg_file and str(self.installed_at) in game_cfg_file:
+                fn = game_cfg_file
                 break
+        else:
+            for game_cfg_file in os.listdir(os.path.join(os.path.expanduser(lutris_config_dir), 'games')):
+                if self.slug in game_cfg_file:
+                    fn = game_cfg_file
+                    break
 
         lutris_game_cfg = os.path.join(os.path.expanduser(lutris_config_dir), 'games', fn)
         if not os.path.exists(lutris_game_cfg):

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -136,8 +136,15 @@ class LutrisGame:
     def get_game_config(self):
         lutris_config_dir = self.install_loc.get('config_dir')
         if not lutris_config_dir:
+            print('no config dir')
             return {}
-        fn = str(self.installer_slug) + '-' + str(self.installed_at) + '.yml'
+
+        fn = ''
+        for lutris_cfg in os.listdir(os.path.join(os.path.expanduser(lutris_config_dir), 'games')):
+            if self.slug in lutris_cfg or str(self.installer_slug) in lutris_cfg:
+                fn = lutris_cfg
+                break
+
         lutris_game_cfg = os.path.join(os.path.expanduser(lutris_config_dir), 'games', fn)
         if not os.path.exists(lutris_game_cfg):
             return {}

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -71,13 +71,15 @@ class PupguiCtInfoDialog(QObject):
 
     def update_game_list_lutris(self):
         self.ui.listGames.clear()
+
+        lutris_games = [game for game in get_lutris_game_list(self.install_loc) if game.runner == 'wine' and game.get_game_config().get('wine', {}).get('version') == self.ctool.displayname]
+
+        self.ui.listGames.setRowCount(len(lutris_games))
         self.ui.listGames.setHorizontalHeaderLabels([self.tr('Slug'), self.tr('Name')])
-        for i, game in enumerate(get_lutris_game_list(self.install_loc)):
-            if game.runner == 'wine':
-                cfg = game.get_game_config()
-                if self.ctool.displayname == cfg.get('wine', {}).get('version'):
-                    self.ui.listGames.setItem(i, 0, QTableWidgetItem(game.slug))
-                    self.ui.listGames.setItem(i, 1, QTableWidgetItem(game.name))
+        self.ui.txtNumGamesUsingTool.setText(str(len(lutris_games)))
+        for i, game in enumerate(lutris_games):
+            self.ui.listGames.setItem(i, 0, QTableWidgetItem(game.slug))
+            self.ui.listGames.setItem(i, 1, QTableWidgetItem(game.name))
 
     def btn_close_clicked(self):
         self.ui.close()


### PR DESCRIPTION
I was originally going to open an issue for this, but I decided to investigate to try and fix this issue instead. This PR solves the issue I mentioned in #137 with being unable to test Lutris games.

## Overview
The Lutris compatibility tools list has a couple of issues:
- Sometimes, `installer_slug` is `None` and so a game file won't be found, since the logic tries to build a file string for the Lutris game yml config (so a filename could end up being `None-34496832234.yml`
- The label for the number of games using a Lutris compat tool was not set

This PR addresses both of these problems.

## Solution
Instead of building a string, we now loop through all the files in the Lutris game config directory (`~/.config/lutris/games`) and when we find a filename that matches *either* the `slug` *or* the `installer_slug`, we set the name of the config file to that, and then we break. The rest of the logic is the same after that.

For the compat tool count issue, we use a list comprehension to generate the list of Lutris games with a Wine runner that match the `ctool.displayname`. and then set the `txtNumGamesUsingTool` to the length of the generated list.

![image](https://user-images.githubusercontent.com/7917345/202824100-02a17428-eda1-4f7b-9466-5b131310ec8d.png)

## Concerns
I have a couple of concerns here:
- I am using lutris-git from the AUR, but Lutris seems very... *temperamental* about how it saves the compatibility tool name. Usually it is set incorrectly in the yml file until I change the Wine version to something else and then switch back. This is certainly external to PUPQT, but it is something I wanted to bring up nonetheless (in case any lutris-git users run into this)
- This works on my end, but I don't use Lutris very much, so having this work in my testing may not mean very much. I would like more testing to ensure this doesn't destroy any existing functionality
- Should we be stricter about matching the filename? I wasn't sure if we should go to the effort of checking if the `installed_at` timestamp was in the filename too. I think maybe just checking on the slug is enough? :slightly_smiling_face: 

As usual, all feedback is welcomed here :smile: 

Thanks!