### PR TITLE
Allow Sorting in Game List Dialog

### DIFF
--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -1,9 +1,9 @@
 import os
 import pkgutil
 
-from PySide6.QtCore import QObject, Signal, Slot, QDataStream, QByteArray
+from PySide6.QtCore import QObject, Signal, Slot, QDataStream, QByteArray, Qt
 from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QLabel, QComboBox, QPushButton
+from PySide6.QtWidgets import QLabel, QComboBox, QPushButton, QTableWidgetItem
 from PySide6.QtUiTools import QUiLoader
 
 from pupgui2.constants import PROTONDB_COLORS
@@ -73,7 +73,7 @@ class PupguiGameListDialog(QObject):
 
         game_id_table_lables = []
         for i, game in enumerate(self.games):
-            self.ui.tableGames.setCellWidget(i, 0, QLabel(game.game_name))
+            self.ui.tableGames.setItem(i, 0, QTableWidgetItem(game.game_name))
 
             combo = QComboBox()
             combo.addItem('-')
@@ -96,10 +96,13 @@ class PupguiGameListDialog(QObject):
             lbl_deck_compat = QLabel()
             deckc = game.get_deck_compat_category()
             deckt = game.get_deck_recommended_tool()
+            lbltxt = ''
             if deckc == SteamDeckCompatEnum.UNKNOWN:
-                lbl_deck_compat.setText(self.tr('Unknown'))
+                lbltxt = self.tr('Unknown')
+                # lbl_deck_compat.setText(self.tr('Unknown'))
             elif deckc == SteamDeckCompatEnum.UNSUPPORTED:
-                lbl_deck_compat.setText(self.tr('Unsupported'))
+                # lbl_deck_compat.setText(self.tr('Unsupported'))
+                lbltxt = self.tr('Unsupported')
             elif deckc == SteamDeckCompatEnum.PLAYABLE:
                 if deckt == '':
                     lbltxt = self.tr('Playable')
@@ -107,7 +110,7 @@ class PupguiGameListDialog(QObject):
                     lbltxt = self.tr('Native (playable)')
                 else:
                     lbltxt = self.tr('Playable using {compat_tool}').format(compat_tool=deckt)
-                lbl_deck_compat.setText(lbltxt)
+                # lbl_deck_compat.setText(lbltxt)
             elif deckc == SteamDeckCompatEnum.VERIFIED:
                 if deckt == '':
                     lbltxt = self.tr('Verified')
@@ -115,8 +118,9 @@ class PupguiGameListDialog(QObject):
                     lbltxt = self.tr('Native (verified)')
                 else:
                     lbltxt = self.tr('Verified for {compat_tool}').format(compat_tool=deckt)
-                lbl_deck_compat.setText(lbltxt)
-            self.ui.tableGames.setCellWidget(i, 2, lbl_deck_compat)
+                # lbl_deck_compat.setText(lbltxt)
+
+            self.ui.tableGames.setItem(i, 2, QTableWidgetItem(lbltxt))
 
             # AWACY status
             lblicon = QLabel()
@@ -152,7 +156,7 @@ class PupguiGameListDialog(QObject):
         self.ui.tableGames.setRowCount(len(games))
 
         for i, game in enumerate(games):
-            self.ui.tableGames.setCellWidget(i, 0, QLabel(game.name))
+            self.ui.tableGames.setItem(i, 0, QTableWidgetItem(game.name))
 
     def btn_apply_clicked(self):
         self.update_queued_ctools_steam()

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -93,15 +93,12 @@ class PupguiGameListDialog(QObject):
             self.ui.tableGames.setCellWidget(i, 4, btn_fetch_protondb)
 
             # SteamDeck compatibility
-            lbl_deck_compat = QLabel()
             deckc = game.get_deck_compat_category()
             deckt = game.get_deck_recommended_tool()
             lbltxt = ''
             if deckc == SteamDeckCompatEnum.UNKNOWN:
                 lbltxt = self.tr('Unknown')
-                # lbl_deck_compat.setText(self.tr('Unknown'))
             elif deckc == SteamDeckCompatEnum.UNSUPPORTED:
-                # lbl_deck_compat.setText(self.tr('Unsupported'))
                 lbltxt = self.tr('Unsupported')
             elif deckc == SteamDeckCompatEnum.PLAYABLE:
                 if deckt == '':
@@ -110,7 +107,6 @@ class PupguiGameListDialog(QObject):
                     lbltxt = self.tr('Native (playable)')
                 else:
                     lbltxt = self.tr('Playable using {compat_tool}').format(compat_tool=deckt)
