### PR TITLE
Show Tool Count on Main Menu, Show Total Installed Games on Games List DIalog

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -185,6 +185,7 @@ class MainWindow(QObject):
     def update_ui(self):
         """ update ui contents """
         install_loc = get_install_location_from_directory_name(install_directory())
+        unused_ctools = 0
 
         self.ui.listInstalledVersions.clear()
         self.compat_tool_index_map = get_installed_ctools(install_directory())
@@ -206,8 +207,12 @@ class MainWindow(QObject):
                 ct.no_games = len(map.get(ct, []))
 
         for ct in self.compat_tool_index_map:
-            self.ui.listInstalledVersions.addItem(ct.get_displayname(unused_tr=self.tr('unused')))
+            ct_displayname = ct.get_displayname(unused_tr=self.tr('unused'))
+            if self.tr('unused') in ct_displayname:
+                unused_ctools += 1
 
+            self.ui.listInstalledVersions.addItem(ct_displayname)
+            
         self.ui.txtActiveDownloads.setText(str(len(self.pending_downloads)))
         if len(self.pending_downloads) == 0:
             self.set_default_statusbar()
@@ -223,7 +228,9 @@ class MainWindow(QObject):
         else:
             self.ui.btnShowGameList.setVisible(False)
 
-        self.ui.txtInstalledVersions.setText(str(len(self.compat_tool_index_map)))
+        # installed_versions_txt = f'{len(self.compat_tool_index_map)}'
+        self.ui.txtUnusedVersions.setText(f'{self.tr("Unused")}: {unused_ctools}' if unused_ctools > 0 else '')
+        self.ui.txtInstalledVersions.setText(f'{len(self.compat_tool_index_map)}')
 
     def get_installed_versions(self, ctool_name, ctool_dir):
         for ct in get_installed_ctools(ctool_dir):

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -121,6 +121,7 @@ class MainWindow(QObject):
         self.progressBarDownload.setVisible(False)
         self.ui.statusBar().addPermanentWidget(self.progressBarDownload)
         self.ui.setWindowIcon(QIcon.fromTheme('net.davidotek.pupgui2'))
+        self.ui.txtInstalledVersions.setText('0')
 
         self.update_combo_install_location()
 
@@ -221,6 +222,8 @@ class MainWindow(QObject):
         #    self.ui.btnShowGameList.setVisible(True)
         else:
             self.ui.btnShowGameList.setVisible(False)
+
+        self.ui.txtInstalledVersions.setText(str(len(self.compat_tool_index_map)))
 
     def get_installed_versions(self, ctool_name, ctool_dir):
         for ct in get_installed_ctools(ctool_dir):

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -236,7 +236,6 @@ class MainWindow(QObject):
         else:
             self.ui.btnShowGameList.setVisible(False)
 
-        # installed_versions_txt = f'{len(self.compat_tool_index_map)}'
         self.ui.txtUnusedVersions.setText(f'{self.tr("Unused")}: {unused_ctools}' if unused_ctools > 0 else '')
         self.ui.txtInstalledVersions.setText(f'{len(self.compat_tool_index_map)}')
 

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -213,11 +213,10 @@ class MainWindow(QObject):
                 ct.no_games = len([game for game in heroic_game_list if game.is_installed and ct.displayname in game.wine_info.get('name', '')])
 
         for ct in self.compat_tool_index_map:
-            ct_displayname = ct.get_displayname(unused_tr=self.tr('unused'))
-            if self.tr('unused') in ct_displayname:
+            self.ui.listInstalledVersions.addItem(ct.get_displayname(unused_tr=self.tr('unused')))
+            if ct.no_games == 0:
                 unused_ctools += 1
 
-            self.ui.listInstalledVersions.addItem(ct_displayname)
             
         self.ui.txtActiveDownloads.setText(str(len(self.pending_downloads)))
         if len(self.pending_downloads) == 0:
@@ -236,7 +235,7 @@ class MainWindow(QObject):
         else:
             self.ui.btnShowGameList.setVisible(False)
 
-        self.ui.txtUnusedVersions.setText(f'{self.tr("Unused")}: {unused_ctools}' if unused_ctools > 0 else '')
+        self.ui.txtUnusedVersions.setText(self.tr('Unused: {unused_ctools}').format(unused_ctools=unused_ctools) if unused_ctools > 0 else '')
         self.ui.txtInstalledVersions.setText(f'{len(self.compat_tool_index_map)}')
 
     def get_installed_versions(self, ctool_name, ctool_dir):

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -54,7 +54,7 @@ class PupguiGameListDialog(QObject):
             self.setup_heroic_list_ui()
 
         self.ui.tableGames.itemDoubleClicked.connect(self.item_doubleclick_action)
