### PR TITLE
Heroic: Add Basic Games List

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -81,4 +81,5 @@ STEAM_STL_DATA_PATH = os.path.join(os.path.expanduser('~'), '.local', 'share', '
 STEAM_STL_SHELL_FILES = [ '.bashrc', '.zshrc', '.kshrc' ]
 STEAM_STL_FISH_VARIABLES = os.path.join(os.path.expanduser('~'), '.config/fish/fish_variables')
 
-LUTRIS_WEB_URL='https://lutris.net/games/'
+LUTRIS_WEB_URL = 'https://lutris.net/games/'
+EPIC_STORE_URL = 'https://store.epicgames.com/p/'

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -183,7 +183,7 @@ class HeroicGame:
     is_installed: bool  # Not always set properly by Heroic for GOG?
     wine_info: Dict[str, str]  # can store bin, name, and type - Has to be fetched from GamesConfig/app_name.json
     platform: str  # Game platform, stored differently for sideload, GOG and legendary
-    executable: str  # Path to game executable
+    executable: str  # Path to game executable, always stored at 'start.sh' for native Linux GOG games 
     is_dlc: bool  # Stored for GOG and legendary, defaults to False for sideloaded
 
     def get_game_config(self):

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -175,7 +175,6 @@ class HeroicGame:
     app_name: str  # internal name encoded in some way, e.g. 'sPZQ5kmzYj5KnZKdxE2bR1'
     title: str  # Real name for game
     developer: str  # May be blank for side-loaded games
-    install: Dict[str, str]  # e.g. executable, platform details
     heroic_path: str  # e.g. '~/.config/heroic', '~/.var/app/com.heroicgameslauncher.hgl/config/heroic'
     install_path: str  # Path to game folder, e.g. '/home/Gaben/Games/Half-Life 3'
     store_url: str  # May be blank for side-loaded games
@@ -183,6 +182,9 @@ class HeroicGame:
     art_square: str  # Optional?
     is_installed: bool  # Not always set properly by Heroic for GOG?
     wine_info: Dict[str, str]  # can store bin, name, and type - Has to be fetched from GamesConfig/app_name.json
+    platform: str  # Game platform, stored differently for sideload, GOG and legendary
+    executable: str  # Path to game executable
+    is_dlc: bool  # Stored for GOG and legendary, defaults to False for sideloaded
 
     def get_game_config(self):
         game_config = os.path.join(self.heroic_path, 'GamesConfig', f'{self.app_name}.json')

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -1,9 +1,11 @@
 import os
 import json
+import re
 
 from typing import List, Dict
 
 from pupgui2.datastructures import HeroicGame
+from pupgui2.constants import EPIC_STORE_URL
 
 
 def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
@@ -63,6 +65,7 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
             lg.developer: str = ''  # Not stored or stored elsewhere?
             lg.heroic_path: str = heroic_path
             lg.install_path: str = game_data.get('install_path', '') 
+            lg.store_url: str = f'{EPIC_STORE_URL}{re.sub("[^a-zA-Z0-9]", "-", lg.title.lower())}'
             lg.art_cover: str = ''  # Not stored or stored elsewhere?
             lg.art_square: str = ''  # Not stored or stored elsewhere?
             lg.is_installed: str = True  # Games in Legendary `installed.json` should always be installed

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -13,7 +13,7 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
     """
 
     if not os.path.isdir(heroic_path):
-        return {}
+        return []
 
     store_paths: List[str] = [ os.path.join(heroic_path, 'sideload_apps', 'library.json'), os.path.join(heroic_path, 'gog_store', 'library.json') ]
     legendary_path: str = os.path.abspath(os.path.join(heroic_path, '..', 'legendary', 'installed.json'))

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -43,10 +43,10 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
         hg.wine_info: Dict[str, str] = hg.get_game_config().get('wineVersion', {})
         # Sideloaded games store platform in its library.json (it has no installed.json) under the 'install' object
         # GOG games store the platform for the version of the installed game in `installed.json` (as GOG games can target multiple platforms, installed will show if the user has the Windows or Linux version)
-        hg.platform: str = game.get('install', {}).get('platform', '').capitalize() if hg.runner.lower() == 'sideload' else get_gog_installed_game_entry(hg).get('platform', '').capitalize()  # Capitalize ensures consistency
+        hg.platform: str = get_gog_installed_game_entry(hg).get('platform', '').capitalize() if hg.runner.lower() == 'gog' else game.get('install', {}).get('platform', '').capitalize()  # Capitalize ensures consistency
         # GOG and Epic store the exe name on its own, but sideloaded stores the full path, so for consistency get the basename for sideloaded apps
         # Native GOG games seem to just store the 'executable' as 'start.sh' script
-        hg.executable: str = get_gog_game_executable(hg) if hg.runner == 'gog' else os.path.basename(game.get('install', {}).get('executable', ''))
+        hg.executable: str = get_gog_game_executable(hg) if hg.runner.lower() == 'gog' else os.path.basename(game.get('install', {}).get('executable', ''))
         hg.is_dlc: bool = game.get('install', {}).get('is_dlc', False)
 
         hgs.append(hg)
@@ -112,12 +112,12 @@ def get_gog_game_executable(game: HeroicGame) -> str:
     gog_gameinfo_filename = f'goggame-{game.app_name}.info'
     gog_gameinfo_json_path = os.path.join(game.install_path, gog_gameinfo_filename)
 
-    if not os.path.isfile(gog_gameinfo_json_path) or not game.runner.lower() == 'gog':
-        return ''
-
-    # Native Linux games seem to only store 'start.sh' as their executable
+    # Native Linux games seem to only store 'start.sh' as their executable -- Assume native Linux if no wine_info
     if not game.wine_info:
         return 'start.sh'
+
+    if not os.path.isfile(gog_gameinfo_json_path) or not game.runner.lower() == 'gog':
+        return ''
 
     gog_gameinfo_json = json.load(open(gog_gameinfo_json_path))
     gog_gameinfo_name = gog_gameinfo_json.get('name', '')

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -225,8 +225,8 @@ class MainWindow(QObject):
             self.ui.btnShowGameList.setVisible(True)
         elif install_loc.get('launcher') == 'lutris':
            self.ui.btnShowGameList.setVisible(True)
-        # elif is_heroic_launcher(install_loc.get('launcher')):
-        #     self.ui.btnShowGameList.setVisible(True)
+        elif is_heroic_launcher(install_loc.get('launcher')):
+            self.ui.btnShowGameList.setVisible(True)
         else:
             self.ui.btnShowGameList.setVisible(False)
 

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -212,9 +212,6 @@ class PupguiGameListDialog(QObject):
             self.ui.tableGames.setItem(i, 3, install_date_item)
 
     def update_game_list_heroic(self):
-
-        # TODO native games???
-
         heroic_dir = os.path.join(os.path.expanduser(self.install_loc.get('install_dir')), '../..')
         games: List[HeroicGame] = list(filter(lambda heroic_game: (heroic_game.is_installed and len(heroic_game.runner) > 0 and not heroic_game.is_dlc), get_heroic_game_list(heroic_dir)))
 
@@ -223,8 +220,7 @@ class PupguiGameListDialog(QObject):
         for i, game in enumerate(games):
             title_item = QTableWidgetItem(game.title)
             if game.store_url:
-                # TODO only tested with a handful of GOG games
-                # Do Legendary games have this? How does Heroic store the "Store Page" value for games on EGS, if at all? 
+                # TODO only tested with a handful of GOG games - Do Legendary games have this? How does Heroic store the "Store Page" value for games on EGS, if at all? 
                 # Is there a way to set this for side-loaded games? I couldn't see one, but I would like this to be feasible for GOG and Epic games
                 title_item.setData(Qt.UserRole, game.store_url)
 
@@ -245,6 +241,7 @@ class PupguiGameListDialog(QObject):
 
             compat_item = QTableWidgetItem(compat_tool_prettyname)
             compat_item.setToolTip(compat_tool_tooltip)
+            compat_item.setTextAlignment(Qt.AlignCenter)
 
             install_path_item = QTableWidgetItem(game.install_path)
             self.set_item_data_directory(install_path_item, game.install_path)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -213,8 +213,10 @@ class PupguiGameListDialog(QObject):
 
     def update_game_list_heroic(self):
 
+        # TODO native games???
+
         heroic_dir = os.path.join(os.path.expanduser(self.install_loc.get('install_dir')), '../..')
-        games: List[HeroicGame] = list(filter(lambda heroic_game: (heroic_game.is_installed and len(heroic_game.runner) > 0 and len(heroic_game.wine_info.get('name', '')) > 0), get_heroic_game_list(heroic_dir)))
+        games: List[HeroicGame] = list(filter(lambda heroic_game: (heroic_game.is_installed and len(heroic_game.runner) > 0 and not heroic_game.is_dlc), get_heroic_game_list(heroic_dir)))
 
         self.ui.tableGames.setRowCount(len(games))
 
@@ -226,10 +228,20 @@ class PupguiGameListDialog(QObject):
                 # Is there a way to set this for side-loaded games? I couldn't see one, but I would like this to be feasible for GOG and Epic games
                 title_item.setData(Qt.UserRole, game.store_url)
 
-            compat_tool_prettyname = game.wine_info.get('name', '').split('-', 1)[1].strip()
-            compat_tool_tooltip = f'Name: {compat_tool_prettyname}'
-            compat_tool_tooltip += f'\nPath: {game.wine_info.get("bin", "")}' if game.wine_info.get("bin", "") else ''
-            compat_tool_tooltip += f'\nType: {game.wine_info.get("type", "").capitalize()}' if game.wine_info.get("type", "") else ''
+            title_tooltip = game.title
+            if game.executable:
+                title_tooltip += f' ({game.executable})'
+            title_item.setToolTip(title_tooltip)
+
+            # If no wine_info, assume this is a native game -- May be more reliable than checking a platform string
+            if game.wine_info.get('name', ''):
+                compat_tool_prettyname = game.wine_info.get('name', '').split('-', 1)[1].strip()
+                compat_tool_tooltip = f'Name: {compat_tool_prettyname}'
+                compat_tool_tooltip += f'\nPath: {game.wine_info.get("bin", "")}' if game.wine_info.get("bin", "") else ''
+                compat_tool_tooltip += f'\nType: {game.wine_info.get("type", "").capitalize()}' if game.wine_info.get("type", "") else ''
+            else:
+                compat_tool_prettyname = 'Native'
+                compat_tool_tooltip = f'Type: Native'
 
             compat_item = QTableWidgetItem(compat_tool_prettyname)
             compat_item.setToolTip(compat_tool_tooltip)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -229,17 +229,24 @@ class PupguiGameListDialog(QObject):
                 title_tooltip += f' ({game.executable})'
             title_item.setToolTip(title_tooltip)
 
+            compat_item = QTableWidgetItem()
             # If no wine_info, assume this is a native game -- May be more reliable than checking a platform string
             if game.wine_info.get('name', ''):
-                compat_tool_prettyname = game.wine_info.get('name', '').split('-', 1)[1].strip()
-                compat_tool_tooltip = f'Name: {compat_tool_prettyname}'
-                compat_tool_tooltip += f'\nPath: {game.wine_info.get("bin", "")}' if game.wine_info.get("bin", "") else ''
-                compat_tool_tooltip += f'\nType: {game.wine_info.get("type", "").capitalize()}' if game.wine_info.get("type", "") else ''
+                compat_item_text = game.wine_info.get('name', '').split('-', 1)[1].strip()
+                compat_tool_bin_path = game.wine_info.get('bin', '')
+
+                compat_tool_tooltip = f'Name: {compat_item_text}'
+                if compat_tool_bin_path:
+                    compat_tool_tooltip += f'\nPath: {compat_tool_bin_path}'
+
+                    compat_tool_folder = os.path.join(compat_tool_bin_path.split(compat_item_text)[0], compat_item_text)  # wine_info name is always "<tool_type> - <tool_folder_name>", compat_text_item is always "<tool_folder_name>" if we have the path
+                    compat_item.setData(Qt.UserRole, lambda path: os.system(f'xdg-open "{compat_tool_folder}"'))
+                compat_tool_tooltip += f'\nType: {game.wine_info.get("type", "").capitalize()}' if game.wine_info.get('type', '') else ''
             else:
-                compat_tool_prettyname = 'Native'
+                compat_item_text = 'Native'
                 compat_tool_tooltip = f'Type: Native'
 
-            compat_item = QTableWidgetItem(compat_tool_prettyname)
+            compat_item.setText(compat_item_text)
             compat_item.setToolTip(compat_tool_tooltip)
             compat_item.setTextAlignment(Qt.AlignCenter)
 

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -235,16 +235,16 @@ class PupguiGameListDialog(QObject):
                 compat_item_text = game.wine_info.get('name', '').split('-', 1)[1].strip()
                 compat_tool_bin_path = game.wine_info.get('bin', '')
 
-                compat_tool_tooltip = f'Name: {compat_item_text}'
+                compat_tool_tooltip = self.tr('Name: {compat_item_text}').format(compat_item_text=compat_item_text)
                 if compat_tool_bin_path:
-                    compat_tool_tooltip += f'\nPath: {compat_tool_bin_path}'
+                    compat_tool_tooltip += self.tr('\nPath: {compat_tool_bin_path}').format(compat_tool_bin_path=compat_tool_bin_path)
 
                     compat_tool_folder = os.path.join(compat_tool_bin_path.split(compat_item_text)[0], compat_item_text)  # wine_info name is always "<tool_type> - <tool_folder_name>", compat_text_item is always "<tool_folder_name>" if we have the path
                     compat_item.setData(Qt.UserRole, lambda path: os.system(f'xdg-open "{compat_tool_folder}"'))
-                compat_tool_tooltip += f'\nType: {game.wine_info.get("type", "").capitalize()}' if game.wine_info.get('type', '') else ''
+                compat_tool_tooltip += self.tr('\nType: {wine_type}').format(wine_type=game.wine_info.get("type", "").capitalize()) if game.wine_info.get('type', '') else ''
             else:
-                compat_item_text = 'Native'
-                compat_tool_tooltip = f'Type: Native'
+                compat_item_text = self.tr('Native')
+                compat_tool_tooltip = self.tr('Type: Native')
 
             compat_item.setText(compat_item_text)
             compat_item.setToolTip(compat_tool_tooltip)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -307,14 +307,22 @@ class PupguiGameListDialog(QObject):
         elif isinstance(item_url, Callable):
             item_url(item.text())
 
-    def set_item_data_directory(self, item: QTableWidgetItem, path: str, tooltip_exists: str = 'Double click to browse...', tooltip_invalid: str = 'Install location does not exist!'):
+    def set_item_data_directory(self, item: QTableWidgetItem, path: str,
+                                    tooltip_exists: str = 'Double click to browse...',
+                                    tooltip_invalid: str = 'Install location does not exist!'):
         """ Set the Qt.UserRole data for a QTableWidgetItem to a lambda which uses xdg-open to open a given path, if it exists. """
 
+        # (hacky way to) show default tooltips in parameters while allowing translation (make sure they match the default parameters)
+        if tooltip_exists == 'Double click to browse...':
+            tooltip_exists = self.tr('Double click to browse...')
+        if tooltip_invalid == 'Install location does not exist!':
+            tooltip_invalid = self.tr('Install location does not exist!')
+
         if os.path.isdir(path):
-            item.setToolTip(self.tr(tooltip_exists))
+            item.setToolTip(tooltip_exists)
             item.setData(Qt.UserRole, lambda path: os.system(f'xdg-open "{path}"'))
         else:
-            item.setToolTip(self.tr(tooltip_invalid))
+            item.setToolTip(tooltip_invalid)
 
     def get_steamapp_awacystatus(self, game: SteamApp) -> Tuple[str, str]:
         """ Return translated status text and icon representing AreWeAntiCheatYet.com status for a Steam game """


### PR DESCRIPTION
This PR implements #168, at least in a basic capacity :-) There is also some slight refactoring and additions to the fields stored in `HeroicGame`.

## Games List
### Layout
Here's the layout I came up with:

![image](https://user-images.githubusercontent.com/7917345/221652780-c9b9c3e6-2ba2-4a2b-a2bb-30a210700776.png)

Note: There are no Legendary games in the screenshot as my test `installed.json` games don't have corresponding `GamesConfig/<app_name>.json` files, so they were showing up as native games, and so I decided to exclude them as this would not normally happen in practice.

### Implementation
The data for this list is fetched from a list of `HeroicGame`s. The Heroic Wine and Heroic Proton install locations share a gamelist, I felt that from a *user* perspective there is not much reason to split them up. In my mind I think it would be more frustrating to have to switch between each install directory just to see the games used. It makes sense for individual compatibility tools but in my mind it makes a bit less sense for viewing a list of games. But that's also just *my* opinion :-)

Plus, if they were split, native games would be shown on both, leading to inconsistencies there as well.

However if it is preferred to split them, it shouldn't be too hard of a change. We could just set another filter condition for the heroic games list fetching to only show those with the relevant `type` in their `wine_info` based on the `self.launcher` value.

Like with the Steam and Lutris game lists, I have implemented some tooltip information and double-click functionality where I thought it made sense to do so.
- Game Name
    - Tooltip shows `Game Name`, and appends ` (executable_name)` if the game executable can be found. Game name is shown in tooltip in case the game name is too long.
    - Double click opens the `store_url` using `xdg-open`, if the `store_url` is valid (not set for sideloaded games, _should_ be set for GOG games, unsure about legendary?)
- Compatibility Tool - Shows the name of the compatibility tool with `Wine - ` or `Proton - ` stripped off (e.g. `Proton 7.0` instead of `Proton - Proton 7.0`), or `Native` for native Linux games
    - Tooltip shows the name, path, and type (`Wine`/`Proton`) in that order if each can be found, and simply shows `Type: Native` for native Linux games
    - No double-click action, though perhaps we could bind this to opening the compatibility tool `path` (if present)?
-  Install location - Path to the game's base folder as per `HeroicGame.install_path`
    - Tooltip shows "Double click to browse..." if path is valid, otherwise shows "Install location does not exist!" -- This mirrors Lutris games list
    - Double click action will open the path in the user's default file manager, if it is valid
- Runner
    - No tooltip or double-click action

### Considerations
The data I chose to include here is purely based on my own initial thoughts of what would be good to include. Please let me know if there are better choices or more preferable choices. Of course, users will also be a good way to gauge what should be shown, so I didn't spend *too* long deliberating and just tried to show what I felt would be the most useful and what matched the other game lists best.

I don't own any Legendary games to test this with, so please do test with some Legendary games installed!

Speaking of Legendary, I couldn't find out if those games have a `store_url`. Heroic has a button in its hamburger menu for GOG games which stores lets you view the store page. I would be a bit surprised if it didn't have this for Legendary. In the example in #168 I did see a `base_urls`, but this seems to be for downloading and not for a store page. Perhaps this is stored elsewhere, and if so we can store this on legendary `HeroicGame`s, and then the double-click functionality will work for Legendary games too :smile: 

## Code Refactoring
### `HeroicGame` data
I updated the `HeroicGame` datastructure a little bit. The main change was that I removed the `install` dict, which is based on the `install` dict for Heroic games. The issue is that this can store varying information. Instead, I decided to remove that and store the fields we would be mostly interested in as separate attributes. Not all `install` sections of a Heroic Game JSON will store the same data, so it didn't make much sense looking back to try and shoehorn our `HeroicGame` class to do this.

Now, we have three new fields on the `HeroicGame`:
- `platform` - The *current platform* version of a game e.g., even if a game supports Windows/macOS/Linux, this only stores the platform for the current installed version, e.g. "Linux"
- `executable` - The basename for the executable which is what Legendary stores and what GOG stores *generally* - Sometimes GOG stores paths like `DOSBox\game.exe`
    - `executable` for GOG games seems to be a blank entry in `installed.json`, but in my research I discovered that Wine/Proton games store the executable in a separate way I'll describe later, and native games default to `start.sh`.
    - Sideloaded  games store the full path
    - Legendary games seem to just store the exe basename, but I only have one example to work off of.
- `is_dlc` - Denotes whether a game is DLC, and we filter this out of the Games List -- This field is not set for sideloaded games but should be set for GOG and legendary, we default it to `False` to be safe though

Figuring out how to get the executable for GOG games was a bit of a (heroic) adventure. In the end I found out that the executable is stored in a rather roundabout way for Wine/Proton games. In a Wine/Proton game's folder, there will be a file named `goggame-<app_name>.info`, which is a file with a JSON file structure. Here is an example of this file:

<details>
    <summary>DOOM I Enhanced (goggame-2015545325.info)</summary>

```json
{
    "buildId": "56055485420912305",
    "clientId": "55704669042708932",
    "gameId": "2015545325",
    "language": "English",
    "languages": [
        "en-US"
    ],
    "name": "DOOM I Enhanced",
    "osBitness": [
        "64"
    ],
    "playTasks": [
        {
            "arguments": "--bnet-language en",
            "category": "game",
            "isPrimary": true,
            "languages": [
                "en-US"
            ],
            "name": "DOOM I Enhanced",
            "osBitness": [
                "64"
            ],
            "path": "DOOM.exe",
            "type": "FileTask"
        }
    ],
    "rootGameId": "2015545325",
    "version": 1
}
```
</details> 

The executable path (which afaict is the relative path from the install folder) is always stored in the `playTasks` list of objects, and it's always stored on the object whose `name` attribute matches the root `name` attribute -- I checked this with 5 different GOG games and it seemed to be the case. From reading through a few of these files, I would guess that `playTasks` is used for things like alternative game executables that you can use, such as multiplayer servers. Some files like Dungeon Keeper for example had several of the `playTasks`, and we couldn't guarantee that the first entry would be the correct one, so we had to resort to searching the file for the correct `path` to use.

I created a separate utility function in heroicutil to get this value: `get_gog_game_executable` which manages doing this. It defaults to `start.sh` for native GOG games (instead of just an empty string). For Wine/Proton, it searches for this `goggame` info file and attempts to extract the relevant `path` attribute from the correct object.

For the game I tested this seemed to work but as always, the more testing, the better! :smile: 

### Games List Dialog changes
I created a utility method in the games dialog, `set_item_data_directory`, which manages attaching a path to a `QTableWidgetItem`'s data. This logic was duplicated between Lutris and Heroic for the Install Path double-click functionality, so I created a helper method for this.

If we do want to add a double-click action for compat tools which opens their folder, this method could be used.

<hr>

The changes here turned out to be a little bigger than anticipated in the end, with the HeroicGame refactor. Hopefully I justified the changes I made there well enough. Other fields could potentially be removed and that is certainly up for discussion, maybe storing the art paths is not really that useful. Some of the fields stored are not explicitly used at least not yet, but I thought they were good to store as it's good general information to store about a game. Likewise if there is some data that was missed we can always expand the `HeroicGame`.

Thanks! :-)