### PR TITLE
Add Quit Shortcut

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -142,8 +142,7 @@ class MainWindow(QObject):
         self.ui.btnShowCtInfo.setEnabled(False)
 
         # Keyboard Shortcuts
-        quit_shortcut = QShortcut(QKeySequence.Quit, self.ui)
-        quit_shortcut.activated.connect(self.btn_close_clicked)
+        QShortcut(QKeySequence.Quit, self.ui).activated.connect(self.btn_close_clicked)
 
         self.set_default_statusbar()
 

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -8,7 +8,7 @@ import threading
 
 from PySide6.QtCore import Qt, QCoreApplication, QObject, QThread, QWaitCondition, QMutex, QDataStream
 from PySide6.QtCore import QByteArray, QEvent, Signal, Slot, QTranslator, QLocale, QLibraryInfo
-from PySide6.QtGui import QIcon, QKeyEvent
+from PySide6.QtGui import QIcon, QKeyEvent, QKeySequence, QShortcut
 from PySide6.QtWidgets import QApplication, QDialog, QMessageBox, QLabel, QPushButton, QCheckBox, QProgressBar, QVBoxLayout
 from PySide6.QtUiTools import QUiLoader
 
@@ -140,6 +140,10 @@ class MainWindow(QObject):
 
         self.ui.btnRemoveSelected.setEnabled(False)
         self.ui.btnShowCtInfo.setEnabled(False)
+
+        # Keyboard Shortcuts
+        quit_shortcut = QShortcut(QKeySequence.Quit, self.ui)
+        quit_shortcut.activated.connect(self.btn_close_clicked)
 
         self.set_default_statusbar()
 


### PR DESCRIPTION
Adds the option to use `QKeySequence.Quit` to quit the application. Generally on Linux this is `Ctrl+Q` (for some command line stuff it can be `Ctrl+Shift+Q`). Though we could use `QShortcut(QKeySequence('Ctrl+Q'))`, it's generally better to use built-in `QKeySequence` values for shortcuts.

I had this idea when working on #204, and eventually figured out how to properly implement keyboard shortcuts. I'll look into updating how I did it in that PR too :-)

Thanks!