### PR TITLE
Heroic: Add Info Dialog (GOG, side-loaded, Legendary)

### DIFF
--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -166,10 +166,10 @@ class LutrisGame:
 
 
 # Information for games is stored in a per-storefront 'library.json' - This has most of the information we need
-# Information for installed Epic games is stored at '<heroic_dir>/legendary/installed.json' and has a separate JSON format but the same data we need -  
-# Information about game config (sideload, GOG, Epic) is stored in a 'GamesConfig/<app_name>.json' file, which is universal between GOG and sideloaded apps - This has Wine information
+# Information for installed Epic games is stored at '<heroic_dir>/legendary/installed.json' and has a separate JSON format but the same data we need
+# Information about game config (sideload, GOG, Epic) is stored in a 'GamesConfig/<app_name>.json' file, which is universal - This has Wine information
 class HeroicGame:
-    runner: str  # can be 'GOG', 'sideload' - all known for now
+    runner: str  # can be 'GOG', 'sideload' - Epic is hardcoded to 'legendary'
     app_name: str  # internal name encoded in some way, e.g. 'sPZQ5kmzYj5KnZKdxE2bR1'
     title: str  # Real name for game
     developer: str  # May be blank for side-loaded games

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -175,7 +175,6 @@ class HeroicGame:
     developer: str  # May be blank for side-loaded games
     install: Dict[str, str]  # e.g. executable, platform details
     install_path: str  # e.g. '~/.config/heroic', '~/.var/app/com.heroicgameslauncher.hgl/config/heroic'
-    folder_name: str
     store_url: str  # May be blank for side-loaded games
     art_cover: str  # Optional?
     art_square: str  # Optional?

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -6,6 +6,7 @@ import json
 from enum import Enum
 from typing import Dict
 
+
 class SteamDeckCompatEnum(Enum):
     UNKNOWN = 0
     UNSUPPORTED = 1
@@ -82,7 +83,8 @@ class SteamApp:
 
     def get_shortcut_id_str(self) -> str:
         return str(self.shortcut_id)
-    
+
+
 class BasicCompatTool:
     displayname = ''
     version = ''

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -165,9 +165,8 @@ class LutrisGame:
 
 
 # Information for games is stored in a per-storefront 'library.json' - This has most of the information we need
-# Information about game config is stored in a 'GamesConfig/<app_name>.json' file, which is universal between GOG and sideloaded apps - This has Wine information
-#
-# TODO Epic support
+# Information for installed Epic games is stored at '<heroic_dir>/legendary/installed.json' and has a separate JSON format but the same data we need -  
+# Information about game config (sideload, GOG, Epic) is stored in a 'GamesConfig/<app_name>.json' file, which is universal between GOG and sideloaded apps - This has Wine information
 class HeroicGame:
     runner: str  # can be 'GOG', 'sideload' - all known for now
     app_name: str  # internal name encoded in some way, e.g. 'sPZQ5kmzYj5KnZKdxE2bR1'

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -174,6 +174,7 @@ class HeroicGame:
     title: str  # Real name for game
     developer: str  # May be blank for side-loaded games
     install: Dict[str, str]  # e.g. executable, platform details
+    install_path: str  # e.g. '~/.config/heroic', '~/.var/app/com.heroicgameslauncher.hgl/config/heroic'
     folder_name: str
     store_url: str  # May be blank for side-loaded games
     art_cover: str  # Optional?
@@ -181,8 +182,8 @@ class HeroicGame:
     is_installed: bool  # Not always set properly by Heroic for GOG?
     wine_info: Dict[str, str]  # can store bin, name, and type - Has to be fetched from GamesConfig/app_name.json
 
-    def get_game_config(self, install_path: str):
-        game_config = os.path.join(install_path, 'GamesConfig', f'{self.app_name}.json')
+    def get_game_config(self):
+        game_config = os.path.join(self.install_path, 'GamesConfig', f'{self.app_name}.json')
         if not os.path.isfile(game_config):
             return {}
         

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -174,7 +174,8 @@ class HeroicGame:
     title: str  # Real name for game
     developer: str  # May be blank for side-loaded games
     install: Dict[str, str]  # e.g. executable, platform details
