### PR TITLE
Lutris: Add vkd3d sources

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -177,13 +177,13 @@ class MainWindow(QObject):
         self.ui.listInstalledVersions.clear()
         self.compat_tool_index_map = get_installed_ctools(install_directory())
 
-        # Launcher specific (Lutris): Show DXVK
+        # Launcher specific (Lutris): Show DXVK and vkd3d-proton
         if install_loc.get('launcher') == 'lutris':
             dxvk_dir = os.path.join(install_directory(), '../../runtime/dxvk')
-            for ct in get_installed_ctools(dxvk_dir):
-                if not 'dxvk' in ct.get_displayname().lower():
-                    ct.displayname = 'DXVK ' + ct.displayname
-                self.compat_tool_index_map.append(ct)
+            vkd3d_dir = os.path.join(install_directory(), '../../runtime/vkd3d')
+
+            self.get_installed_versions('dxvk', dxvk_dir)
+            self.get_installed_versions('vkd3d', vkd3d_dir)
 
         # Launcher specific (Steam): Number of games using the compatibility tool
         if install_loc.get('launcher') == 'steam' and 'vdf_dir' in install_loc:
@@ -210,6 +210,12 @@ class MainWindow(QObject):
         #    self.ui.btnShowGameList.setVisible(True)
         else:
             self.ui.btnShowGameList.setVisible(False)
+
+    def get_installed_versions(self, ctool_name, ctool_dir):
+        for ct in get_installed_ctools(ctool_dir):
+            if not ctool_name in ct.get_displayname().lower():
+                ct.displayname = f'{ctool_name} {ct.displayname}'
+            self.compat_tool_index_map.append(ct) 
 
     def install_compat_tool(self, compat_tool):
         """ install compatibility tool (called by install dialog signal) """

--- a/pupgui2/resources/ctmods/ctmod_vkd3dlutris.py
+++ b/pupgui2/resources/ctmods/ctmod_vkd3dlutris.py
@@ -2,10 +2,8 @@
 # vkd3d-lutris for Lutris: https://github.com/lutris/vkd3d/
 # Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
 
-import os, shutil, tarfile, requests, tempfile
-import zstandard
+import os, shutil, tarfile, requests
 
-from pathlib import Path
 from PySide6.QtCore import *
 
 CT_NAME = 'vkd3d-lutris'
@@ -120,16 +118,14 @@ class CtInstaller(QObject):
 
         vkd3d_dir = os.path.join(install_dir, '../../runtime/vkd3d')
 
-        destination = temp_dir
-        destination += data['download'].split('/')[-1]
-        destination = destination
+        temp_download = os.path.join(temp_dir, data['download'].split('/')[-1])
 
-        if not self.__download(url=data['download'], destination=destination):
+        if not self.__download(url=data['download'], destination=temp_download):
             return False
 
         if os.path.exists(vkd3d_dir + 'vkd3d-' + data['version'].lower()):
             shutil.rmtree(vkd3d_dir + 'vkd3d-' + data['version'].lower())
-        tarfile.open(destination, "r:xz").extractall(vkd3d_dir)        
+        tarfile.open(temp_download, "r:xz").extractall(vkd3d_dir)        
 
         self.__set_download_progress_percent(100)
 