-                # lbl_deck_compat.setText(lbltxt)
             elif deckc == SteamDeckCompatEnum.VERIFIED:
                 if deckt == '':
                     lbltxt = self.tr('Verified')
@@ -118,7 +114,6 @@ class PupguiGameListDialog(QObject):
                     lbltxt = self.tr('Native (verified)')
                 else:
                     lbltxt = self.tr('Verified for {compat_tool}').format(compat_tool=deckt)
-                # lbl_deck_compat.setText(lbltxt)
 
             self.ui.tableGames.setItem(i, 2, QTableWidgetItem(lbltxt))
 
@@ -144,6 +139,12 @@ class PupguiGameListDialog(QObject):
                 lblicon.setToolTip(self.tr('Anti-Cheat status unknown'))
                 p.loadFromData(pkgutil.get_data(__name__, 'resources/img/awacy_unknown.png'))
             lblicon.setPixmap(p)
+
+            # Used for sorting
+            lblicon_item = QTableWidgetItem()
+            lblicon_item.setData(Qt.DisplayRole, game.awacy_status.value)
+
+            self.ui.tableGames.setItem(i, 3, lblicon_item)
             self.ui.tableGames.setCellWidget(i, 3, lblicon)
 
             game_id_table_lables.append(game.app_id)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -75,6 +75,7 @@ class PupguiGameListDialog(QObject):
         for i, game in enumerate(self.games):
             self.ui.tableGames.setItem(i, 0, QTableWidgetItem(game.game_name))
 
+            # Compat Tool combobox
             combo = QComboBox()
             combo.addItem('-')
             combo.addItems(ctools)
@@ -85,6 +86,11 @@ class PupguiGameListDialog(QObject):
             else:
                 combo.setCurrentText(game.compat_tool)
             combo.currentTextChanged.connect(lambda text,game=game: self.queue_ctool_change_steam(text, game))
+
+            compat_item = QTableWidgetItem()
+            compat_item.setData(Qt.DisplayRole, combo.currentText())
+
+            self.ui.tableGames.setItem(i, 1, compat_item)
             self.ui.tableGames.setCellWidget(i, 1, combo)
 
             # ProtonDB status

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -19,6 +19,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QTableWidget" name="tableGames">
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
      <property name="columnCount">
       <number>5</number>
      </property>


### PR DESCRIPTION
The goal of this PR is to allow sorting in the Games List dialog, as a little bit of UIX-sugar and to match the behaviour of other QTableWidgets :smile: 

Currently, I have implemented sorting for the Game Name, Compatibility Tool (I'll come back to this), Deck Compatibility, and Anti-Cheat status.

![Deck Compatibility Rating Sorting](https://user-images.githubusercontent.com/7917345/216784101-361cd32f-e2ac-42b6-aa6e-fc9d1b1d2ef7.png)

![Anti-Cheat Rating Sorting](https://user-images.githubusercontent.com/7917345/216784118-6bd0cf22-ae13-42c5-93f7-59ade24714c8.png)

Going back to the compat tool sorting, it works, but if you change something from say `steamlinuxruntime` to `GE-Proton-blah`, the sorting will still be based on the first selected value, so this changed option will appear out-of-order even if you re-sort. In my mind, desirable behaviour here is to update the sort order but to do it after the user selects a new value and *then* re-sorts. I'll look into what's up with this, the `data` for that `QTableWidgetItem` probably needs updated or something after selection (or perhaps there is a signal when the column sort is selected that should check for and update this on sort, not sure yet). 

I tested setting the compatibility tool when the columns were sorted and applying the change, and the compatibility tool seems to be correctly updated for the corresponding game even after sorted.

Also, sorting does not yet seem to work for ProtonDB rating. There is an issue with revealing the ProtonDB status on "sorted" columns. If you sort by, say, Game Name, and then "click" for the ProtonDB rating, the rating will be revealed for another game that could be _way_ down the list of installed games. For example, sorting by name and clicking to reveal the rating for "Yakuza 0" will instead reveal the rating beside "Cuphead". I'm not sure yet which game it's actually revealing the rating for.

There is also a minor segfaulting issue I have noticed but been unable to narrow down, it seems to happen randomly when interacting with the Games List dialog after sorting. However it _only_ happens when I'm using the Wayland backend for PySide6. Using `QT_QPA_PLATFORM=xcb python3 -m pupgui2` does not have any segfaulting when sorting, perhaps this is just a Qt bug?

<hr>

TODO
- [ ] Fix compat tool sorting to reflect updated compat tool selection
- [ ] Implement proper ProtonDB rating sorting