-        self.ui.tableGames.horizontalHeaderItem(0).setToolTip(f'Installed games: {str(len(self.games))}')
+        self.ui.tableGames.horizontalHeaderItem(0).setToolTip(self.tr('Installed games: {NO_INSTALLED}').format(NO_INSTALLED=str(len(self.games))))
         self.ui.btnApply.clicked.connect(self.btn_apply_clicked)
 
     def setup_steam_list_ui(self):

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -55,6 +55,7 @@ class PupguiGameListDialog(QObject):
 
         self.ui.txtGamesFound.setText(str(len(self.games)))
         self.ui.tableGames.itemDoubleClicked.connect(self.item_doubleclick_action)
+        self.ui.tableGames.horizontalHeaderItem(0).setToolTip(f'Installed games: {str(len(self.games))}')
         self.ui.btnApply.clicked.connect(self.btn_apply_clicked)
 
     def setup_steam_list_ui(self):

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -53,7 +53,6 @@ class PupguiGameListDialog(QObject):
         elif is_heroic_launcher(self.launcher):
             self.setup_heroic_list_ui()
 
-        self.ui.txtGamesFound.setText(str(len(self.games)))
         self.ui.tableGames.itemDoubleClicked.connect(self.item_doubleclick_action)
         self.ui.tableGames.horizontalHeaderItem(0).setToolTip(f'Installed games: {str(len(self.games))}')
         self.ui.btnApply.clicked.connect(self.btn_apply_clicked)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -29,6 +29,7 @@ class PupguiGameListDialog(QObject):
         self.install_dir = install_dir
         self.parent = parent
         self.queued_changes = {}
+        self.games = []
 
         self.install_loc = get_install_location_from_directory_name(install_dir)
         self.launcher = self.install_loc.get('launcher')
@@ -49,7 +50,8 @@ class PupguiGameListDialog(QObject):
             self.setup_steam_list_ui()
         elif self.launcher == 'lutris':
             self.setup_lutris_list_ui()
-
+        
+        self.ui.txtGamesFound.setText(str(len(self.games)))
         self.ui.tableGames.itemDoubleClicked.connect(self.item_doubleclick_action)
         self.ui.btnApply.clicked.connect(self.btn_apply_clicked)
 
@@ -190,13 +192,13 @@ class PupguiGameListDialog(QObject):
         """ update the game list for the Lutris launcher """
         # Filter blank runners and Steam games, because we can't change any compat tool options for Steam games via Lutris
         # Steam games can be seen from the Steam games list, so no need to duplicate it here
-        games: List[LutrisGame] = list(filter(lambda lutris_game: (lutris_game.runner is not None and lutris_game.runner != 'steam' and len(lutris_game.runner) > 0), get_lutris_game_list(self.install_loc)))
+        self.games: List[LutrisGame] = list(filter(lambda lutris_game: (lutris_game.runner is not None and lutris_game.runner != 'steam' and len(lutris_game.runner) > 0), get_lutris_game_list(self.install_loc)))
 
-        self.ui.tableGames.setRowCount(len(games))
+        self.ui.tableGames.setRowCount(len(self.games))
 
         # Not sure if we can allow compat tool updating from here, as Lutris allows configuring more than just Wine version
         # It lets you set Wine/DXVK/vkd3d/etc independently, so for now the dialog just displays game information
-        for i, game in enumerate(games): 
+        for i, game in enumerate(self.games): 
             name_item = QTableWidgetItem(game.name)
             name_item.setToolTip(f'{game.name} ({game.slug})')
             if game.installer_slug:

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -215,11 +215,11 @@ class PupguiGameListDialog(QObject):
 
     def update_game_list_heroic(self):
         heroic_dir = os.path.join(os.path.expanduser(self.install_loc.get('install_dir')), '../..')
-        games: List[HeroicGame] = list(filter(lambda heroic_game: (heroic_game.is_installed and len(heroic_game.runner) > 0 and not heroic_game.is_dlc), get_heroic_game_list(heroic_dir)))
+        self.games: List[HeroicGame] = list(filter(lambda heroic_game: (heroic_game.is_installed and len(heroic_game.runner) > 0 and not heroic_game.is_dlc), get_heroic_game_list(heroic_dir)))
 