-    install_path: str  # e.g. '~/.config/heroic', '~/.var/app/com.heroicgameslauncher.hgl/config/heroic'
+    heroic_path: str  # e.g. '~/.config/heroic', '~/.var/app/com.heroicgameslauncher.hgl/config/heroic'
+    install_path: str  # Path to game folder, e.g. '/home/Gaben/Games/Half-Life 3'
     store_url: str  # May be blank for side-loaded games
     art_cover: str  # Optional?
     art_square: str  # Optional?
@@ -182,7 +183,7 @@ class HeroicGame:
     wine_info: Dict[str, str]  # can store bin, name, and type - Has to be fetched from GamesConfig/app_name.json
 
     def get_game_config(self):
-        game_config = os.path.join(self.install_path, 'GamesConfig', f'{self.app_name}.json')
+        game_config = os.path.join(self.heroic_path, 'GamesConfig', f'{self.app_name}.json')
         if not os.path.isfile(game_config):
             return {}
         

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -43,7 +43,7 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
         hg.wine_info: Dict[str, str] = hg.get_game_config().get('wineVersion', {})
 
         hgs.append(hg)
-    
+
     # Legendary Games uses a separate structure, so build separately
     if os.path.isfile(legendary_path):
         legendary_json = json.load(open(legendary_path))
@@ -86,7 +86,7 @@ def get_gog_installed_game_entry(game: HeroicGame) -> Dict:
     gog_installed_json_path = os.path.join(game.heroic_path, 'gog_store', 'installed.json')
     if not os.path.isfile(gog_installed_json_path) or not game.runner == 'gog':
         return {}
-    
+
     gog_installed_json = json.load(open(gog_installed_json_path)).get('installed', [])
     for gog_game in gog_installed_json:
         if gog_game.get('appName', '') == game.app_name:

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from typing import List, Dict, Union
+from typing import List, Dict
 
 from pupgui2.datastructures import HeroicGame
 
@@ -69,6 +69,7 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:  # Optionally sp
 
 def is_heroic_launcher(launcher: str) -> bool:
     """ Returns True if the supplied launcher name is a valid name for Heroic Games Launcher, e.g. "heroicwine" """
+
     return any(hero in launcher for hero in ['heroicwine', 'heroicproton'])
 
 
@@ -79,8 +80,8 @@ def is_gog_game_installed(game: HeroicGame) -> bool:
     return bool(get_gog_installed_game_entry(game))
 
 
-def get_gog_installed_game_entry(game: HeroicGame) -> Union[Dict[str, str], None]:
-    """ Return 'install_path' for GOG game from heroic/gog_store/installed.json """
+def get_gog_installed_game_entry(game: HeroicGame) -> Dict:
+    """ Return JSON entry as dict for an installed GOG game from heroic/gog_store/installed.json """
 
     gog_installed_json_path = os.path.join(game.heroic_path, 'gog_store', 'installed.json')
     if not os.path.isfile(gog_installed_json_path) or not game.runner == 'gog':

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -85,7 +85,7 @@ def get_gog_installed_game_entry(game: HeroicGame) -> Dict:
 
     gog_installed_json_path = os.path.join(game.heroic_path, 'gog_store', 'installed.json')
     if not os.path.isfile(gog_installed_json_path) or not game.runner == 'gog':
-        return ''
+        return {}
     
     gog_installed_json = json.load(open(gog_installed_json_path)).get('installed', [])
     for gog_game in gog_installed_json:

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -31,7 +31,7 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
         hg.app_name: str = game.get('app_name', '')
         hg.title: str = game.get('title', '')
         hg.developer: str = game.get('developer', '')
-        hg.install: str = game.get('install', {})
+        hg.install: Dict[str, str] = game.get('install', {})
         hg.heroic_path: str = heroic_path
         # Sideloaded games uses folder_name as their full install path, GOG games store a folder_name but this is *just* their install folder name
         # Prioritise getting install_path for GOG games as this is the GOG game equivalent to 'folder_name'
@@ -39,7 +39,7 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
         hg.store_url: str = game.get('store_url', '')
         hg.art_cover: str = game.get('art_cover', '')  # May need to replace path if it has 'file:///app/blah in name - See example in #168
         hg.art_square: str = game.get('art_square', '')
-        hg.is_installed: str = game.get('is_installed', False) or is_gog_game_installed(hg)  # Some installed gog games may not be marked properly in library.json, so cross-reference with installed.json
+        hg.is_installed: bool = game.get('is_installed', False) or is_gog_game_installed(hg)  # Some installed gog games may not be marked properly in library.json, so cross-reference with installed.json
         hg.wine_info: Dict[str, str] = hg.get_game_config().get('wineVersion', {})
 
         hgs.append(hg)
