### PR TITLE
Fix Steam games list regression from #183

### DIFF
--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -52,8 +52,8 @@ def get_steam_app_list(steam_config_folder: str, cached=False, no_shortcuts=Fals
                 fid_steamapps_path = os.path.join(fid_libraryfolder_path, 'steamapps')  # e.g. /home/gaben/Games/steamapps
                 appmanifest_path = os.path.join(fid_steamapps_path, f'appmanifest_{appid}.acf')
                 if os.path.isfile(appmanifest_path):
-                    appmanifest_install_path = vdf.load(open(appmanifest_path)).get('AppState', {}).get('installdir')    
-                    if not os.path.isdir(os.path.join(fid_steamapps_path, 'common', appmanifest_install_path)):
+                    appmanifest_install_path = vdf.load(open(appmanifest_path)).get('AppState', {}).get('installdir', None)
+                    if not appmanifest_install_path or not os.path.isdir(os.path.join(fid_steamapps_path, 'common', appmanifest_install_path)):
                         continue
 
                 app = SteamApp()

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -51,9 +51,10 @@ def get_steam_app_list(steam_config_folder: str, cached=False, no_shortcuts=Fals
                 # Skip if app isn't installed to `/path/to/steamapps/common` - Skips soundtracks
                 fid_steamapps_path = os.path.join(fid_libraryfolder_path, 'steamapps')  # e.g. /home/gaben/Games/steamapps
                 appmanifest_path = os.path.join(fid_steamapps_path, f'appmanifest_{appid}.acf')
-                appmanifest_install_path = vdf.load(open(appmanifest_path)).get('AppState', {}).get('installdir')
-                if not os.path.isdir(os.path.join(fid_steamapps_path, 'common', appmanifest_install_path)):
-                    continue
+                if os.path.isfile(appmanifest_path):
+                    appmanifest_install_path = vdf.load(open(appmanifest_path)).get('AppState', {}).get('installdir')    
+                    if not os.path.isdir(os.path.join(fid_steamapps_path, 'common', appmanifest_install_path)):
+                        continue
 
                 app = SteamApp()
                 app.app_id = int(appid)


### PR DESCRIPTION
I introduced a small regression in #183 that I somehow did not catch. When an appmanifest didn't exist for a SteamApp, the entire app list loading would trigger the exception in `get_steam_app_list`, meaning a lot of tools were erroneously listed as unused.

I added a check before attempting to load the vdf file to ensure it is actually a valid file.