### PR TITLE
Add support to non-steam games

### DIFF
--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -49,6 +49,8 @@ class SteamApp:
     app_id = -1
     libraryfolder_id = -1
     libraryfolder_path = ''
+    shortcut_id = -1
+    shortcut_path = ''
     game_name = ''
     compat_tool = ''
     app_type = ''
@@ -76,7 +78,9 @@ class SteamApp:
         except:
             return ''
 
-
+    def get_shortcut_id_str(self) -> str:
+        return str(self.shortcut_id)
+    
 class BasicCompatTool:
     displayname = ''
     version = ''

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -49,7 +49,7 @@ class SteamApp:
     app_id = -1
     libraryfolder_id = -1
     libraryfolder_path = ''
-    shortcut_id = -1
+    shortcut_id = -1  # Will be a number >=0 if it is a Non-Steam shortcut
     shortcut_path = ''
     game_name = ''
     compat_tool = ''

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -89,6 +89,8 @@ def get_steam_app_list(steam_config_folder: str, cached=False) -> List[SteamApp]
                 app.deck_compatibility = 'Unknown'
                 if ct := c.get(str(appid)):
                     app.compat_tool = ct.get('name')
+                    app.ctool_name = ct.get('name')
+                    app.ctool_from_oslist = ct.get('from_oslist')
                 apps.append(app)
 
     except Exception as e:

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -79,6 +79,8 @@ def get_steam_app_list(steam_config_folder: str, cached=False) -> List[SteamApp]
                 app.shortcut_id = sid
                 app.shortcut_path = svalue.get('StartDir')
                 app.app_type='game'
+                app.game_name = svalue.get('AppName')
+                app.deck_compatibility = 'Unknown'
                 if ct := c.get(str(appid)):
                     app.compat_tool = ct.get('name')
                 apps.append(app)

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -77,7 +77,10 @@ def get_steam_app_list(steam_config_folder: str, cached=False) -> List[SteamApp]
 
             for sid,svalue in shortcuts_vdf.get('shortcuts').items():
                 app = SteamApp()
-                appid = svalue.get('appid')+(1 << 32) #convert to unsigned
+                appid = svalue.get('appid')
+                if appid < 0:
+                    appid = appid +(1 << 32) #convert to unsigned
+                
                 app.app_id = appid
                 app.shortcut_id = sid
                 app.shortcut_path = svalue.get('StartDir')

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -68,6 +68,9 @@ def get_steam_app_list(steam_config_folder: str, cached=False) -> List[SteamApp]
                 continue
 
             shortcuts_file = os.path.join(user_directory,'config/shortcuts.vdf')
+            if not os.path.exists(shortcuts_file):
+                continue
+        
             shortcuts_vdf = vdf.binary_load(open(shortcuts_file,'rb'))
             if 'shortcuts' not in shortcuts_vdf:
                 continue


### PR DESCRIPTION
This fixes bug #175 . I tested it on my machine and everything seems to be working.
I do not see yet why we would actually need to compute the shortcut ids using the CRC-based algorithm, since Steam does it for us already.

So, please verify I did not miss anything. I batch updated all my games with the new change, and everything worked fine.