-        self.ui.tableGames.setRowCount(len(games))
+        self.ui.tableGames.setRowCount(len(self.games))
 
-        for i, game in enumerate(games):
+        for i, game in enumerate(self.games):
             title_item = QTableWidgetItem(game.title)
             if game.store_url:
                 # TODO only tested with a handful of GOG games - Do Legendary games have this? How does Heroic store the "Store Page" value for games on EGS, if at all? 

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -10,13 +10,44 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>300</height>
+    <height>325</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Game List</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="lblGamesFound">
+       <property name="text">
+        <string>Installed Games:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="txtGamesFound">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
    <item>
     <widget class="QTableWidget" name="tableGames">
      <property name="editTriggers">

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -18,37 +18,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="lblGamesFound">
-       <property name="text">
-        <string>Installed Games:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="txtGamesFound">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
     <widget class="QTableWidget" name="tableGames">
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>

--- a/pupgui2/resources/ui/pupgui2_mainwindow.ui
+++ b/pupgui2/resources/ui/pupgui2_mainwindow.ui
@@ -121,6 +121,13 @@
         </property>
        </spacer>
       </item>
+      <item>
+       <widget class="QLabel" name="txtUnusedVersions">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
      </layout>
     </item>
     <item>

--- a/pupgui2/resources/ui/pupgui2_mainwindow.ui
+++ b/pupgui2/resources/ui/pupgui2_mainwindow.ui
@@ -93,11 +93,35 @@
      </layout>
     </item>
     <item>
-     <widget class="QLabel" name="lblInstalledVersions">
-      <property name="text">
-       <string>Installed compatibility tools:</string>
-      </property>
-     </widget>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <item>
+       <widget class="QLabel" name="lblInstalledVersions">
+        <property name="text">
+         <string>Installed compatibility tools:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="txtInstalledVersions">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
     </item>
     <item>
      <widget class="QListWidget" name="listInstalledVersions">


### PR DESCRIPTION
This PR does a few things:
- Show total installed tools for a given launcher beside its "Installed compatibility tools:" label.
- To the right of this, if there are any unused tools, display a label that says "Unused: {num_unused_tools}" (this is hidden if there are no unused tools).
    - This currently only applies to Steam and Heroic, as there is no logic for checking unused Lutris tools
- On the Games List dialog, display the total found installed games.
    - I originally thought to show this count in the dialog title, but in future this may not always be visible (i.e. if running in Steam Deck Game Mode), so I went with adding a label despite it taking up slightly more real-estate in the dialog than I'd like

It can be useful at a glance to see how many compatibility tools you have installed and, if you have a lot installed, how many are unused. It can help highlight if, for example, you end up in a scenario where you have a bunch of old GE-Proton versions laying around.

## Screenshots
![image](https://user-images.githubusercontent.com/7917345/224086781-2a851f3a-5e75-4ef7-9e5d-79bfe00a8a30.png)

![image](https://user-images.githubusercontent.com/7917345/224086854-7f625fa0-16c2-4466-8394-f3fee3428463.png)

## Overview
I've actually been sitting on this one for a while, and was very back and forth on how the UI should look. I think re-using the "Installed compatibility tools" label on the main menu is very natural. I experimented with a lot of different positions and such for the unused text, putting it in the bottom-right, putting it in brackets, different wordings, and in the end I landed on the "Unused: X" in the top-right to the side of the installed tools count. The positioning and wording mirrors the active downloads text above it. However I am absolutely open to any kind of improvements here. I'm no UI designer but I still like to make interfaces better where I can :-)

Finally with the games list dialog, as mentioned the label takes up slightly more real-estate than I'd like, but I wasn't sure where else to put it. The titlebar is kind of out imo. There could be semi-hacky conditional checks to display it in the titlebar under normal circumstances, and only append a label programmatically if we're running in Game Mode, but window decorations can be hid normally anyway, so I just don't feel like it's a solid approach to take. The bottom-left section of the dialog is out too as that's where the Steam warning label goes, and they could end up conflicting. If the Steam warning text is present it would really throw off the "look" of the label. So the top-left position seemed to be the only logical place left to put it.

One last note is that, at least to my eye, it feels like there is a noticeable amount of spacing between the "Installed compatibility tools" label and the actual count, and the same goes for the total installed games count on the games list. I couldn't figure out a way to resolve this, I would guess that this is because they are two separate labels and so they have some padding and such. If there's a way to fix it that's worth the effort I'm definitely open to improving that :-)

<hr>

Thanks!