### PR TITLE
Games List: Move Steam-Specific Logic to steamutil 

### DIFF
--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import QLabel, QComboBox, QPushButton, QTableWidgetItem
 from PySide6.QtUiTools import QUiLoader
 
 from pupgui2.constants import PROTONDB_COLORS, STEAM_APP_PAGE_URL, AWACY_WEB_URL, PROTONDB_APP_PAGE_URL, LUTRIS_WEB_URL
-from pupgui2.datastructures import SteamApp, AWACYStatus, SteamDeckCompatEnum
+from pupgui2.datastructures import AWACYStatus, SteamApp, SteamDeckCompatEnum
 from pupgui2.lutrisutil import get_lutris_game_list, LutrisGame
 from pupgui2.steamutil import steam_update_ctools, get_steam_game_list
 from pupgui2.steamutil import is_steam_running, get_steam_ctool_list

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -96,10 +96,7 @@ class PupguiGameListDialog(QObject):
             btn_fetch_protondb = QPushButton(self.tr('click'))
             btn_fetch_protondb.clicked.connect(lambda checked=False, game=game: get_protondb_status(game, self.protondb_status_fetched))
 
-            fetch_protondb_item = QTableWidgetItem()
-            fetch_protondb_item.setData(Qt.DisplayRole, '')  # Shouldn't need to be set, should always be invisible
-
-            self.ui.tableGames.setItem(i, 4, fetch_protondb_item)
+            self.ui.tableGames.setItem(i, 4, QTableWidgetItem())
             self.ui.tableGames.setCellWidget(i, 4, btn_fetch_protondb)
 
             lbltxt = self.tr(get_steamdeck_compatibility(game))
@@ -113,7 +110,6 @@ class PupguiGameListDialog(QObject):
             lblicon.setToolTip(awacy_tooltip)
             lblicon.setPixmap(p)
 
-            # Used for sorting
             lblicon_item = QTableWidgetItem()
             lblicon_item.setData(Qt.DisplayRole, game.awacy_status.value)
             lblicon_item.setData(Qt.UserRole, AWACY_WEB_URL)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -79,14 +79,11 @@ class PupguiGameListDialog(QObject):
 
             # Compat Tool combobox
             combo = QComboBox()
-            combo.addItem('-')
-            combo.addItems(ctools)
+            combo.addItems(['-'] + ctools)
             if game.compat_tool not in ctools:
                 combo.addItem(game.compat_tool)
-            if game.compat_tool is None:
-                combo.setCurrentText('-')
-            else:
-                combo.setCurrentText(game.compat_tool)
+
+            combo.setCurrentText('-' if game.compat_tool is None else game.compat_tool)
             combo.currentTextChanged.connect(lambda text,game=game: self.queue_ctool_change_steam(text, game))
 
             compat_item = QTableWidgetItem()

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -97,7 +97,7 @@ class PupguiGameListDialog(QObject):
 
             # ProtonDB status
             btn_fetch_protondb = QPushButton(self.tr('click'))
-            btn_fetch_protondb.clicked.connect(lambda checked=False, game=game: self.btn_fetch_protondb_clicked(game))
+            btn_fetch_protondb.clicked.connect(lambda checked=False, game=game: get_protondb_status(game, self.protondb_status_fetched))
 
             fetch_protondb_item = QTableWidgetItem()
             fetch_protondb_item.setData(Qt.DisplayRole, '')  # Shouldn't need to be set, should always be invisible
@@ -140,9 +140,6 @@ class PupguiGameListDialog(QObject):
         self.update_queued_ctools_steam()
         self.ui.close()
 
-    def btn_fetch_protondb_clicked(self, game: SteamApp):
-        get_protondb_status(game, self.protondb_status_fetched)
-
     @Slot(SteamApp)
     def update_protondb_status(self, game: SteamApp):
         """ Slot is gets called when get_protondb_status finishes """
@@ -167,7 +164,7 @@ class PupguiGameListDialog(QObject):
     def queue_ctool_change_steam(self, ctool_name: str, game: SteamApp):
         """ add compatibility tool changes to queue (Steam) """
         ctool_name = None if ctool_name in {'-', ''} else ctool_name
-        
+
         self.queued_changes[game] = ctool_name
         self.ui.tableGames.item(self.ui.tableGames.currentRow(), 1).setData(Qt.DisplayRole, ctool_name)
 

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -1,12 +1,11 @@
 import os
-from typing import Dict, List, Tuple
+from typing import Dict, List
 import shutil
 import subprocess
 import json
 import vdf
 import requests
 import threading
-import pkgutil
 from steam.utils.appcache import parse_appinfo
 
 from PySide6.QtCore import Signal
