### PR TITLE
Bump steam library version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ requests>=2.27.0
 vdf>=3.4
 inputs==0.5
 pyxdg>=0.27
-steam>=1.1.0
+steam>=1.4.4
 PyYAML==6.0
 zstandard>=0.19.0


### PR DESCRIPTION
Fixes #155.

The `steam` library for Python was updated yesterday to address an issue with the `parse_appinfo` function. The format of this changed on Steam's side and so the library had to be updated to accommodate this following commit https://github.com/ValvePython/steam/commit/abf65abff15385deb8ba05adaf4e312254fb435c.

Honestly I don't really understand what the changes here did but I can confirm it fixes the issue for me when running from source. Also from my armchair glance at the commit this should not have any breakages on Flatpak or require any sort of Python version bump. It is a fix but it doesn't seem to do anything *too* "magical" or extravegant that might break compatibility anywhere. My concern here is bumping from a minimum of `1.1.0` to a minimum of `1.4.4`. In testing *from source* I could not see anything that has broken (yet, anyway) but I'm also not sure what the previous version of the library I was using was. I would guess that this is probably fine but the changes from 1.1.0 to 1.4.4 may want to be reviewed with more scrutiny first.

Currently the `requirements.txt` mandate `steam>=1.1.0`, however since this new version of the `steam` library fixes a critical bug, I set the version as `>=1.4.4`, forcing this newer version since without it, various pieces of functionality will not work without this version or higher.

Opening this as a PR for transparency on the research process for this fix, as well as discussion. Merging a 3 character change on its own is rarely worth a PR but the commentary around the change might be worth it :-)

Thanks!