### PR TITLE
Game List Improvements

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -65,8 +65,10 @@ PROTONDB_COLORS = {'platinum': '#b4c7dc', 'gold': '#4f492c', 'silver': '#a6a6a6'
 STEAM_API_GETAPPLIST_URL = 'https://api.steampowered.com/ISteamApps/GetAppList/v2/'
 STEAM_APP_PAGE_URL = 'https://store.steampowered.com/app/'
 AWACY_GAME_LIST_URL = 'https://raw.githubusercontent.com/Starz0r/AreWeAntiCheatYet/master/games.json'
+AWACY_WEB_URL = 'https://areweanticheatyet.com/'
 LOCAL_AWACY_GAME_LIST = os.path.join(TEMP_DIR, 'awacy_games.json')
 PROTONDB_API_URL = 'https://www.protondb.com/api/v1/reports/summaries/{game_id}.json'
+PROTONDB_APP_PAGE_URL = 'https://protondb.com/app/'
 
 STEAM_BOXTRON_FLATPAK_APPSTREAM = 'appstream://com.valvesoftware.Steam.CompatibilityTool.Boxtron'
 STEAM_PROTONGE_FLATPAK_APPSTREAM = 'appstream://com.valvesoftware.Steam.CompatibilityTool.Proton-GE'

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -59,6 +59,7 @@ class PupguiGameListDialog(QObject):
             self.update_game_list_lutris()
             self.ui.lblSteamRunningWarning.setVisible(False)
 
+        self.ui.tableGames.setColumnWidth(0, 300)
         self.ui.tableGames.setColumnWidth(3, 70)
         self.ui.tableGames.setColumnWidth(4, 70)
         self.ui.btnApply.clicked.connect(self.btn_apply_clicked)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -187,7 +187,7 @@ class PupguiGameListDialog(QObject):
         if i := self.games.index(game):
             # Use QTableWidgetItem to replace Button widget
             pdb_item = self.ui.tableGames.item(self.ui.tableGames.currentRow(), 4)
-            pdb_item.setData(Qt.UserRole, pdb_tier)
+            pdb_item.setData(Qt.DisplayRole, pdb_tier)
             pdb_item.setForeground(QBrush(QColor(PROTONDB_COLORS.get(pdb_tier))))
             pdb_item.setToolTip(self.tr('Confidence: {confidence}\nScore: {score}\nTrending: {trending}')
                 .format(confidence=game.protondb_summary.get('confidence', '?'),

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -192,7 +192,9 @@ class PupguiGameListDialog(QObject):
             print('Warning: update_protondb_status called with game=None')
             return
         pdb_tier = game.protondb_summary.get('tier', '?')
-        if i := self.games.index(game):
+
+        i = self.games.index(game)
+        if i != None:
             # Use QTableWidgetItem to replace Button widget
             pdb_item = self.ui.tableGames.item(self.ui.tableGames.currentRow(), 4)
             pdb_item.setData(Qt.DisplayRole, pdb_tier)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -193,8 +193,7 @@ class PupguiGameListDialog(QObject):
             return
         pdb_tier = game.protondb_summary.get('tier', '?')
 
-        i = self.games.index(game)
-        if i != None:
+        if self.games.index(game) != None:
             # Use QTableWidgetItem to replace Button widget
             pdb_item = self.ui.tableGames.item(self.ui.tableGames.currentRow(), 4)
             pdb_item.setData(Qt.DisplayRole, pdb_tier)

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -19,6 +19,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QTableWidget" name="tableGames">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
      <property name="sortingEnabled">
       <bool>true</bool>
      </property>

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>650</width>
+    <width>800</width>
     <height>300</height>
    </rect>
   </property>


### PR DESCRIPTION
This PR fixes a couple of bugs introduced in #180, and adds a small feature that I figured out how to do in the process of fixing those bugs :smile: 

No screenshot this time as there isn't really much to "show" :sweat_smile: 

- **Critically**, fixes the ProtonDB rating text having the wrong flag, meaning it didn't display (needs `Qt.DispalyRole` instead of `Qt.UserRole`)
- Fixes items in the games list being able to be double-clicked and edited by setting `NoEditTriggers` in Qt Designer - I don't think this would cause any problems, but it's minor unwanted behaviour imo
- Adds double-click actions to cells in the Game List, similar to the "Show info" dialog
    - For Game Name, opens the Steam store page - Lutris does not have the "Show games list" button
    - For Anti-Cheat, open the Are We Anti-Cheat Yet web page - It doesn't appear that there is a way to open on a specific game yet
    - For ProtonDB, once a rating is revealed, open the given ProtonDB app page
- Adds a tooltip to the Game Name with `Game Name (AppID)`

The double-click actions were implemented by appending the relevant URLs to a `Qt.UserData` data entry for each `QTableWidgetItem`. Initially I thought of having type checks in the `item_doubleclick_action` method, but this got a bit unwieldy, and it was going to become messy to build things like the ProtonDB URL that way. So instead, we build pass the relevant URLs as data when we create the `QTableWidgetItem`.

The main fix here is the ProtonDB rating breaking, apologies for missing that initially.

Thanks! :-)