### PR TITLE
Steam Apps: Don't fetch soundtracks as steamapps

### DIFF
--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -44,9 +44,17 @@ def get_steam_app_list(steam_config_folder: str, cached=False, no_shortcuts=Fals
             if 'apps' not in v.get('libraryfolders').get(fid):
                 continue
             fid_path = v.get('libraryfolders').get(fid).get('path')
+            fid_libraryfolder_path = fid_path
             if fid == '0':
                 fid_path = os.path.join(fid_path, 'steamapps', 'common')
             for appid in v.get('libraryfolders').get(fid).get('apps'):
+                # Skip if app isn't installed to `/path/to/steamapps/common` - Skips soundtracks
+                fid_steamapps_path = os.path.join(fid_libraryfolder_path, 'steamapps')  # e.g. /home/gaben/Games/steamapps
+                appmanifest_path = os.path.join(fid_steamapps_path, f'appmanifest_{appid}.acf')
+                appmanifest_install_path = vdf.load(open(appmanifest_path)).get('AppState').get('installdir')
+                if not os.path.isdir(os.path.join(fid_steamapps_path, 'common', appmanifest_install_path)):
+                    continue
+
                 app = SteamApp()
                 app.app_id = int(appid)
                 app.libraryfolder_id = fid

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -51,7 +51,7 @@ def get_steam_app_list(steam_config_folder: str, cached=False, no_shortcuts=Fals
                 # Skip if app isn't installed to `/path/to/steamapps/common` - Skips soundtracks
                 fid_steamapps_path = os.path.join(fid_libraryfolder_path, 'steamapps')  # e.g. /home/gaben/Games/steamapps
                 appmanifest_path = os.path.join(fid_steamapps_path, f'appmanifest_{appid}.acf')
-                appmanifest_install_path = vdf.load(open(appmanifest_path)).get('AppState').get('installdir')
+                appmanifest_install_path = vdf.load(open(appmanifest_path)).get('AppState', {}).get('installdir')
                 if not os.path.isdir(os.path.join(fid_steamapps_path, 'common', appmanifest_install_path)):
                     continue
 


### PR DESCRIPTION
This PR fixes Steam game soundtracks being parsed by ProtonUp-Qt and showing up incorrectly in the Games List dialog. It does this by skipping apps that are not stored in `/path/to/steamapps/common`.

**Before**:
![image](https://user-images.githubusercontent.com/7917345/217880252-7aa755b5-a245-4db2-9704-c07b0bde9bef.png)

**After**:

![image](https://user-images.githubusercontent.com/7917345/217881006-bf7ca18e-9e09-45f4-9748-22c525ffbe44.png)

## Background
Steam allows you to download soundtracks you own into a specified library folder. While games tend to go into `/path/to/steamapps/common`, music conveniently goes to `/path/to/steamapps/music`.

The properties dialog in Steam for the soundtrack is virtually identcial to any other Steam app, *including* the ability to select a compatibility tool! This does... nothing, apparently! If you want to use Wine with your game soundtracks you'll have to buy it from the store apparently :-)

## Approach
Steam does not seem to have a good way locally of differentiating between the types of downloaded apps. Downloaded soundtracks are picked up as regular apps, and from browsing various VDF files from Steam I couldn't find a good way to tell my downloaded soundtracks apart straight from Steam. I also spent some time combing the `steam` Python library docs, and I found that they *do* have a `Music` (and `MusicAlbum`, both have the same value though) in their [Enums](https://steam.readthedocs.io/en/stable/api/steam.enums.html?highlight=EAppType#steam.enums.common.EProtoAppType.MusicAlbum) - However I couldn't see this used anywhere by Steam locally. I think it might be used when checking the type of apps with a Web API call. It might be possible to check the App type locally, but I couldn't find a way.

I came up with a solution similar to something I implemented recently for SteamTinkerLaunch. Since soundtracks are stored by Steam as apps, they have their own AppIDs and so on. What I was able to do was the following in `get_steam_app_list`:
1. Get the path to the App Manifest for the current AppID and library folder
2. Use the VDF parser to parse the `.acf` file in the current library folder and get the `installdir` - This is the name of the folder where an app is "installed"
    - AppManifest files are files which store information about a game installed in that library folder, so if we have AppID `391570`, the AppManifest will be called `appmanifest_391570.acf`
    - Despite the extension they are identical to plaintext VDF files like the libraryfolders.vdf file, and can be parsed by the VDF library
3. Build out a `steamapps/common` path based on the current library folder and the install dir - e.g. if `installdir` is `PowerWash Simulator`, the built path would look like `/home/gaben/Games/steamapps/common/PowerWash Simulator`
4. Check if this directory exists and if it does not, assume it's not 

I chose skipping over parsing as unlike Anti-Cheat runtimes, which ProtonUp-Qt does atore and mark with an appropriate `app_type`, there shouldn't be a case where ProtonUp-Qt needs to manage soundtracks. You can technically set the compatibility tool for soundtracks, but it does nothing from what I can see. I personally think it's best to simply skip over apps not in `common` entirely, instead of perhaps checking if they're stored in `steamapps/music` and then setting an App Type. Let me know if there is a preferred approach her :-)

<hr>

In my tests, the Games Used By Compatibility Tool count didn't change, so no apps should be skipped incorrectly, but further testing is welcome to ensure no regressions are introduced.

Thanks!