### PR TITLE
Games List: Search Box, Apply Button UX Tweaks

### DIFF
--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -45,7 +45,6 @@ class PupguiGameListDialog(QObject):
         data = pkgutil.get_data(__name__, 'resources/ui/pupgui2_gamelistdialog.ui')
         ui_file = QDataStream(QByteArray(data))
         self.ui = QUiLoader().load(ui_file.device())
-        self.ui.searchBox.setVisible(False)  # Hide searchbox by default
 
     def setup_ui(self):
         if self.launcher == 'steam':
@@ -54,6 +53,9 @@ class PupguiGameListDialog(QObject):
             self.setup_lutris_list_ui()
         elif is_heroic_launcher(self.launcher):
             self.setup_heroic_list_ui()
+
+        self.ui.searchBox.setVisible(False)  # Hide searchbox by default
+        self.ui.searchBox.textChanged.connect(self.search_gamelist_games)
 
         self.set_apply_btn_text()
         self.ui.lblSteamRunningWarning.setVisible(self.should_show_steam_warning)  # Only show warning if Steam is running, and make it grey if we're running in Flatpak
@@ -274,6 +276,16 @@ class PupguiGameListDialog(QObject):
         self.ui.searchBox.setVisible(not self.ui.searchBox.isVisible())
         self.ui.btnSearch.setText(self.tr('Done') if self.ui.searchBox.isVisible() else self.tr('Search'))  # "Done" is not good text, try something else
         self.ui.lblSteamRunningWarning.setVisible(self.should_show_steam_warning and not self.ui.searchBox.isVisible())
+        self.ui.searchBox.setFocus()
+
+    def search_gamelist_games(self, text):
+        for row in range(self.ui.tableGames.rowCount()):
+            if not text.lower() in self.ui.tableGames.item(row, 0).text().lower():
+                self.ui.tableGames.hideRow(row)
+            elif len(text.strip()) > 0:
+                self.ui.tableGames.showRow(row)
+            else:
+                self.ui.tableGames.showRow(row)
 
     @Slot(SteamApp)
     def update_protondb_status(self, game: SteamApp):

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -278,6 +278,11 @@ class PupguiGameListDialog(QObject):
         self.ui.lblSteamRunningWarning.setVisible(self.should_show_steam_warning and not self.ui.searchBox.isVisible())
         self.ui.searchBox.setFocus()
 
+        if not self.ui.searchBox.isVisible():
+            self.search_gamelist_games('')
+        else:
+            self.search_gamelist_games(self.ui.searchBox.text())
+
     def search_gamelist_games(self, text):
         for row in range(self.ui.tableGames.rowCount()):
             if not text.lower() in self.ui.tableGames.item(row, 0).text().lower():

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -60,7 +60,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="searchBox"/>
+      <widget class="QLineEdit" name="searchBox">
+       <property name="placeholderText">
+        <string>Search for a game...</string>
+       </property>
+      </widget>
      </item>
      <item>
       <spacer name="horizontalSpacer">

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -60,6 +60,9 @@
       </widget>
      </item>
      <item>
+      <widget class="QLineEdit" name="searchBox"/>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -71,6 +74,13 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnSearch">
+       <property name="text">
+        <string>Search</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QPushButton" name="btnApply">


### PR DESCRIPTION
## Overview
This PR adds a search field to the Games List, my new favourite home it seems :sweat_smile: The idea behind this is to make it easier to find games to set compatibility tools for. The column sorting helps a lot and that was one of the reasons I had in mind for implementing it, but if you have hundreds or even thousands of games installed, it might be faster to just search for them.

This applies to all current Games List: Steam, Lutris, and Heroic (Proton+Wine).

## Search
<details>
<summary>Screenshots:</summary>

![image](https://user-images.githubusercontent.com/7917345/225787240-ac41c366-db3a-4ad6-bf9e-39583a630257.png)

![image](https://user-images.githubusercontent.com/7917345/225787247-66319b97-fb1a-4385-9fb6-f77df09fb86f.png)

![image](https://user-images.githubusercontent.com/7917345/225787265-558800d1-640d-4f6b-97c3-b74960058186.png)
</details>

(I'll come back to the "Done" button in a bit)

The search field is hidden by default, and is shown when the user presses the new "Search" button. It shows up in the same position as the Steam warning label. If the label is not displayed, there is no change, but if it is displayed, then this label is temporarily hidden while the search field is present.

Searching preserves the current selected column sort, and sorting works even when the user is in the middle of searching. It also keeps this sort. If the user searches for, say, "Persona", and sorts alphabetically, then this sort will be remembered. Of course, selected compatibility tools are remembered as well!

When the user presses the "Done" button, the search filter is cleared. Once the user presses "Search" again, their last remembered search will be applied as well.

### UI Tweaks
There are also a a couple of smaller changes to the Games List UI logic: 
- Store a boolean that checks if the Steam warning label should be displayed and set it once in `setup_ui` - This removes the extra calls to `lblSteamRunningWarning.setVisible` in the other launcher setup functions
- Use a method to determine the text for the "Apply" button and whether it should say "Apply" or "Close" based on three factors:
    - If Steam is running (only applicable to Steam)
    - If the current launcher is Steam (again, only applicable to Steam)
    - If the `queued_changes >= 0` (nothing to apply if there are no changes queued) - Though it doesn't "reset" if the applied change is reverted i.e. if the compat tool is changed to STL and then back again to whatever its initial value was, though this is more likely related to the logic for populating `queued_changes`

## Improvements
There are a couple of things I would like to "Improve" on this PR that I'd like some feedback on.

### Keyboard Shortcut
The decision to have a dedicated "Search" button was deliberate, for users who may be using a touch screen (i.e. on Steam Deck). But I would also like the ability to trigger this with a standard Ctrl+F shortcut. I'm not sure how to do this though. The `btn_search_clicked` method would need to be called on Ctrl+F being pressed. I read online about a `QKeySequence` being used for this, and it can emit an `activated` but I'm not totally sure, I couldn't find too much (though it *is* late at the moment).

### "Done" Button for Search
My other concern is with the "Done" button for the search field. I'm not too sure if this name is good. It may be confusing for users. One potential solution is to have a layout with the search field that has its own "Done" button (which could be connected to the same signal as the "Search" button probably), that way the done button is farther away from the "Close"/"Apply" button, but it could still end up being confusing. "Stop Searching" is a bit lengthy but could work as a replacement. Some way to better name this button would be appreciated :smile: 

### Performance?
I only have around 307 Steam games installed, but on my PC the search is instantaneous. Maybe if there were thousands of games there could be a performance impact here. If there are ways to optimise the search I'm very open to it! :smile: 

<hr>

I thought my last PR would be my last contribution for a while, but I found a note written down with this idea out of the blue and thought I'd try to implement it and keep the code cost down (tried to keep the Games List under 400 lines but failed...)

Thanks! :-)