### PR TITLE
Lutris: Add Basic Games List

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -80,3 +80,5 @@ STEAM_STL_CACHE_PATH = os.path.join(os.path.expanduser('~'), '.cache', 'steamtin
 STEAM_STL_DATA_PATH = os.path.join(os.path.expanduser('~'), '.local', 'share', 'steamtinkerlaunch')
 STEAM_STL_SHELL_FILES = [ '.bashrc', '.zshrc', '.kshrc' ]
 STEAM_STL_FISH_VARIABLES = os.path.join(os.path.expanduser('~'), '.config/fish/fish_variables')
+
+LUTRIS_WEB_URL='https://lutris.net/games/'

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -135,6 +135,7 @@ class LutrisGame:
     runner = ''
     installer_slug = ''
     installed_at = 0
+    install_dir = ''
 
     install_loc = None
 
@@ -156,7 +157,7 @@ class LutrisGame:
                     break
 
         lutris_game_cfg = os.path.join(os.path.expanduser(lutris_config_dir), 'games', fn)
-        if not os.path.exists(lutris_game_cfg):
+        if not os.path.isfile(lutris_game_cfg):
             return {}
         with open(lutris_game_cfg, 'r') as f:
             return yaml.safe_load(f)

--- a/pupgui2/lutrisutil.py
+++ b/pupgui2/lutrisutil.py
@@ -39,10 +39,10 @@ def get_lutris_game_list(install_loc) -> List[LutrisGame]:
             if not lutris_install_dir:
                 lg_config = lg.get_game_config()
                 working_dir = lg_config.get('game', {}).get('working_dir')
-                exe_dir = os.path.dirname(str(lg_config.get('game', {}).get('exe')))
-                lutris_install_dir = working_dir or exe_dir or ''
+                exe_dir = lg_config.get('game', {}).get('exe')
+                lutris_install_dir = working_dir or (os.path.dirname(str(exe_dir)) if exe_dir else None)
 
-            lg.install_dir = os.path.abspath(lutris_install_dir)
+            lg.install_dir = os.path.abspath(lutris_install_dir) if lutris_install_dir else ''
             lgs.append(lg)
     except Exception as e:
         print('Error: Could not get lutris game list:', e)

--- a/pupgui2/lutrisutil.py
+++ b/pupgui2/lutrisutil.py
@@ -5,7 +5,7 @@ import sqlite3
 from pupgui2.datastructures import LutrisGame
 
 
-LUTRIS_PGA_GAMELIST_QUERY = 'SELECT slug, name, runner, installer_slug, installed_at FROM games'
+LUTRIS_PGA_GAMELIST_QUERY = 'SELECT slug, name, runner, installer_slug, installed_at, directory FROM games'
 
 
 def get_lutris_game_list(install_loc) -> List[LutrisGame]:
@@ -15,7 +15,6 @@ def get_lutris_game_list(install_loc) -> List[LutrisGame]:
     """
     install_dir = os.path.expanduser(install_loc.get('install_dir'))
     lutris_data_dir = os.path.join(install_dir, os.pardir, os.pardir)
-
     pga_db_file = os.path.join(lutris_data_dir, 'pga.db')
     lgs = []
     try:
@@ -31,6 +30,19 @@ def get_lutris_game_list(install_loc) -> List[LutrisGame]:
             lg.runner = g[2]
             lg.installer_slug = g[3]
             lg.installed_at = g[4]
+            
+            # Lutris database file will only store some fields for games installed via an installer and not if it was manually added
+            # If a game doesn't have an install dir (e.g. it was manually added to Lutris), try to use the following for the install dir:
+            # - Working directory (may not be specified)
+            # - Executable: may not be accurate as the exe could be heavily nested, but a good fallback)
+            lutris_install_dir = g[5]
+            if not lutris_install_dir:
+                lg_config = lg.get_game_config()
+                working_dir = lg_config.get('game', {}).get('working_dir')
+                exe_dir = os.path.dirname(str(lg_config.get('game', {}).get('exe')))
+                lutris_install_dir = working_dir or exe_dir or ''
+
+            lg.install_dir = os.path.abspath(lutris_install_dir)
             lgs.append(lg)
     except Exception as e:
         print('Error: Could not get lutris game list:', e)

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -217,8 +217,8 @@ class MainWindow(QObject):
 
         if install_loc.get('launcher') == 'steam' and 'vdf_dir' in install_loc:
             self.ui.btnShowGameList.setVisible(True)
-        #elif install_loc.get('launcher') == 'lutris':
-        #    self.ui.btnShowGameList.setVisible(True)
+        elif install_loc.get('launcher') == 'lutris':
+           self.ui.btnShowGameList.setVisible(True)
         else:
             self.ui.btnShowGameList.setVisible(False)
 

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -222,21 +222,21 @@ class PupguiGameListDialog(QObject):
                 runner_item.setToolTip(tooltip)
 
             # Some games may be in Lutris but not have a valid install path, though the yml should *usually* have some path
-            install_dir_text = game.install_dir or 'Unknown'
+            install_dir_text = game.install_dir or self.tr('Unknown')
             install_dir_item = QTableWidgetItem(install_dir_text)
             if not game.install_dir:
                 install_dir_item.setForeground(QBrush(QColor(PROTONDB_COLORS.get('gold'))))
             else:
                 if os.path.isdir(install_dir_text):
                     # Set double click action to open valid install dir with xdg-open
-                    install_dir_item.setToolTip('Double-click to browse...')
+                    install_dir_item.setToolTip(self.tr('Double-click to browse...'))
                     install_dir_item.setData(Qt.UserRole, lambda url: os.system(f'xdg-open "{url}"'))
                 else:
-                    install_dir_item.setToolTip('Install location does not exist!')
+                    install_dir_item.setToolTip(self.tr('Install location does not exist!'))
 
             install_date = datetime.fromtimestamp(int(game.installed_at)).isoformat().split('T')
             install_date_short = f'{install_date[0]}'
-            install_date_tooltip = f'Installed at {install_date[0]} ({install_date[1]})'
+            install_date_tooltip = self.tr('Installed at {DATE} ({TIME})').format(DATE=install_date[0], TIME=install_date[1])
 
             install_date_item = QTableWidgetItem(install_date_short)
             install_date_item.setData(Qt.UserRole, int(game.installed_at))

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -204,6 +204,7 @@ class PupguiGameListDialog(QObject):
                 name_item.setData(Qt.UserRole, f'{LUTRIS_WEB_URL}{game.slug}')
 
             runner_item = QTableWidgetItem(game.runner.capitalize())
+            runner_item.setTextAlignment(Qt.AlignCenter)
             # Display wine runner information in tooltip
             if game.runner == 'wine':
                 game_cfg = game.get_game_config()
@@ -240,6 +241,7 @@ class PupguiGameListDialog(QObject):
             install_date_item = QTableWidgetItem(install_date_short)
             install_date_item.setData(Qt.UserRole, int(game.installed_at))
             install_date_item.setToolTip(install_date_tooltip)
+            install_date_item.setTextAlignment(Qt.AlignCenter)
 
             self.ui.tableGames.setItem(i, 0, name_item)
             self.ui.tableGames.setItem(i, 1, runner_item)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -224,7 +224,7 @@ class PupguiGameListDialog(QObject):
             # Some games may be in Lutris but not have a valid install path, though the yml should *usually* have some path
             install_dir_text = game.install_dir or 'Unknown'
             install_dir_item = QTableWidgetItem(install_dir_text)
-            if install_dir_text == 'Unknown':
+            if not game.install_dir:
                 install_dir_item.setForeground(QBrush(QColor(PROTONDB_COLORS.get('gold'))))
             else:
                 if os.path.isdir(install_dir_text):

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -203,6 +203,23 @@ class PupguiGameListDialog(QObject):
                 # Only games with an installer_slug will have a Lutris web URL - Could be an edge case that runners get removed/updated from lutris.net?
                 name_item.setData(Qt.UserRole, f'{LUTRIS_WEB_URL}{game.slug}')
 
+            runner_item = QTableWidgetItem(game.runner.capitalize())
+            # Display wine runner information in tooltip
+            if game.runner == 'wine':
+                game_cfg = game.get_game_config()
+                runnerinfo = game_cfg.get('wine', {})
+
+                wine_ver = runnerinfo.get('version')
+                dxvk_ver = runnerinfo.get('dxvk_version')
+                vkd3d_ver = runnerinfo.get('vkd3d_version')
+
+                tooltip = ''
+                tooltip += f'Wine version: {wine_ver}' if wine_ver else ''
+                tooltip += f'\nDXVK version: {dxvk_ver}' if dxvk_ver else ''
+                tooltip += f'\nvkd3d version: {vkd3d_ver}' if vkd3d_ver else ''
+
+                runner_item.setToolTip(tooltip)
+
             # Some games may be in Lutris but not have a valid install path, though the yml should *usually* have some path
             install_dir_text = game.install_dir or 'Unknown'
             install_dir_item = QTableWidgetItem(install_dir_text)
@@ -225,7 +242,7 @@ class PupguiGameListDialog(QObject):
             install_date_item.setToolTip(install_date_tooltip)
 
             self.ui.tableGames.setItem(i, 0, name_item)
-            self.ui.tableGames.setItem(i, 1, QTableWidgetItem(game.runner))
+            self.ui.tableGames.setItem(i, 1, runner_item)
             self.ui.tableGames.setItem(i, 2, install_dir_item)
             self.ui.tableGames.setItem(i, 3, install_date_item)
 

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -28,11 +28,17 @@
      <property name="columnCount">
       <number>5</number>
      </property>
+     <attribute name="horizontalHeaderVisible">
+      <bool>true</bool>
+     </attribute>
      <attribute name="horizontalHeaderDefaultSectionSize">
       <number>160</number>
      </attribute>
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
      </attribute>
      <column/>
      <column/>


### PR DESCRIPTION
This PR adds a Games List for Lutris, adjusting the data displayed to be relevant to Lutris games :smile: It displays games from all runners except Steam (as we already display Steam games in the Steam games list dialog), and also has full sorting support to match the Steam games list. Because I really wanted a change of pace from writing Bash :sweat_smile: 

I implemented this in `pupgui2gameslistdialog.py`. There was some logic there already in preparation for a Lutris games list it seems. I'm a bit undecided if this is "better" than having a separate dialog, but the ctinfo dialog is shared, and as mentioned there was already some prep work for a Lutris games list, so I figured it was fine at least for now :-)

![image](https://user-images.githubusercontent.com/7917345/219829160-2604d7a7-f0dc-4951-8559-0a6ad36f56b8.png)

## Overview
Instead of displaying the compatibility tool, Deck compatibility, Anti-Cheat status, and ProtonDB rating, we instead display the following:
- Game Name
  - Tooltip: `Game Name (Game Slug)`
  - Double click: Takes you to lutris.net page for that game, if an `installer_slug` is present (only games with an `installer_slug` have a page on lutris.net, games without are manually-added games)
- Runner (with first letter capitalized as a small design preference)
  - Tooltip: Wine version, DXVK version, and vkd3d version; whichever are available
- Install Location
  - Tooltip: Either `Double click to browse`, or a warning if the directory doesn't exist (Lutris has a separate section on its menu for games with invalid paths as well)
  - Double click: Opens that path with `xdg-open`, if it exists. Otherwise it does nothing.
- Installed Date (ISO formatted)
  - Tooltip: ISO formatted date with time in brackets, e.g. `2010-07-28 (12:51:03)`

The fifth column that the Steam games list has is hidden. The "Apply" button was also changed to "Close", since there is nothing to Apply in this menu.

I chose to put the Wine information in a tooltip because I figured it would be useful to show a "complete" Lutris games list, minus Steam games only because we already display that for the Steam runner. Since not all Lutris runners will have Wine information, I chose to put it in the tooltip when the runner is Wine.

There is the option of only showing Lutris games that have a Wine runner, and then we show the Wine version/DXVK version/vkd3d version in that column (in that fallback order, in case one is missing, and show the rest in the tooltip). In the case where there is no Wine version (yep, that can be a scenario...) we could display "Unknown". I am personally slightly more in favour of the approach I took but only because my personal preference is seeing a "full" Lutris game list.

Unlike the Steam dialog though, there is no way to "change" a compatibility tool, there is no dropdown in the Lutris list like its Steam counterpart, and there are a couple of reasons for this:
- Related to above, not all runners have a Wine version to change
- A game with a Wine runner can have its Wine, DXVK and vkd3d version changed independently. These *could* all be added to the dialog in separate columns, and there would have to be logic to skip/remove unset Wine/DXVK/vkd3d versions so that it uses the Lutris default, but users may inadvertently think they need to set the DXVK/vkd3d versions for games. This could potentially lead to confusion.
- Bulk-changing Lutris Wine versions may not be as desirable as it is for Steam games, though updating to the latest, for example, Wine-GE may be desirable in some cases- But instead of this being implemented in this Games List, it could be better left to the likes of #162 or #139.

## Other Changes
I made a couple of other changes along the way to implement this.
- Updated logic in `LutrisGame#get_game_config` to use `os.path.isfile` instead of `os.path.exists`. If `fn == ''`, then the result of `os.path.join(os.path.expanduser(lutris_config_dir), 'games', fn)` would point to `{lutris_config_dir}/games/` (because `fn` was blank, the end of the path was just not filled in). This config dir path should pretty much always exist if Lutris is installed.
- In `lutrisutil.get_lutris_game_list`, some extra logic was added to fetch the install path of a game and store it in `install_dir`. We don't bother checking if this directory actually exists as its still a valid Lutris entry regardless, and Lutris itself has a separate menu entry for games that are missing.
  - The Lutris query was updated to select `directory`, however this will only be set whn a game is installed via a Lutris installer, as during the install process it asks you for an install directory. Manually added games do not have this.
  - As a fallback if `directory` cannot be found, we check if the game has a Working Directory, which we can get from the Lutris game's config yml. This is an optional field as far as I know and Lutris will infer it probably from the exe base directory, but not all games have to have a working directory as far as I am aware (at least one of my games didn't :sweat_smile:).
  - As a final fallback, if we don't have `directory` (i.e. this is a manually added game) **and** if we don't have a working directory, we use the base directory of the exe as the install directory. This may not always be correct, imagine a scenario where an exe is buried in some folder structure like `/path/to/GameFolder/CompanyName/EngineName/Game.exe`. However as far as I know, this exe path can't ever really be blank, so it serves as a good final fallback in my opinion.
  - If we don't have a `directory` from the query, or a working directory or exe directroy, we default to an empty string.
- Remove the vertical header from the games list, as it doesn't appear to be used anywhere. I tested the Steam dialog as well and I was able to update compatibility tools, sort, etc without issue. If it is actually used I can re-enable it no problem though.

I have only tested this on my main PC, which only has a selection of Lutris games. Further testing is, of course, very welcome here to make sure this works for more than my setup :-)

<hr>

I decided to try and implement this on a whim, after I noticed the commented out lines to show the games list button for Lutris games. So I wanted to see if it would be feasible to implement a Lutris Games List. I don't use Lutris very much so it was just a bit of an experiment that could potentially end up being useful :-)

At the very least, I hope that this could serve as a "proof-of-concept" for a future Lutris games list implementation (perhaps similar to what I described with the Wine/etc comboboxes), if this simplistic "game information only" approach is not desirable.

Thanks!