--- a/pupgui2/resources/ctmods/ctmod_vkd3dlutris.py
+++ b/pupgui2/resources/ctmods/ctmod_vkd3dlutris.py
@@ -1,0 +1,143 @@
+# pupgui2 compatibility tools module
+# vkd3d-lutris for Lutris: https://github.com/lutris/vkd3d/
+# Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
+
+import os, shutil, tarfile, requests, tempfile
+import zstandard
+
+from pathlib import Path
+from PySide6.QtCore import *
+
+CT_NAME = 'vkd3d-lutris'
+CT_LAUNCHERS = ['lutris']
+CT_DESCRIPTION = {}
+CT_DESCRIPTION['en'] = QCoreApplication.instance().translate('ctmod_vkd3d-lutris', '''Fork of Wine's VKD3D which aims to implement the full Direct3D 12 API on top of Vulkan (Lutris Release).<br/><br/>https://github.com/lutris/docs/blob/master/HowToDXVK.md''')
+
+class CtInstaller(QObject):
+
+    BUFFER_SIZE = 65536
+    CT_URL = 'https://api.github.com/repos/lutris/vkd3d/releases'
+    CT_INFO_URL = 'https://github.com/lutris/vkd3d/releases/tag/'
+
+    p_download_progress_percent = 0
+    download_progress_percent = Signal(int)
+
+    def __init__(self, main_window = None):
+        super(CtInstaller, self).__init__()
+        self.p_download_canceled = False
+        self.rs = main_window.rs if main_window.rs else requests.Session()
+
+    def get_download_canceled(self):
+        return self.p_download_canceled
+
+    def set_download_canceled(self, val):
+        self.p_download_canceled = val
+
+    download_canceled = Property(bool, get_download_canceled, set_download_canceled)
+
+    def __set_download_progress_percent(self, value : int):
+        if self.p_download_progress_percent == value:
+            return
+        self.p_download_progress_percent = value
+        self.download_progress_percent.emit(value)
+
+    def __download(self, url, destination):
+        """
+        Download files from url to destination
+        Return Type: bool
+        """
+        try:
+            file = self.rs.get(url, stream=True)
+        except OSError:
+            return False
+
+        self.__set_download_progress_percent(1) # 1 download started
+        f_size = int(file.headers.get('content-length'))
+        c_count = int(f_size / self.BUFFER_SIZE)
+        c_current = 1
+        destination = os.path.expanduser(destination)
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        with open(destination, 'wb') as dest:
+            for chunk in file.iter_content(chunk_size=self.BUFFER_SIZE):
+                if self.download_canceled:
+                    self.download_canceled = False
+                    self.__set_download_progress_percent(-2) # -2 download canceled
+                    return False
+                if chunk:
+                    dest.write(chunk)
+                    dest.flush()
+                self.__set_download_progress_percent(int(min(c_current / c_count * 98.0, 98.0))) # 1-98, 100 after extract
+                c_current += 1
+        self.__set_download_progress_percent(99) # 99 download complete
+        return True
+
+    def __fetch_github_data(self, tag):
+        """
+        Fetch GitHub release information
+        Return Type: dict
+        Content(s):
+            'version', 'date', 'download', 'size', 'checksum'
+        """
+        url = self.CT_URL + (f'/tags/{tag}' if tag else '/latest')
+        data = self.rs.get(url).json()
+        if 'tag_name' not in data:
+            return None
+
+        values = {'version': data['tag_name'], 'date': data['published_at'].split('T')[0]}
+        for asset in data['assets']:
+            if asset['name'].endswith('tar.xz'):
+                values['download'] = asset['browser_download_url']
+                values['size'] = asset['size']
+        return values
+
+    def is_system_compatible(self):
+        """
+        Are the system requirements met?
+        Return Type: bool
+        """
+        return True
+
+    def fetch_releases(self, count=100):
+        """
+        List available releases
+        Return Type: str[]
+        """
+        tags = []
+        for release in self.rs.get(self.CT_URL + '?per_page=' + str(count)).json():
+            if 'tag_name' in release:
+                tags.append(release['tag_name'])
+        return tags
+
+    def get_tool(self, version, install_dir, temp_dir):
+        """
+        Download and install the compatibility tool
+        Return Type: bool
+        """
+        data = self.__fetch_github_data(version)
+
+        if not data or 'download' not in data:
+            return False
+
+        vkd3d_dir = os.path.join(install_dir, '../../runtime/vkd3d')
+
+        destination = temp_dir
+        destination += data['download'].split('/')[-1]
+        destination = destination
+
+        if not self.__download(url=data['download'], destination=destination):
+            return False
+
+        if os.path.exists(vkd3d_dir + 'vkd3d-' + data['version'].lower()):
+            shutil.rmtree(vkd3d_dir + 'vkd3d-' + data['version'].lower())
+        tarfile.open(destination, "r:xz").extractall(vkd3d_dir)        
+
+        self.__set_download_progress_percent(100)
+
+        return True
+
+    def get_info_url(self, version):
+        """
+        Get link with info about version (eg. GitHub release page)
+        Return Type: str
+        """
+        return self.CT_INFO_URL + version