@@ -54,7 +54,7 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
             lg.app_name: str = app_name  # installed.json key is always the app_name 
             lg.title: str = game_data.get('title', '')
             lg.developer: str = ''  # Not stored or stored elsewhere?
-            lg.install = { 'executable': game_data.get('executable', ''), 'is_dlc': game_data.get('is_dlc', False), 'platform': game_data.get('platform', '') }
+            lg.install: Dict[str, str] = { 'executable': game_data.get('executable', ''), 'is_dlc': game_data.get('is_dlc', False), 'platform': game_data.get('platform', '') }
             lg.heroic_path: str = heroic_path
             lg.install_path: str = game_data.get('install_path', '') 
             lg.art_cover: str = ''  # Not stored or stored elsewhere?

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -60,7 +60,7 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:  # Optionally sp
             lg.art_cover: str = ''  # Not stored or stored elsewhere?
             lg.art_square: str = ''  # Not stored or stored elsewhere?
             lg.is_installed: str = True  # Games in Legendary `installed.json` are always installed
-            lg.wine_info: Dict[str, str] = hg.get_game_config().get('wineVersion', {})  # Mirrors above, Legendary games should use the same GameConfig json structure
+            lg.wine_info: Dict[str, str] = lg.get_game_config().get('wineVersion', {})  # Mirrors above, Legendary games should use the same GameConfig json structure
 
             hgs.append(lg)
 

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -8,7 +8,7 @@ from pupgui2.datastructures import HeroicGame
 
 def get_heroic_game_list(install_path: str) -> List[HeroicGame]:  # Optionally specify a runner
     """
-    Returns a list of installed games for Heroic Games
+    Returns a list of installed games for Heroic Games at'install_path' (e.g., '~/.config/heroic', '~/.var/app/com.heroicgameslauncher.hgl/config/heroic')
     Return Type: List[HeroicGame]
     """
 
@@ -32,30 +32,31 @@ def get_heroic_game_list(install_path: str) -> List[HeroicGame]:  # Optionally s
         hg.title: str = game.get('title', '')
         hg.developer: str = game.get('developer', '')
         hg.install: str = game.get('install', '')
+        hg.install_path: str = install_path
         hg.folder_name: str = game.get('folder_name', '')
         hg.store_url: str = game.get('store_url', '')
         hg.art_cover: str = game.get('art_cover', '')  # May need to replace path if it has 'file:///app/blah in name - See example in #168
         hg.art_square: str = game.get('art_square', '')
-        hg.is_installed: str = game.get('is_installed', False) or is_gog_game_installed(hg, install_path)  # Some installed gog games may not be marked properly in library.json, so cross-reference with installed.json
-        hg.wine_info: Dict[str, str] = hg.get_game_config(install_path).get('wineVersion', {})
+        hg.is_installed: str = game.get('is_installed', False) or is_gog_game_installed(hg)  # Some installed gog games may not be marked properly in library.json, so cross-reference with installed.json
+        hg.wine_info: Dict[str, str] = hg.get_game_config().get('wineVersion', {})
 
         hgs.append(hg)
     
     return hgs
 
 
-def is_heroic_launcher(launcher) -> bool:
-    """ Return if current launcher is Heroic Games """
+def is_heroic_launcher(launcher: str) -> bool:
+    """ Returns True if the supplied launcher name is a valid name for Heroic Games Launcher, e.g. "heroicwine" """
     return any(hero in launcher for hero in ['heroicwine', 'heroicproton'])
 
 
 # `is_installed` for GOG games is not always set properly
-def is_gog_game_installed(game: HeroicGame, heroic_dir) -> bool:
-    """ Return if a GOG game has an entry in heroic/gog_store/installed.json """
+def is_gog_game_installed(game: HeroicGame) -> bool:
+    """ Return True if a GOG game has an entry in heroic/gog_store/installed.json """
     if not game.runner == 'gog':
         return False
 
-    gog_installed_json_path = os.path.join(heroic_dir, 'gog_store', 'installed.json')
+    gog_installed_json_path = os.path.join(game.install_path, 'gog_store', 'installed.json')
     if not os.path.isfile(gog_installed_json_path):
         return False
 

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -1,22 +1,22 @@
 import os
 import json
 
-from typing import List, Dict
+from typing import List, Dict, Union
 
 from pupgui2.datastructures import HeroicGame
 
 
