### PR TITLE
Add Offline Indicator to StatusBar

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -25,7 +25,7 @@ from pupgui2.pupgui2installdialog import PupguiInstallDialog
 from pupgui2.steamutil import get_steam_acruntime_list, get_steam_game_list
 from pupgui2.util import apply_dark_theme, create_compatibilitytools_folder, get_installed_ctools, remove_ctool
 from pupgui2.util import install_directory, available_install_directories, get_install_location_from_directory_name
-from pupgui2.util import print_system_information, single_instance, download_awacy_gamelist
+from pupgui2.util import print_system_information, single_instance, download_awacy_gamelist, is_online
 
 
 class InstallWineThread(QThread):
@@ -134,7 +134,7 @@ class MainWindow(QObject):
         self.ui.btnRemoveSelected.setEnabled(False)
         self.ui.btnShowCtInfo.setEnabled(False)
 
-        self.ui.statusBar().showMessage(f'{APP_NAME} {APP_VERSION}')
+        self.set_default_statusbar()
 
         self.giw = GamepadInputWorker()
         if os.getenv('PUPGUI2_DISABLE_GAMEPAD', '0') == '0':
@@ -145,6 +145,12 @@ class MainWindow(QObject):
         self.install_thread = InstallWineThread(self)
         self.install_thread.start()
         QApplication.instance().aboutToQuit.connect(self.install_thread.stop)
+
+    def set_default_statusbar(self):
+        if not is_online():
+            self.ui.statusBar().showMessage(f'{APP_NAME} {APP_VERSION} (Offline)')
+        else:
+            self.ui.statusBar().showMessage(f'{APP_NAME} {APP_VERSION}')
 
     def update_combo_install_location(self):
         self.updating_combo_install_location = True
@@ -194,7 +200,7 @@ class MainWindow(QObject):
 
         self.ui.txtActiveDownloads.setText(str(len(self.pending_downloads)))
         if len(self.pending_downloads) == 0:
-            self.ui.statusBar().showMessage(f'{APP_NAME} {APP_VERSION}')
+            self.set_default_statusbar()
             self.progressBarDownload.setVisible(False)
             self.ui.comboInstallLocation.setEnabled(True)
 
@@ -229,7 +235,7 @@ class MainWindow(QObject):
         if value:
             self.ui.statusBar().showMessage(self.tr('Fetching releases...'))
         else:
-            self.ui.statusBar().showMessage(f'{APP_NAME} {APP_VERSION}')
+            self.set_default_statusbar()
 
     def set_download_progress_percent(self, value):
         """ set download progress bar value and update status bar text """

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -390,7 +390,7 @@ def host_which(name: str) -> str:
     which = subprocess.run(proc_prefix + ['which', name], universal_newlines=True, stdout=subprocess.PIPE).stdout.strip()
     return None if which == '' else which
 
-def is_online(host='https://google.com', timeout=10) -> bool:
+def is_online(host='https://api.github.com/repos/', timeout=3) -> bool:
     """
     Attempts to ping a given host using `requests`.
     Returns False if `requests` raises a `ConnectionError` or `Timeout` exception, otherwise returns True 

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -389,3 +389,16 @@ def host_which(name: str) -> str:
     proc_prefix = ['flatpak-spawn', '--host'] if os.path.exists('/.flatpak-info') else []
     which = subprocess.run(proc_prefix + ['which', name], universal_newlines=True, stdout=subprocess.PIPE).stdout.strip()
     return None if which == '' else which
+
+def is_online(host='https://google.com', timeout=10) -> bool:
+    """
+    Attempts to ping a given host using `requests`.
+    Returns False if `requests` raises a `ConnectionError` or `Timeout` exception, otherwise returns True 
+    
+    Return Type: bool
+    """
+    try:
+        requests.get(host, timeout=timeout)
+        return True
+    except (requests.ConnectionError, requests.Timeout):
+        return False


### PR DESCRIPTION
Had this idea as part of my comments on #163.

Adds an offline check and indicates when the user is offline in the StatusBar by showing a message like `ProtonUp-Qt 2.7.6 (Offline)`. It does this with a newly created `util` method called `is_online`. This pings a given host with a specified timeout using `requests`, and determines if a user is offline by returning False if either a `ConnectionError` or `Timeout` exception is raised. Otherwise we return `True`.

![image](https://user-images.githubusercontent.com/7917345/208968885-03cdc7c0-a6bc-45e4-9985-459d52ccea25.png)

The default host is `google.com` because it has fairly reliable uptime and a short response time. The default timeout passed to requests is `10`. However `is_online` can take a `host` and `timeout` argument, to help keep it flexible (for example, if we need to ping `github.com` instead).

The logic for resetting the statusbar message back to just `ProtonUp-Qt 1.2.3` was repeated in a few places, so I replaced it with a generic `set_default_statusbar` which currently has an if/else. However, based on my comments in #163, this could have an `elif` to show if the GitHub Rate Limit is reached.

Using this function also means when the user interacts with a part of the code that updates this statusbar message (such as trying to download a compatibility tool, where it changes to "Fetching releases..." and then back to the default statusbar message), it will re-check if we're offline and update the message properly.

This was an off-the-cuff idea I had when writing the comment on the mentioned PR and some of the foundation of this PR could help with the suggestions I gave there too, and I figured I could try to help out with implementing this. As usual I'm always open to feedback :-)

Thanks!