--- a/pupgui2/resources/ctmods/ctmod_vkd3dproton.py
+++ b/pupgui2/resources/ctmods/ctmod_vkd3dproton.py
@@ -1,0 +1,157 @@
+# pupgui2 compatibility tools module
+# vkd3d-proton for Lutris: https://github.com/HansKristian-Work/vkd3d-proton/
+# Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
+
+import os, shutil, tarfile, requests, tempfile
+import zstandard
+
+from pathlib import Path
+from PySide6.QtCore import *
+
+CT_NAME = 'vkd3d-proton'
+CT_LAUNCHERS = ['lutris']
+CT_DESCRIPTION = {}
+CT_DESCRIPTION['en'] = QCoreApplication.instance().translate('ctmod_vkd3d-proton', '''Fork of Wine's VKD3D which aims to implement the full Direct3D 12 API on top of Vulkan (Valve Release).<br/><br/>https://github.com/lutris/docs/blob/master/HowToDXVK.md''')
+
+class CtInstaller(QObject):
+
+    BUFFER_SIZE = 65536
+    CT_URL = 'https://api.github.com/repos/HansKristian-Work/vkd3d-proton/releases'
+    CT_INFO_URL = 'https://github.com/HansKristian-Work/vkd3d-proton/releases/tag/'
+
+    p_download_progress_percent = 0
+    download_progress_percent = Signal(int)
+
+    def __init__(self, main_window = None):
+        super(CtInstaller, self).__init__()
+        self.p_download_canceled = False
+        self.rs = main_window.rs if main_window.rs else requests.Session()
+
+    def get_download_canceled(self):
+        return self.p_download_canceled
+
+    def set_download_canceled(self, val):
+        self.p_download_canceled = val
+
+    download_canceled = Property(bool, get_download_canceled, set_download_canceled)
+
+    def __set_download_progress_percent(self, value : int):
+        if self.p_download_progress_percent == value:
+            return
+        self.p_download_progress_percent = value
+        self.download_progress_percent.emit(value)
+
+    def __download(self, url, destination):
+        """
+        Download files from url to destination
+        Return Type: bool
+        """
+        try:
+            file = self.rs.get(url, stream=True)
+        except OSError:
+            return False
+
+        self.__set_download_progress_percent(1) # 1 download started
+        f_size = int(file.headers.get('content-length'))
+        c_count = int(f_size / self.BUFFER_SIZE)
+        c_current = 1
+        destination = os.path.expanduser(destination)
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        with open(destination, 'wb') as dest:
+            for chunk in file.iter_content(chunk_size=self.BUFFER_SIZE):
+                if self.download_canceled:
+                    self.download_canceled = False
+                    self.__set_download_progress_percent(-2) # -2 download canceled
+                    return False
+                if chunk:
+                    dest.write(chunk)
+                    dest.flush()
+                self.__set_download_progress_percent(int(min(c_current / c_count * 98.0, 98.0))) # 1-98, 100 after extract
+                c_current += 1
+        self.__set_download_progress_percent(99) # 99 download complete
+        return True
+
+    def __fetch_github_data(self, tag):
+        """
+        Fetch GitHub release information
+        Return Type: dict
+        Content(s):
+            'version', 'date', 'download', 'size', 'checksum'
+        """
+        url = self.CT_URL + (f'/tags/{tag}' if tag else '/latest')
+        data = self.rs.get(url).json()
+        if 'tag_name' not in data:
+            return None
+
+        values = {'version': data['tag_name'], 'date': data['published_at'].split('T')[0]}
+        for asset in data['assets']:
+            if asset['name'].endswith('tar.zst'):
+                values['download'] = asset['browser_download_url']
+                values['size'] = asset['size']
+        return values
+
+    def is_system_compatible(self):
+        """
+        Are the system requirements met?
+        Return Type: bool
+        """
+        return True
+
+    def fetch_releases(self, count=100):
+        """
+        List available releases
+        Return Type: str[]
+        """
+        tags = []
+        for release in self.rs.get(self.CT_URL + '?per_page=' + str(count)).json():
+            if 'tag_name' in release:
+                tags.append(release['tag_name'])
+        return tags
+
+    def get_tool(self, version, install_dir, temp_dir):
+        """
+        Download and install the compatibility tool
+        Return Type: bool
+        """
+        data = self.__fetch_github_data(version)
+
+        if not data or 'download' not in data:
+            return False
+
+        vkd3d_dir = os.path.join(install_dir, '../../runtime/vkd3d')
+
+        destination = temp_dir
+        destination += data['download'].split('/')[-1]
+        destination = destination
+
+        if not self.__download(url=data['download'], destination=destination):
+            return False
+
+        if os.path.exists(vkd3d_dir + 'vkd3d-proton-' + data['version'].lower()):
+            shutil.rmtree(vkd3d_dir + 'vkd3d-proton-' + data['version'].lower())
+        
+        # Setup zst paths
+        vkd3d_archive_path = Path(destination).expanduser()
+        vkd3d_extract_path = Path(os.path.abspath(vkd3d_dir)).expanduser().resolve()
+
+        vkd3d_decomp = zstandard.ZstdDecompressor()
+        
+        # Extract .tar.zst file - Very convoluted, there is an open request to add support for this to Python tarfile: https://bugs.python.org/issue37095
+        with tempfile.TemporaryFile(suffix='.tar') as vkd3d_outfile:
+            with vkd3d_archive_path.open('rb') as vkd3d_infile:
+                vkd3d_decomp.copy_stream(vkd3d_infile, vkd3d_outfile)
+            vkd3d_outfile.seek(0)
+
+            with tarfile.open(fileobj=vkd3d_outfile) as vkd3d_tarfile:
+                vkd3d_tarfile.extractall(vkd3d_extract_path)
+
+        self.__set_download_progress_percent(100)
+
+        return True
+
+    def get_info_url(self, version):
+        """
+        Get link with info about version (eg. GitHub release page)
+        Return Type: str
+        """
+        return self.CT_INFO_URL + version

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ inputs==0.5
 pyxdg>=0.27
 steam>=1.1.0
 PyYAML==6.0
