### PR TITLE
Fix Qt Signal error (use Tuple)

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_boxtron.py
+++ b/pupgui2/resources/ctmods/ctmod_boxtron.py
@@ -27,7 +27,7 @@ class CtInstaller(QObject):
 
     p_download_progress_percent = 0
     download_progress_percent = Signal(int)
-    message_box_message = Signal(str, str, QMessageBox.Icon)
+    message_box_message = Signal((str, str, QMessageBox.Icon))
 
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()

--- a/pupgui2/resources/ctmods/ctmod_roberta.py
+++ b/pupgui2/resources/ctmods/ctmod_roberta.py
@@ -27,7 +27,7 @@ class CtInstaller(QObject):
 
     p_download_progress_percent = 0
     download_progress_percent = Signal(int)
-    message_box_message = Signal(str, str, QMessageBox.Icon)
+    message_box_message = Signal((str, str, QMessageBox.Icon))
 
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -50,8 +50,8 @@ class CtInstaller(QObject):
 
     p_download_progress_percent = 0
     download_progress_percent = Signal(float)
-    message_box_message = Signal(str, str, QMessageBox.Icon)
-    question_box_message = Signal(str, str, str, MsgBoxType, QMessageBox.Icon)
+    message_box_message = Signal((str, str, QMessageBox.Icon))
+    question_box_message = Signal((str, str, str, MsgBoxType, QMessageBox.Icon))
 
 
     def __init__(self, main_window = None, allow_git=False):


### PR DESCRIPTION
With *Python 3.11.1* and *PySide 6.4.0.1* following error occurs when the STL ctmod tries to display a question message box: `question_box_message(PyObject) only accepts 1 argument(s), 5 given!`
Does not happen with ProtonUp-Qt AppImage (*Python 3.8*, *PySide 6.2.4*)

Fixed by passing a tuple with arguments instead of the arguments as parameters.
```diff
- Signal(str, str, QMessageBox.Icon)
+ Signal((str, str, QMessageBox.Icon))
```