### PR TITLE
Lutris: Add Vanilla Wine

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_winetkg_vanilla_wine.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_vanilla_wine.py
@@ -1,0 +1,25 @@
+# pupgui2 compatibility tools module
+# Proton-Tkg https://github.com/Frogging-Family/wine-tkg-git
+# Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
+
+from PySide6.QtCore import QCoreApplication, Signal
+
+from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstaller  # Use ProtonTKg Ctmod as base
+
+
+CT_NAME = 'Wine Tkg (Vanilla Wine)'
+CT_LAUNCHERS = ['lutris', 'advmode']
+CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_winetkg_vanilla_ubuntu', '''Custom Wine build for running Windows games, built with the Wine-tkg build system.''')}
+
+
+class CtInstaller(TKGCtInstaller):
+
+    BUFFER_SIZE = 65536
+    PROTON_PACKAGE_NAME = 'wine-ubuntu.yml'
+    TKG_EXTRACT_NAME = 'wine_tkg'
+
+    p_download_progress_percent = 0
+    download_progress_percent = Signal(int)
+
+    def __init__(self, main_window = None):
+        super().__init__(main_window)


### PR DESCRIPTION
Follow-up from discussion in #178, another component of #156 

Adds the ability to download Vanilla Wine as a runner for Lutris. It uses the build based on the [Ubuntu build system](https://github.com/Frogging-Family/wine-tkg-git/actions/workflows/wine-ubuntu.yml), as discussed in #178. This is gated behind advanced mode as builds of Wine based on vanilla Wine may be less compatible, and generally a user will *probably* want to use builds based on Valve Wine for gaming, likewise discussed in #178.

![image](https://user-images.githubusercontent.com/7917345/216789841-afbbd9bb-2f96-44f0-a270-60307fd38e7f.png)

Not sure if we want anything further added to the description of the ctmod. I did consider adding a warning but that might be excessive, and a user in advanced mode should (ideally) know what they're doing :slightly_smiling_face: 

The process of creating the ctmod is actually exactly how I described it in the previous PR, it was able to download and extract perfectly fine without any changes to the base Tkg ctmod! :partying_face: 

If desirable, as part of this PR I could also look into adding the League of Legends build, gated behind advanced mode as well. Not sure how beneficial or useful this is though.

I did some tests with a couple of builds and it seemed to work fine, but if I missed anything please feel free to let me know :-) Thanks! 