@@ -14,7 +13,7 @@ from PySide6.QtWidgets import QMessageBox, QApplication
 
 from pupgui2.constants import LOCAL_AWACY_GAME_LIST, PROTONDB_API_URL
 from pupgui2.constants import STEAM_STL_INSTALL_PATH, STEAM_STL_CONFIG_PATH, STEAM_STL_SHELL_FILES, STEAM_STL_FISH_VARIABLES
-from pupgui2.datastructures import SteamApp, AWACYStatus, BasicCompatTool, CTType, SteamDeckCompatEnum
+from pupgui2.datastructures import SteamApp, AWACYStatus, BasicCompatTool, CTType
 
 
 _cached_app_list = []
@@ -292,33 +291,6 @@ def update_steamapp_awacystatus(steamapp_list: List[SteamApp]) -> List[SteamApp]
     return steamapp_list
 
 
-def get_steamapp_awacystatus(game: SteamApp) -> Tuple[str, str]:
-    """ Return status string and icon representing Are We Anti-Cheat Yet status for a Steam game. """
-    awacy_status: str = ''
-    awacy_icon: str = ''
-
-    if game.awacy_status == AWACYStatus.ASUPPORTED:
-        awacy_status = 'Support was explicitly enabled / works out of the box'
-        awacy_icon = 'awacy_supported.png'
-    elif game.awacy_status == AWACYStatus.PLANNED:
-        awacy_status = 'Game plans to support Proton/Wine'
-        awacy_icon = 'awacy_planned.png'
-    elif game.awacy_status == AWACYStatus.RUNNING:
-        awacy_status = 'No official statement but runs fine (may require tinkering)'
-        awacy_icon = 'awacy_running.png'
-    elif game.awacy_status == AWACYStatus.BROKEN:
-        awacy_status = 'Anti-Cheat stops game from running properly'
-        awacy_icon = 'awacy_broken.png'
-    elif game.awacy_status == AWACYStatus.DENIED:
-        awacy_status = 'Linux support was explicitly denied'
-        awacy_status = 'awacy_denied.png'
-    else:
-        awacy_status = 'Anti-Cheat status unknown'
-        awacy_icon = 'awacy_unknown.png'
-
-    return awacy_status, os.path.join('resources/img', awacy_icon)
-
-
 def get_protondb_status_thread(game: SteamApp, signal: Signal) -> None:
     """ Downloads the ProtonDB.com status and calls the Qt Signal "signal" when done. Use with "get_protondb_status"!"""
     try:
@@ -336,33 +308,6 @@ def get_protondb_status(game: SteamApp, signal: Signal) -> None:
     """ Downloads the ProtonDB.com status in a separate threads. When done the Qt Signal "signal" is called """
     t = threading.Thread(target=get_protondb_status_thread, args=(game, signal))
     t.start()
-
-
-def get_steamdeck_compatibility(game: SteamApp) -> str:
-    """ Return Steam Deck compatibility rating for a Steam game. """
-    deckc = game.get_deck_compat_category()
-    deckt = game.get_deck_recommended_tool()
-
-    if deckc == SteamDeckCompatEnum.UNKNOWN:
-        return 'Unknown'
-    elif deckc == SteamDeckCompatEnum.UNSUPPORTED:
-        return 'Unsupported'
-    elif deckc == SteamDeckCompatEnum.PLAYABLE:
-        if deckt == '':
-            return 'Playable'
-        elif deckt == 'native':
-            return 'Native (playable)'
-        else:
-            return 'Playable using {COMPAT_TOOL}'.format(COMPAT_TOOL=deckt)
-    elif deckc == SteamDeckCompatEnum.VERIFIED:
-        if deckt == '':
-            return 'Verified'
-        elif deckt == 'native':
-            return 'Native (verified)'
-        else:
-            return 'Verified for {compat_tool}'.format(compat_tool=deckt)
-    else:
-        return ''
 
 
 def steam_update_ctool(game: SteamApp, new_ctool=None, steam_config_folder='') -> bool:


### PR DESCRIPTION
Initially the Games List really only managed Steam game stuff. Lutris recently got support for showing a Games List, and in future hopefully there will also be a Heroic games list.

No screenshot here as there should be no user-facing change, just "backend" changes :-)

This PR splits the ProtonDB fetching logic and the Anti-Cheat status logic out into separate functions in `steamutil`.  This is not really faster or anything as far as I can tell (nor does it appear to be any slower), but the hope is to make the games list a little bit cleaner. Instead of having all of this logic in the games list, it's separated out into utility functions.

This also introduces the possibility of fetching ProtonDB and Anti-Cheat status outside of the games list dialog if it's ever needed, though I don't know when this would be used.

There are also some other small tweaks in this file that I noticed and thought would fit in this PR too, but the main goal of this was to break down the logic in the games list to make it a bit more clean and hopefully easier to maintain as this dialog could grow to accommodate more game lists.

Hope this makes sense and please let me know if there are any further changes/improvements that should be made, or if there are any changes made here that should be undone.

Thanks!