### PR TITLE
Fix compat tool game list for Steam Flatpak (CtInfoDialog)

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -28,7 +28,7 @@ for steam_root in _POSSIBLE_STEAM_ROOTS:
 
 POSSIBLE_INSTALL_LOCATIONS = [
     {'install_dir': _STEAM_ROOT + '/compatibilitytools.d/', 'display_name': 'Steam', 'launcher': 'steam', 'type': 'native', 'icon': 'steam', 'vdf_dir': _STEAM_ROOT + '/config'},
-    {'install_dir': '~/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d/', 'display_name': 'Steam Flatpak', 'launcher': 'steam', 'type': 'flatpak', 'icon': 'steam'},
+    {'install_dir': '~/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d/', 'display_name': 'Steam Flatpak', 'launcher': 'steam', 'type': 'flatpak', 'icon': 'steam', 'vdf_dir': '~/.var/app/com.valvesoftware.Steam/.local/share/Steam/config'},
     {'install_dir': '~/snap/steam/common/.steam/root/compatibilitytools.d/', 'display_name': 'Steam Snap', 'launcher': 'steam', 'type': 'snap', 'icon': 'steam', 'vdf_dir': '~/snap/steam/common/.steam/root/config'},
     {'install_dir': '~/.local/share/lutris/runners/wine/', 'display_name': 'Lutris', 'launcher': 'lutris', 'type': 'native', 'icon': 'lutris', 'config_dir': '~/.config/lutris'},
     {'install_dir': '~/.var/app/net.lutris.Lutris/data/lutris/runners/wine/', 'display_name': 'Lutris Flatpak', 'launcher': 'lutris', 'type': 'flatpak', 'icon': 'lutris', 'config_dir': '~/.var/app/net.lutris.Lutris/config/lutris'},

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -48,8 +48,12 @@ class PupguiCtInfoDialog(QObject):
                 if 'Proton' in self.ctool.displayname and self.ctool.ct_type == CTType.CUSTOM:  # 'batch update' option for Proton-GE
                     self.ui.btnBatchUpdate.setVisible(True)
                     self.ui.btnBatchUpdate.clicked.connect(self.btn_batch_update_clicked)
-        else:
+        elif self.install_loc.get('launcher') == 'lutris':
             self.update_game_list_lutris()
+        else:
+            self.ui.txtNumGamesUsingTool.setText('-')
+            self.ui.listGames.setHorizontalHeaderLabels(['', ''])
+            self.ui.listGames.setEnabled(False)
 
         self.ui.btnClose.clicked.connect(self.btn_close_clicked)
 


### PR DESCRIPTION
Close https://github.com/DavidoTek/ProtonUp-Qt/issues/147

1. Add a `vdf_dir` to `Steam Flatpak` in `constants.py`
2. Change the code in `pupgui2ctinfodialog.py` from `else: self.update_game_list_lutris()` to `elif self.install_loc.get('launcher') == 'lutris': self.update_game_list_lutris()`
