### PR TITLE
Add ProtonDB.com status

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -64,6 +64,7 @@ STEAM_API_GETAPPLIST_URL = 'https://api.steampowered.com/ISteamApps/GetAppList/v
 STEAM_APP_PAGE_URL = 'https://store.steampowered.com/app/'
 AWACY_GAME_LIST_URL = 'https://raw.githubusercontent.com/Starz0r/AreWeAntiCheatYet/master/games.json'
 LOCAL_AWACY_GAME_LIST = os.path.join(TEMP_DIR, 'awacy_games.json')
+PROTONDB_API_URL = 'https://www.protondb.com/api/v1/reports/summaries/{game_id}.json'
 
 STEAM_BOXTRON_FLATPAK_APPSTREAM = 'appstream://com.valvesoftware.Steam.CompatibilityTool.Boxtron'
 STEAM_PROTONGE_FLATPAK_APPSTREAM = 'appstream://com.valvesoftware.Steam.CompatibilityTool.Proton-GE'

--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -60,6 +60,8 @@ def PALETTE_DARK():
     palette_dark.setColor(QPalette.HighlightedText, Qt.black)
     return palette_dark
 
+PROTONDB_COLORS = {'platinum': '#b4c7dc', 'gold': '#4f492c', 'silver': '#a6a6a6', 'bronze': '#cd7f32', 'borked': '#ff0000'}
+
 STEAM_API_GETAPPLIST_URL = 'https://api.steampowered.com/ISteamApps/GetAppList/v2/'
 STEAM_APP_PAGE_URL = 'https://store.steampowered.com/app/'
 AWACY_GAME_LIST_URL = 'https://raw.githubusercontent.com/Starz0r/AreWeAntiCheatYet/master/games.json'

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -56,6 +56,7 @@ class SteamApp:
     ctool_name = ''  # Steam's internal compatiblity tool name, e.g. 'proton_7'
     ctool_from_oslist = ''
     awacy_status = AWACYStatus.UNKNOWN  # areweanticheatyet.com Status
+    protondb_summary = {}  # protondb status summary from JSON file
 
     def get_app_id_str(self) -> str:
         return str(self.app_id)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -82,12 +82,18 @@ class PupguiGameListDialog(QObject):
             combo.currentTextChanged.connect(lambda text,game=game: self.queue_ctool_change_steam(text, game))
             self.ui.tableGames.setCellWidget(i, 1, combo)
 
+            lbl_deck_compat = QLabel()
+            # ProtonDB status
+            pdb_tier = game.protondb_summary.get('tier', '?')
+            lbl_deck_compat.setToolTip(f'ProtonDB.com: {pdb_tier}')
+
+            # SteamDeck compatibility
             deckc = game.get_deck_compat_category()
             deckt = game.get_deck_recommended_tool()
             if deckc == SteamDeckCompatEnum.UNKNOWN:
-                self.ui.tableGames.setCellWidget(i, 2, QLabel(self.tr('Unknown')))
+                lbl_deck_compat.setText(self.tr('Unknown'))
             elif deckc == SteamDeckCompatEnum.UNSUPPORTED:
-                self.ui.tableGames.setCellWidget(i, 2, QLabel(self.tr('Unsupported')))
+                lbl_deck_compat.setText(self.tr('Unsupported'))
             elif deckc == SteamDeckCompatEnum.PLAYABLE:
                 if deckt == '':
                     lbltxt = self.tr('Playable')
@@ -95,7 +101,7 @@ class PupguiGameListDialog(QObject):
                     lbltxt = self.tr('Native (playable)')
                 else:
                     lbltxt = self.tr('Playable using {compat_tool}').format(compat_tool=deckt)
-                self.ui.tableGames.setCellWidget(i, 2, QLabel(lbltxt))
+                lbl_deck_compat.setText(lbltxt)
             elif deckc == SteamDeckCompatEnum.VERIFIED:
                 if deckt == '':
                     lbltxt = self.tr('Verified')
@@ -103,8 +109,10 @@ class PupguiGameListDialog(QObject):
                     lbltxt = self.tr('Native (verified)')
                 else:
                     lbltxt = self.tr('Verified for {compat_tool}').format(compat_tool=deckt)
-                self.ui.tableGames.setCellWidget(i, 2, QLabel(lbltxt))
+                lbl_deck_compat.setText(lbltxt)
+            self.ui.tableGames.setCellWidget(i, 2, lbl_deck_compat)
 
+            # AWACY status
             lblicon = QLabel()
             p = QPixmap()
             if game.awacy_status == AWACYStatus.ASUPPORTED:

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>570</width>
+    <width>650</width>
     <height>300</height>
    </rect>
   </property>
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTableWidget" name="tableGames">
      <property name="columnCount">
-      <number>4</number>
+      <number>5</number>
      </property>
      <attribute name="horizontalHeaderDefaultSectionSize">
       <number>160</number>
@@ -28,6 +28,7 @@
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>
      </attribute>
+     <column/>
      <column/>
      <column/>
      <column/>


### PR DESCRIPTION
This PR adds functionality to show the status from [ProtonDB](https://www.protondb.com/) for a game.

- It will download the status summary for all installed games on each startup of ProtonUp-Qt
- Currently, you can display the "ProtonDB tier" by hovering the SteamDeck Compatibilty in the game list
- TODO: Maybe display the status in a separate column?

![Screenshot](https://user-images.githubusercontent.com/54072917/208242291-9a1c6ec3-c9b8-411b-888c-3c7d6ae77cf8.png)