-def get_heroic_game_list(install_path: str) -> List[HeroicGame]:  # Optionally specify a runner
+def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:  # Optionally specify a runner
     """
-    Returns a list of installed games for Heroic Games at 'install_path' (e.g., '~/.config/heroic', '~/.var/app/com.heroicgameslauncher.hgl/config/heroic')
+    Returns a list of installed games for Heroic Games at 'heroic_path' (e.g., '~/.config/heroic', '~/.var/app/com.heroicgameslauncher.hgl/config/heroic')
     Return Type: List[HeroicGame]
     """
 
-    if not os.path.isdir(install_path):
+    if not os.path.isdir(heroic_path):
         return {}
 
-    store_paths: List[str] = [ os.path.join(install_path, 'sideload_apps', 'library.json'), os.path.join(install_path, 'gog_store', 'library.json') ]
-    legendary_path: str = os.path.abspath(os.path.join(install_path, '..', 'legendary', 'installed.json'))
+    store_paths: List[str] = [ os.path.join(heroic_path, 'sideload_apps', 'library.json'), os.path.join(heroic_path, 'gog_store', 'library.json') ]
+    legendary_path: str = os.path.abspath(os.path.join(heroic_path, '..', 'legendary', 'installed.json'))
 
     games_json: List = []
     for sp in store_paths:
@@ -32,7 +32,10 @@ def get_heroic_game_list(install_path: str) -> List[HeroicGame]:  # Optionally s
         hg.title: str = game.get('title', '')
         hg.developer: str = game.get('developer', '')
         hg.install: str = game.get('install', {})
-        hg.install_path: str = install_path
+        hg.heroic_path: str = heroic_path
+        # Sideloaded games uses folder_name as their full install path, GOG games store a folder_name but this is *just* their install folder name
+        # Prioritise getting install_path for GOG games as this is the GOG game equivalent to 'folder_name'
+        hg.install_path: str = get_gog_installed_game_entry(hg).get('install_path', '') if hg.runner == 'gog' else game.get('folder_name', '')
         hg.store_url: str = game.get('store_url', '')
         hg.art_cover: str = game.get('art_cover', '')  # May need to replace path if it has 'file:///app/blah in name - See example in #168
         hg.art_square: str = game.get('art_square', '')
@@ -52,7 +55,8 @@ def get_heroic_game_list(install_path: str) -> List[HeroicGame]:  # Optionally s
             lg.title: str = game_data.get('title', '')
             lg.developer: str = ''  # Not stored or stored elsewhere?
             lg.install = { 'executable': game_data.get('executable', ''), 'is_dlc': game_data.get('is_dlc', False), 'platform': game_data.get('platform', '') }
-            lg.install_path: str = install_path
+            lg.heroic_path: str = heroic_path
+            lg.install_path: str = game_data.get('install_path', '') 
             lg.art_cover: str = ''  # Not stored or stored elsewhere?
             lg.art_square: str = ''  # Not stored or stored elsewhere?
             lg.is_installed: str = True  # Games in Legendary `installed.json` are always installed
@@ -71,16 +75,20 @@ def is_heroic_launcher(launcher: str) -> bool:
 # `is_installed` for GOG games is not always set properly
 def is_gog_game_installed(game: HeroicGame) -> bool:
     """ Return True if a GOG game has an entry in heroic/gog_store/installed.json """
-    if not game.runner == 'gog':
-        return False
 
-    gog_installed_json_path = os.path.join(game.install_path, 'gog_store', 'installed.json')
-    if not os.path.isfile(gog_installed_json_path):
-        return False
+    return bool(get_gog_installed_game_entry(game))
 
+
+def get_gog_installed_game_entry(game: HeroicGame) -> Union[Dict[str, str], None]:
+    """ Return 'install_path' for GOG game from heroic/gog_store/installed.json """
+
+    gog_installed_json_path = os.path.join(game.heroic_path, 'gog_store', 'installed.json')
+    if not os.path.isfile(gog_installed_json_path) or not game.runner == 'gog':
+        return ''
+    
     gog_installed_json = json.load(open(gog_installed_json_path)).get('installed', [])
     for gog_game in gog_installed_json:
         if gog_game.get('appName', '') == game.app_name:
-            return True
+            return gog_game    
     else:
-        return False
+        return {}

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -6,7 +6,7 @@ from typing import List, Dict
 from pupgui2.datastructures import HeroicGame
 
 
