### PR TITLE
Add Tooltip to Custom Install Directory button

### DIFF
--- a/pupgui2/resources/ui/pupgui2_mainwindow.ui
+++ b/pupgui2/resources/ui/pupgui2_mainwindow.ui
@@ -85,6 +85,9 @@
       </item>
       <item>
        <widget class="QToolButton" name="btnManageInstallLocations">
+        <property name="toolTip">
+         <string>Add Custom Install Directory...</string>
+        </property>
         <property name="text">
          <string>...</string>
         </property>


### PR DESCRIPTION
It isn't immediately obvious at first glance what this button does, so this PR adds a tooltip that describes what the button does.

The rest of the UI imo is fairly self-explanatory and intuitive, and the user only has to click on this tool button to figure out what it does, but a tooltip is a nice quality-of-life improvement I think :-)