### PR TITLE
Fix lsb-release not found

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -59,7 +59,11 @@ class CtInstaller(QObject):
         self.rs = main_window.rs if main_window.rs else requests.Session()
         self.allow_git = allow_git
         proc_prefix = ['flatpak-spawn', '--host'] if os.path.exists('/.flatpak-info') else []
-        self.distinfo = subprocess.run(proc_prefix + ['cat', '/etc/lsb-release'], universal_newlines=True, stdout=subprocess.PIPE).stdout.strip().lower()
+        self.distinfo = subprocess.run(
+            proc_prefix + ['cat', '/etc/lsb-release' if os.path.exists('/etc/lsb-release') else '/etc/os-release'],
+            universal_newlines=True,
+            stdout=subprocess.PIPE
+            ).stdout.strip().lower()
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -60,7 +60,7 @@ class CtInstaller(QObject):
         self.allow_git = allow_git
         proc_prefix = ['flatpak-spawn', '--host'] if os.path.exists('/.flatpak-info') else []
         self.distinfo = subprocess.run(
-            proc_prefix + ['cat', '/etc/lsb-release' if os.path.exists('/etc/lsb-release') else '/etc/os-release'],
+            proc_prefix + ['cat', '/etc/lsb-release', '/etc/os-release'],
             universal_newlines=True,
             stdout=subprocess.PIPE
             ).stdout.strip().lower()

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -314,9 +314,10 @@ def print_system_information() -> None:
     ver_info += ', PySide ' + PySide6.__version__ + '\n'
     ver_info += 'Platform: '
     try:
-        f = open('/etc/lsb-release')
+        f = open('/etc/lsb-release') if os.path.exists('/etc/lsb-release') else open('/etc/os-release')
         l = f.readlines()
         ver_info += l[0].strip().split('=')[1] + ' ' + l[1].strip().split('=')[1] + ' '
+        ver_info = ver_info.replace('"', '')
         f.close()
     except:
         pass


### PR DESCRIPTION
Close https://github.com/DavidoTek/ProtonUp-Qt/issues/148

Use `/etc/os-release` if `/etc/lsb-release` not found.