-def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:  # Optionally specify a runner
+def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
     """
     Returns a list of installed games for Heroic Games at 'heroic_path' (e.g., '~/.config/heroic', '~/.var/app/com.heroicgameslauncher.hgl/config/heroic')
     Return Type: List[HeroicGame]
@@ -59,7 +59,7 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:  # Optionally sp
             lg.install_path: str = game_data.get('install_path', '') 
             lg.art_cover: str = ''  # Not stored or stored elsewhere?
             lg.art_square: str = ''  # Not stored or stored elsewhere?
-            lg.is_installed: str = True  # Games in Legendary `installed.json` are always installed
+            lg.is_installed: str = True  # Games in Legendary `installed.json` should always be installed
             lg.wine_info: Dict[str, str] = lg.get_game_config().get('wineVersion', {})  # Mirrors above, Legendary games should use the same GameConfig json structure
 
             hgs.append(lg)

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -6,7 +6,7 @@ from typing import List, Dict
 from pupgui2.datastructures import HeroicGame
 
 
-def get_heroic_game_list(install_path: str, runner: str = '') -> List[HeroicGame]:  # Optionally specify a runner
+def get_heroic_game_list(install_path: str) -> List[HeroicGame]:  # Optionally specify a runner
     """
     Returns a list of installed games for Heroic Games
     Return Type: List[HeroicGame]

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -1,0 +1,49 @@
+import os
+import json
+
+from typing import List, Dict
+
+from pupgui2.datastructures import HeroicGame
+
+
+def get_heroic_game_list(install_path: str, runner: str = '') -> List[HeroicGame]:  # Optionally specify a runner
+    """
+    Returns a list of installed games for Heroic Games
+    Return Type: List[HeroicGame]
+    """
+
+    if not os.path.isdir(install_path):
+        return {}
+
+    store_paths = [ os.path.join(install_path, 'sideload_apps', 'library.json'), os.path.join(install_path, 'gog_store', 'library.json') ]
+
+    games_json: List = []
+    for sp in store_paths:
+        if os.path.isfile(sp):
+            games_json += json.load(open(sp)).get('games', [])
+
+    # TODO how do Epic library entries look?
+    hgs: List[HeroicGame] = []
+    for game in games_json:
+        hg = HeroicGame()
+
+        hg.runner: str = game.get('runner', '')
+        hg.app_name: str = game.get('app_name', '')
+        hg.title: str = game.get('title', '')
+        hg.developer: str = game.get('developer', '')
+        hg.install: str = game.get('install', '')
+        hg.folder_name: str = game.get('folder_name', '')
+        hg.store_url: str = game.get('store_url', '')
+        hg.art_cover: str = game.get('art_cover', '')  # May need to replace path if it has 'file:///app/blah in name - See example in #168
+        hg.art_square: str = game.get('art_square', '')
+        hg.is_installed: str = game.get('is_installed', '')
+        hg.wine_info: Dict[str, str] = hg.get_game_config(install_path).get('wineVersion', {})
+
+        hgs.append(hg)
+    
+    return hgs
+
+
+def is_heroic_launcher(launcher) -> bool:
+    """ Return if current launcher is Heroic Games """
+    return any(hero in launcher for hero in ['heroicwine', 'heroicproton'])

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -219,8 +219,8 @@ class MainWindow(QObject):
             self.ui.btnShowGameList.setVisible(True)
         elif install_loc.get('launcher') == 'lutris':
            self.ui.btnShowGameList.setVisible(True)
-        elif is_heroic_launcher(install_loc.get('launcher')):
-            self.ui.btnShowGameList.setVisible(True)
+        # elif is_heroic_launcher(install_loc.get('launcher')):
+        #     self.ui.btnShowGameList.setVisible(True)
         else:
             self.ui.btnShowGameList.setVisible(False)
 

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -24,7 +24,7 @@ from pupgui2.pupgui2customiddialog import PupguiCustomInstallDirectoryDialog
 from pupgui2.pupgui2gamelistdialog import PupguiGameListDialog
 from pupgui2.pupgui2installdialog import PupguiInstallDialog
 from pupgui2.steamutil import get_steam_acruntime_list, get_steam_app_list, get_steam_ct_game_map