+zstandard==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ inputs==0.5
 pyxdg>=0.27
 steam>=1.1.0
 PyYAML==6.0
-zstandard==0.19.0
+zstandard>=0.19.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,5 +27,6 @@ install_requires =
     pyxdg>=0.27
     steam>=1.1.0
     PyYAML==6.0
+    zstandard>=0.19.0
 
 packages = find:


### PR DESCRIPTION
Implements #73 

## Overview
Adds support for downloading vkd3d for Lutris. Like with manual DXVK version downloads, this has to be entered manually in the Advanced Options for a Lutris game, but this is general Lutris usage and would apply if this was done manually as well :-)

Two sources are added here: [vkd3d-proton](https://github.com/HansKristian-Work/vkd3d-proton/) (the project used by Valve in Proton) and [vkd3d-lutris](https://github.com/lutris/vkd3d/) (a fork of this project with seemingly minimal changes, at least at the time of writing) - The latter is just a Lutris fork of upstream vkd3d-proton simply called "vkd3d" - This is slightly further behind than regular vkd3d-proton, and releases as a `.tar.xz` instead of a `.tar.zst` like vkd3d-proton does. 

The benefit of having both is the ability to use the latest vkd3d release from upstream vkd3d-proton  and using it "raw", in case there are any changes in the downstream Lutris build. Upstream is on v2.7, Lutris is on v2.6. A brief skim of the commits appears like there are no real changes in the fork, maybe they just host separately for packaging? I am not sure of the reason, but both should work. The folder structure is identical.

This change does **not** impact Steam, as this is irrelevant to Steam.

![image](https://user-images.githubusercontent.com/7917345/203440016-141ba87a-ef09-4e7f-b4ba-349e87c5a1bc.png)
![image](https://user-images.githubusercontent.com/7917345/203440038-edb16a14-997c-4913-967f-aa232ed40b79.png)

## Implementation
### Two Ctmods
I considered taking a similar approach to what I did with SteamTinkerLaunch: Having one "main" ctmod for vkd3d, and then having a separate one for vkd3d-lutris. Since I thought the code would be much the same, just different URLs.

It turns out the URLs are different, and some of the code needed for vkd3d-proton was different. The release asset extensions are different and the extraction and paths would be different. Since they are in reality two separate repositories, I figured having two separate ctmods made the most sense in the end and would be cleaner as there wouldn't be a bunch of conditional checks.

### Zstandard Library
Okay, the main "problem" with this implementation. Upstream vkd3d-proton is releases as a `.tar.zst` file, and this is **not** supported by the Python tarball library. There is a [stale request](https://bugs.python.org/issue37095) for this upstream, but I wouldn't hold my breath on this. And even so, ProtonUp-Qt does not use the latest Python version, so a version bump would be required to make use of that.

To implement this, I used the [Zstandard Python library](https://pypi.org/project/zstandard/) and mostly followed an implementation from a [GitHub Gist](https://gist.github.com/scivision/ad241e9cf0474e267240e196d7545eca). It basically uses this Zstandard library to extract the tar data to a temporary tarfile, which is then extracted properly using the tarfile library.

The problem is that this adds an extra dependency. Creating a PR that adds an extra dependency is probably not very helpful, and I am really sorry about that. I did investigate to see if there was a way to do this without pulling in an extra dependency, but that is how I came across the upstream Python issue.

If there is a way to fix this, I would be happy to remove this dependency.

## Remaining Issues
The only remaining issue with this PR is that the vkd3d downloads don't show up in the compatibility tool list. I figure the Lutris runner `vkd3d` directory just needs to be added somewhere in the code, but I couldn't figure out where to put it.

Apart from this issue, I am happy with the state of the PR and think it's ready for review.

<hr>

Phew, I was meant to take a break but I couldn't resist trying to tackle this :sweat_smile: As always, feedback is appreciated! :-)