### PR TITLE
Fix Steam AppID sort in ctinfodialog

### DIFF
--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -10,7 +10,7 @@ from pupgui2.util import open_webbrowser_thread
 from PySide6.QtCore import QObject, Signal, QDataStream, QByteArray
 from PySide6.QtWidgets import QTableWidgetItem
 from PySide6.QtUiTools import QUiLoader
-
+from PySide6.QtCore import Qt
 
 class PupguiCtInfoDialog(QObject):
 
@@ -65,7 +65,10 @@ class PupguiCtInfoDialog(QObject):
         self.ui.listGames.setRowCount(len(self.games))
         self.ui.listGames.setHorizontalHeaderLabels([self.tr('AppID'), self.tr('Name')])
         for i, game in enumerate(self.games):
-            self.ui.listGames.setItem(i, 0, QTableWidgetItem(game.get_app_id_str()))
+            dataitem_appid = QTableWidgetItem()
+            dataitem_appid.setData(Qt.DisplayRole, int(game.get_app_id_str()))
+
+            self.ui.listGames.setItem(i, 0, dataitem_appid)
             self.ui.listGames.setItem(i, 1, QTableWidgetItem(game.game_name))
 
         self.batch_update_complete.emit(True)


### PR DESCRIPTION
In the `ctinfodialog`, sorting by Steam AppID doesn't work properly. I guess it tries to sort them as strings instead of numbers. The fix for this is a small change to set the data properly as an integer. In my tests, a call to `setData` *is* actually required, as just `QTableWidgetItem(int(game.get_app_id_str()))` results in an empty AppID column :shrug: 

![image](https://user-images.githubusercontent.com/7917345/216610455-38cb8e89-6fc9-43c6-a73d-0aaddebc5be2.png)

My bad for missing this initially. No change should be needed on the Lutris side as Lutris is sorted by slugs, which are strings anyway. I think Steam even stores AppIDs as integers so there shouldn't be any problem with setting the data type as integer.

Thanks :smile: 