-from pupgui2.heroicutil import is_heroic_launcher
+from pupgui2.heroicutil import is_heroic_launcher, get_heroic_game_list
 from pupgui2.util import apply_dark_theme, create_compatibilitytools_folder, get_installed_ctools, remove_ctool
 from pupgui2.util import install_directory, available_install_directories, get_install_location_from_directory_name
 from pupgui2.util import print_system_information, single_instance, download_awacy_gamelist, is_online
@@ -203,6 +203,11 @@ class MainWindow(QObject):
             map = get_steam_ct_game_map(install_loc.get('vdf_dir'), self.compat_tool_index_map, cached=True)
             for ct in self.compat_tool_index_map:
                 ct.no_games = len(map.get(ct, []))
+        # Launcher specific (Heroic): Set number of installed games using compat tool
+        elif is_heroic_launcher(install_loc.get('launcher')):
+            for ct in self.compat_tool_index_map:
+                heroic_dir = os.path.join(os.path.expanduser(install_loc.get('install_dir')), '../..')
+                ct.no_games = len([game for game in get_heroic_game_list(heroic_dir) if game.is_installed and ct.displayname in game.wine_info.get('name', '')])
 
         for ct in self.compat_tool_index_map:
             self.ui.listInstalledVersions.addItem(ct.get_displayname(unused_tr=self.tr('unused')))

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -205,9 +205,10 @@ class MainWindow(QObject):
                 ct.no_games = len(map.get(ct, []))
         # Launcher specific (Heroic): Set number of installed games using compat tool
         elif is_heroic_launcher(install_loc.get('launcher')):
+            heroic_dir = os.path.join(os.path.expanduser(install_loc.get('install_dir')), '../..')
+            heroic_game_list = get_heroic_game_list(heroic_dir)
             for ct in self.compat_tool_index_map:
-                heroic_dir = os.path.join(os.path.expanduser(install_loc.get('install_dir')), '../..')
-                ct.no_games = len([game for game in get_heroic_game_list(heroic_dir) if game.is_installed and ct.displayname in game.wine_info.get('name', '')])
+                ct.no_games = len([game for game in heroic_game_list if game.is_installed and ct.displayname in game.wine_info.get('name', '')])
 
         for ct in self.compat_tool_index_map:
             self.ui.listInstalledVersions.addItem(ct.get_displayname(unused_tr=self.tr('unused')))

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -24,6 +24,7 @@ from pupgui2.pupgui2customiddialog import PupguiCustomInstallDirectoryDialog
 from pupgui2.pupgui2gamelistdialog import PupguiGameListDialog
 from pupgui2.pupgui2installdialog import PupguiInstallDialog
 from pupgui2.steamutil import get_steam_acruntime_list, get_steam_app_list, get_steam_ct_game_map
+from pupgui2.heroicutil import is_heroic_launcher
 from pupgui2.util import apply_dark_theme, create_compatibilitytools_folder, get_installed_ctools, remove_ctool
 from pupgui2.util import install_directory, available_install_directories, get_install_location_from_directory_name
 from pupgui2.util import print_system_information, single_instance, download_awacy_gamelist, is_online
@@ -195,9 +196,8 @@ class MainWindow(QObject):
 
             self.get_installed_versions('dxvk', dxvk_dir)
             self.get_installed_versions('vkd3d', vkd3d_dir)
-
         # Launcher specific (Steam): Number of games using the compatibility tool
-        if install_loc.get('launcher') == 'steam' and 'vdf_dir' in install_loc:
+        elif install_loc.get('launcher') == 'steam' and 'vdf_dir' in install_loc:
             get_steam_app_list(install_loc.get('vdf_dir'), cached=False)  # update app list cache
             self.compat_tool_index_map += get_steam_acruntime_list(install_loc.get('vdf_dir'), cached=True)
             map = get_steam_ct_game_map(install_loc.get('vdf_dir'), self.compat_tool_index_map, cached=True)
@@ -217,8 +217,10 @@ class MainWindow(QObject):
 
         if install_loc.get('launcher') == 'steam' and 'vdf_dir' in install_loc:
             self.ui.btnShowGameList.setVisible(True)
-        #elif install_loc.get('launcher') == 'lutris':
-        #    self.ui.btnShowGameList.setVisible(True)
+        elif install_loc.get('launcher') == 'lutris':
+           self.ui.btnShowGameList.setVisible(True)
+        elif is_heroic_launcher(install_loc.get('launcher')):
+            self.ui.btnShowGameList.setVisible(True)
         else:
             self.ui.btnShowGameList.setVisible(False)
 

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -83,7 +83,7 @@ class PupguiCtInfoDialog(QObject):
     def update_game_list_lutris(self):
         lutris_games = [game for game in get_lutris_game_list(self.install_loc) if game.runner == 'wine' and game.get_game_config().get('wine', {}).get('version') == self.ctool.displayname]
 
