### PR TITLE
Don't update statusbar to fetch releases when offline

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -240,7 +240,7 @@ class MainWindow(QObject):
         self.install_thread.buffer_mutex.unlock()
 
     def set_fetching_releases(self, value):
-        if value:
+        if value and is_online():
             self.ui.statusBar().showMessage(self.tr('Fetching releases...'))
         else:
             self.set_default_statusbar()


### PR DESCRIPTION
Fixes a small oversight from #164.

In my tests for that PR I opened ProtonUp-Qt offline to make sure it came up with "(offline)", and then re-connected and opened the compat tool dialog. What I somehow didn't think about was pressing this button while offline. If you do this while offline, the status bar will get stuck on "Fetching releases..."

This just updates the conditional to only update the statusbar text if we can connect to the internet, using the `is_online` method.

There are a couple of other things around offline functionality to consider, like right now there is an error when trying to fetch information from GitHub about the compattool while offline. But those are other issues that as far as I can tell don't have any user-facing impact, they're just """ugly""" in the command line, so I didn't address them here.

Thanks!

P.S. No rush on review/merge, it's the holidays!! :christmas_tree: 