-        self.setup_game_list(len(lut), [self.tr('Slug'), self.tr('Name')])
+        self.setup_game_list(len(lutris_games), [self.tr('Slug'), self.tr('Name')])
 
         for i, game in enumerate(lutris_games):
             self.ui.listGames.setItem(i, 0, QTableWidgetItem(game.slug))

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -96,6 +96,7 @@ class PupguiCtInfoDialog(QObject):
         self.setup_game_list(len(heroic_games), [self.tr('Runner'), self.tr('Game')])
 
         for i, game in enumerate(heroic_games):
+            print(f'{game.title} -> {game.install_path}')
             self.ui.listGames.setItem(i, 0, QTableWidgetItem(game.runner))
             self.ui.listGames.setItem(i, 1, QTableWidgetItem(game.title))
 

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -91,7 +91,7 @@ class PupguiCtInfoDialog(QObject):
 
     def update_game_list_heroic(self):
         heroic_dir = os.path.join(os.path.expanduser(self.install_loc.get('install_dir')), '../..')
-        heroic_games = [game for game in get_heroic_game_list(heroic_dir) if self.ctool.displayname in game.wine_info.get('name', '')]
+        heroic_games = [game for game in get_heroic_game_list(heroic_dir) if game.is_installed and self.ctool.displayname in game.wine_info.get('name', '')]
 
         self.setup_game_list(len(heroic_games), [self.tr('Runner'), self.tr('Game')])
 

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -96,7 +96,6 @@ class PupguiCtInfoDialog(QObject):
         self.setup_game_list(len(heroic_games), [self.tr('Runner'), self.tr('Game')])
 
         for i, game in enumerate(heroic_games):
-            print(f'{game.title} -> {game.install_path}')
             self.ui.listGames.setItem(i, 0, QTableWidgetItem(game.runner))
             self.ui.listGames.setItem(i, 1, QTableWidgetItem(game.title))
 

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -1,4 +1,5 @@
 import pkgutil
+import os
 
 from pupgui2.constants import STEAM_APP_PAGE_URL
 from pupgui2.datastructures import BasicCompatTool, CTType
@@ -6,11 +7,15 @@ from pupgui2.lutrisutil import get_lutris_game_list
 from pupgui2.pupgui2ctbatchupdatedialog import PupguiCtBatchUpdateDialog
 from pupgui2.steamutil import get_steam_game_list
 from pupgui2.util import open_webbrowser_thread
+from pupgui2.heroicutil import get_heroic_game_list, is_heroic_launcher
 
 from PySide6.QtCore import QObject, Signal, QDataStream, QByteArray
 from PySide6.QtWidgets import QTableWidgetItem
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtCore import Qt
+
+from typing import List
+
 
 class PupguiCtInfoDialog(QObject):
 
@@ -47,6 +52,8 @@ class PupguiCtInfoDialog(QObject):
                     self.ui.btnBatchUpdate.clicked.connect(self.btn_batch_update_clicked)
         elif self.install_loc.get('launcher') == 'lutris':
             self.update_game_list_lutris()
+        elif is_heroic_launcher(self.install_loc.get('launcher')):
+            self.update_game_list_heroic()
         else:
             self.ui.txtNumGamesUsingTool.setText('-')
             self.ui.listGames.setHorizontalHeaderLabels(['', ''])
@@ -74,16 +81,29 @@ class PupguiCtInfoDialog(QObject):
         self.batch_update_complete.emit(True)
 
     def update_game_list_lutris(self):
-        self.ui.listGames.clear()
-
         lutris_games = [game for game in get_lutris_game_list(self.install_loc) if game.runner == 'wine' and game.get_game_config().get('wine', {}).get('version') == self.ctool.displayname]
 
-        self.ui.listGames.setRowCount(len(lutris_games))
-        self.ui.listGames.setHorizontalHeaderLabels([self.tr('Slug'), self.tr('Name')])
-        self.ui.txtNumGamesUsingTool.setText(str(len(lutris_games)))
+        self.setup_game_list(len(lut), [self.tr('Slug'), self.tr('Name')])
+
         for i, game in enumerate(lutris_games):
             self.ui.listGames.setItem(i, 0, QTableWidgetItem(game.slug))
             self.ui.listGames.setItem(i, 1, QTableWidgetItem(game.name))
+
+    def update_game_list_heroic(self):
+        heroic_dir = os.path.join(os.path.expanduser(self.install_loc.get('install_dir')), '../..')
+        heroic_games = [game for game in get_heroic_game_list(heroic_dir) if self.ctool.displayname in game.wine_info.get('name', '')]
+
+        self.setup_game_list(len(heroic_games), [self.tr('Runner'), self.tr('Game')])
+
+        for i, game in enumerate(heroic_games):
+            self.ui.listGames.setItem(i, 0, QTableWidgetItem(game.runner))
+            self.ui.listGames.setItem(i, 1, QTableWidgetItem(game.title))
+
+    def setup_game_list(self, row_count: int, header_labels: List[str]):
+        self.ui.listGames.clear()
+        self.ui.listGames.setRowCount(row_count)
+        self.ui.listGames.setHorizontalHeaderLabels(header_labels)
+        self.ui.txtNumGamesUsingTool.setText(str(row_count))
 
     def btn_close_clicked(self):
         self.ui.close()


### PR DESCRIPTION
Some work is a prerequisite for #168.

Implements support for showing an Info Dialog for Heroic Games compatibility tools :partying_face: To faciliate this, this also implements a `HeroicGame` datastructure, some associated utility functions and some other misc work around this.

![image](https://user-images.githubusercontent.com/7917345/219983966-fad743d2-30a4-4dbb-9a88-510da5cc7c77.png)

## Overview
This is heavily work-in-progress for the moment and has only seen light testing.
- No Epic Games integration - Not sure where the `library.json` file is (if it exists), what it looks like, etc
  - However, if the Epic Games data is similarly structured then it should be trivial to include support!
- No Games List integration - It could go in a separate PR, I didn't want to work on it until #192 was merged
  - I also have some other refactor work I want to submit for review for the games list dialog, and I don't want to submit that until the Lutris game list work is reviewed and merged
- Minimal testing of GOG and side-loaded apps - I had never used Heroic before a few hours ago :sweat_smile: 
- Minimal testing of compatibility tools - Only tested Wine-GE
- Only tested for Heroic Wine Flatpak - Did not test Proton Flatpak or Heroic AppImage/Heroic from repos
- Only parsed what I considered relevant from the `library.json` and `GamesConfig/<app_name>.json` - There is certainly room to expand to more fields 

## Implementation
### Performance
In my tests, performance seems pretty good, though I only have 176 games (175 from GOG, 1 side-loaded).

### Oddities
One other thing I would like to note is about the `is_installed` field in the `library.json`. This is set correctly for my side-loaded game, but not for my GOG game. It's installed, and Heroic can see that it's installed, and as well as this it has an entry in the `gog_store/installed.json` file, but it's still set to `false` for me.

For this reason I created a utility function `is_gog_game_installed` that cross-references with the `installed.json` file to check if the app name for the game is in that file.

## Future
When implementing this I tried to keep extensibility and maintenance in mind, for future runners that Heroic might add (if they add Amazon Games etc). It should be mostly straightforward to add support for this, assuming they keep the `library.json` formats the same, which I would *assume* they would :sweat_smile: 

Getting games from a new runner should really only be a case of adding its path to the `store_paths` list in `get_heroic_game_list`.

## Improvements
At the very least I would like to include support for showing games using the Epic/Legendary(?) runner in this PR, but I do not use the Epic Games Store so I don't know how Heroic stores data about it - And it doesn't appear to store that data unless you link an Epic Games account, which I don't have.

Also, any type hinting suggestions/improvements are welcome, as well as thoughts on implementing docstrings.

<hr>

Very open to feedback on this, especially around the information stored for `HeroicGame`s. I'm not sure if there is more we want to store, or if we're storing too much, so please feel free to give suggestion here :-) I tried to keep the rest of the code as concise as I could.

I don't want to submit something half-baked so if there is any further work that should be done here, or if you would prefer this PR to (eventually) capture all of #168 that's fine too. I'd like to fully implement #168 but I thought it better to spread it out across two PRs: One for the ctinfo dialog (as it would include creating the `HeroicGame` datastructure-related groundwork and getting a proof-of-concept of using that data in a table) and one for the Games List.

Further testing is welcome, as well as help on implementing Epic Games support.

Thanks! :-)  