### PR TITLE
pupgui2: Add More Keyboard Shortcuts

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -152,6 +152,12 @@ class MainWindow(QObject):
         QShortcut(QKeySequence('Alt+Return'), self.ui).activated.connect(self.btn_show_ct_info_clicked)  # Uses 'Return' even though docs mention 'Enter' - https://doc.qt.io/qt-6/qkeysequence.html
         QShortcut(QKeySequence('Ctrl+G'), self.ui).activated.connect(self.btn_show_game_list_clicked)
 
+        # TODO These are currently Steam-specific, need to be able to handle other launchers
+        QShortcut(QKeySequence('Ctrl+Shift+T'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='Proton Tkg'))
+        QShortcut(QKeySequence('Ctrl+Shift+B'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='Boxtron'))
+        QShortcut(QKeySequence('Ctrl+Shift+L'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='Luxtorpeda'))
+        QShortcut(QKeySequence('Ctrl+Shift+S'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='SteamTinkerLaunch'))
+
         self.set_default_statusbar()
 
         self.giw = GamepadInputWorker()
@@ -300,11 +306,12 @@ class MainWindow(QObject):
             self.ui.statusBar().showMessage(self.tr('Installed {current_compat_tool_name}.').format(current_compat_tool_name=self.current_compat_tool_name))
             self.update_ui()
 
-    def btn_add_version_clicked(self):
+    def btn_add_version_clicked(self, compat_tool=''):
         dialog = PupguiInstallDialog(get_install_location_from_directory_name(install_directory()), self.ct_loader, parent=self.ui)
         dialog.compat_tool_selected.connect(self.install_compat_tool)
         dialog.is_fetching_releases.connect(self.set_fetching_releases)
         dialog.setup_ui()
+        dialog.set_selected_compat_tool(compat_tool)
         dialog.show()
         dialog.setFixedSize(dialog.size())
 

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -308,12 +308,12 @@ class MainWindow(QObject):
 
     def btn_add_version_clicked(self, compat_tool=''):
         dialog = PupguiInstallDialog(get_install_location_from_directory_name(install_directory()), self.ct_loader, parent=self.ui)
+        dialog.compat_tool_selected.connect(self.install_compat_tool)
+        dialog.is_fetching_releases.connect(self.set_fetching_releases)
         dialog.setup_ui()
-        if dialog.set_selected_compat_tool(compat_tool):
-            dialog.compat_tool_selected.connect(self.install_compat_tool)
-            dialog.is_fetching_releases.connect(self.set_fetching_releases)
-            dialog.show()
-            dialog.setFixedSize(dialog.size())
+        dialog.set_selected_compat_tool(compat_tool)
+        dialog.show()
+        dialog.setFixedSize(dialog.size())
 
     def btn_remove_selcted_clicked(self):
         ctools_to_remove = []

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -27,7 +27,7 @@ from pupgui2.steamutil import get_steam_acruntime_list, get_steam_app_list, get_
 from pupgui2.heroicutil import is_heroic_launcher, get_heroic_game_list
 from pupgui2.util import apply_dark_theme, create_compatibilitytools_folder, get_installed_ctools, remove_ctool
 from pupgui2.util import install_directory, available_install_directories, get_install_location_from_directory_name
-from pupgui2.util import print_system_information, single_instance, download_awacy_gamelist, is_online
+from pupgui2.util import print_system_information, single_instance, download_awacy_gamelist, is_online, config_advanced_mode, compat_tool_available
 
 
 class InstallWineThread(QThread):
@@ -151,12 +151,15 @@ class MainWindow(QObject):
         QShortcut(QKeySequence('Ctrl+Backspace'), self.ui).activated.connect(self.btn_remove_selcted_clicked)
         QShortcut(QKeySequence('Alt+Return'), self.ui).activated.connect(self.btn_show_ct_info_clicked)  # Uses 'Return' even though docs mention 'Enter' - https://doc.qt.io/qt-6/qkeysequence.html
         QShortcut(QKeySequence('Ctrl+G'), self.ui).activated.connect(self.btn_show_game_list_clicked)
-
-        # TODO These are currently Steam-specific, need to be able to handle other launchers
-        QShortcut(QKeySequence('Ctrl+Shift+T'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='Proton Tkg'))
+        ## Steam Compat Tool Shortcuts (Some overlap w/ Heroic)
         QShortcut(QKeySequence('Ctrl+Shift+B'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='Boxtron'))
         QShortcut(QKeySequence('Ctrl+Shift+L'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='Luxtorpeda'))
+        QShortcut(QKeySequence('Ctrl+Shift+T'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='Proton Tkg'))
         QShortcut(QKeySequence('Ctrl+Shift+S'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='SteamTinkerLaunch'))
+        ## Lutris Compat Tool Shortcuts (Some overlap w/ Heroic)
+        QShortcut(QKeySequence('Ctrl+Shift+D'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='DXVK'))
+        QShortcut(QKeySequence('Ctrl+Shift+L'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='Lutris-Wine'))
+        QShortcut(QKeySequence('Ctrl+Shift+W'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='Wine Tkg (Valve Wine)'))
 
         self.set_default_statusbar()
 
@@ -306,14 +309,19 @@ class MainWindow(QObject):
             self.ui.statusBar().showMessage(self.tr('Installed {current_compat_tool_name}.').format(current_compat_tool_name=self.current_compat_tool_name))
             self.update_ui()
 
-    def btn_add_version_clicked(self, compat_tool=''):
-        dialog = PupguiInstallDialog(get_install_location_from_directory_name(install_directory()), self.ct_loader, parent=self.ui)
-        dialog.compat_tool_selected.connect(self.install_compat_tool)
-        dialog.is_fetching_releases.connect(self.set_fetching_releases)
-        dialog.setup_ui()
-        dialog.set_selected_compat_tool(compat_tool)
-        dialog.show()
-        dialog.setFixedSize(dialog.size())
+    def btn_add_version_clicked(self, compat_tool: str = ''):
+        advanced_mode = (config_advanced_mode() == 'enabled')
+        install_loc = get_install_location_from_directory_name(install_directory())
+
+        if not compat_tool or compat_tool_available(compat_tool, self.ct_loader.get_ctobjs(install_loc, advanced_mode=advanced_mode)):
+            dialog = PupguiInstallDialog(install_loc, self.ct_loader, parent=self.ui)
+            dialog.compat_tool_selected.connect(self.install_compat_tool)
+            dialog.is_fetching_releases.connect(self.set_fetching_releases)
+            dialog.setup_ui()
+            dialog.set_selected_compat_tool(compat_tool)
+            dialog.show()
+            dialog.setFixedSize(dialog.size())
+
 
     def btn_remove_selcted_clicked(self):
         ctools_to_remove = []

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -308,12 +308,12 @@ class MainWindow(QObject):
 
     def btn_add_version_clicked(self, compat_tool=''):
         dialog = PupguiInstallDialog(get_install_location_from_directory_name(install_directory()), self.ct_loader, parent=self.ui)
-        dialog.compat_tool_selected.connect(self.install_compat_tool)
-        dialog.is_fetching_releases.connect(self.set_fetching_releases)
         dialog.setup_ui()
-        dialog.set_selected_compat_tool(compat_tool)
-        dialog.show()
-        dialog.setFixedSize(dialog.size())
+        if dialog.set_selected_compat_tool(compat_tool):
+            dialog.compat_tool_selected.connect(self.install_compat_tool)
+            dialog.is_fetching_releases.connect(self.set_fetching_releases)
+            dialog.show()
+            dialog.setFixedSize(dialog.size())
 
     def btn_remove_selcted_clicked(self):
         ctools_to_remove = []

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -143,6 +143,12 @@ class MainWindow(QObject):
 
         # Keyboard Shortcuts
         QShortcut(QKeySequence.Quit, self.ui).activated.connect(self.btn_close_clicked)
+        QShortcut(QKeySequence('Ctrl+,'), self.ui).activated.connect(self.btn_about_clicked)
+        QShortcut(QKeySequence(QKeySequence.HelpContents), self.ui).activated.connect(self.btn_about_clicked)
+        QShortcut(QKeySequence('Ctrl+Shift+N'), self.ui).activated.connect(self.btn_manage_install_locations_clicked)
+        QShortcut(QKeySequence.New, self.ui).activated.connect(self.btn_add_version_clicked)
+        QShortcut(QKeySequence.Delete, self.ui).activated.connect(self.btn_remove_selcted_clicked)
+        QShortcut(QKeySequence('Alt+Return'), self.ui).activated.connect(self.btn_show_ct_info_clicked)  # Uses 'Return' even though docs mention 'Enter' - https://doc.qt.io/qt-6/qkeysequence.html
 
         self.set_default_statusbar()
 

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -149,6 +149,7 @@ class MainWindow(QObject):
         QShortcut(QKeySequence.New, self.ui).activated.connect(self.btn_add_version_clicked)
         QShortcut(QKeySequence.Delete, self.ui).activated.connect(self.btn_remove_selcted_clicked)
         QShortcut(QKeySequence('Alt+Return'), self.ui).activated.connect(self.btn_show_ct_info_clicked)  # Uses 'Return' even though docs mention 'Enter' - https://doc.qt.io/qt-6/qkeysequence.html
+        QShortcut(QKeySequence('Ctrl+G'), self.ui).activated.connect(self.btn_show_game_list_clicked)
 
         self.set_default_statusbar()
 

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -148,6 +148,7 @@ class MainWindow(QObject):
         QShortcut(QKeySequence('Ctrl+Shift+N'), self.ui).activated.connect(self.btn_manage_install_locations_clicked)
         QShortcut(QKeySequence.New, self.ui).activated.connect(self.btn_add_version_clicked)
         QShortcut(QKeySequence.Delete, self.ui).activated.connect(self.btn_remove_selcted_clicked)
+        QShortcut(QKeySequence('Ctrl+Backspace'), self.ui).activated.connect(self.btn_remove_selcted_clicked)
         QShortcut(QKeySequence('Alt+Return'), self.ui).activated.connect(self.btn_show_ct_info_clicked)  # Uses 'Return' even though docs mention 'Enter' - https://doc.qt.io/qt-6/qkeysequence.html
         QShortcut(QKeySequence('Ctrl+G'), self.ui).activated.connect(self.btn_show_game_list_clicked)
 

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -108,3 +108,11 @@ class PupguiInstallDialog(QDialog):
             desc = ctobj['description']['en']
         
         self.txtDescription.setHtml(desc)
+
+    def set_selected_compat_tool(self, ctool_name: str):
+        """ Set compat tool dropdown selected index to the index of the compat tool name passed """
+        if ctool_name:
+            for i in range(self.comboCompatTool.count()):
+                if ctool_name == self.comboCompatTool.itemText(i):
+                    self.comboCompatTool.setCurrentIndex(i)
+                    return

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -31,6 +31,7 @@ class PupguiInstallDialog(QDialog):
         button_box.addWidget(self.btnInstall)
         button_box.addWidget(self.btnCancel)
         self.comboCompatTool = QComboBox()
+        self.comboCompatTool.setFocus()
         self.comboCompatToolVersion = QComboBox()
         self.txtDescription = QTextEdit()
         self.txtDescription.setReadOnly(True)

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -109,19 +109,10 @@ class PupguiInstallDialog(QDialog):
         
         self.txtDescription.setHtml(desc)
 
-    def set_selected_compat_tool(self, ctool_name: str) -> bool:
-        """
-        Set compat tool dropdown selected index to the index of the compat tool name passed.
-        Returns True if the tool is in the compat tool combobox, otherwise returns False.
-        
-        Returns Type: Bool
-        """
+    def set_selected_compat_tool(self, ctool_name: str):
+        """ Set compat tool dropdown selected index to the index of the compat tool name passed """
         if ctool_name:
             for i in range(self.comboCompatTool.count()):
                 if ctool_name == self.comboCompatTool.itemText(i):
                     self.comboCompatTool.setCurrentIndex(i)
-                    break
-            else:
-                return False
-
-        return True
+                    return

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -109,10 +109,19 @@ class PupguiInstallDialog(QDialog):
         
         self.txtDescription.setHtml(desc)
 
-    def set_selected_compat_tool(self, ctool_name: str):
-        """ Set compat tool dropdown selected index to the index of the compat tool name passed """
+    def set_selected_compat_tool(self, ctool_name: str) -> bool:
+        """
+        Set compat tool dropdown selected index to the index of the compat tool name passed.
+        Returns True if the tool is in the compat tool combobox, otherwise returns False.
+        
+        Returns Type: Bool
+        """
         if ctool_name:
             for i in range(self.comboCompatTool.count()):
                 if ctool_name == self.comboCompatTool.itemText(i):
                     self.comboCompatTool.setCurrentIndex(i)
-                    return
+                    break
+            else:
+                return False
+
+        return True

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -469,3 +469,8 @@ def is_online(host='https://api.github.com/repos/', timeout=3) -> bool:
         return True
     except (requests.ConnectionError, requests.Timeout):
         return False
+
+def compat_tool_available(compat_tool: str, ctobjs: List[dict]) -> bool:
+    """ Return whether a compat tool is available for a given launcher """
+
+    return compat_tool in [ctobj['name'] for ctobj in ctobjs]


### PR DESCRIPTION
Implement #206.

This is currently missing the shortcuts for the compatibility tools, but should have the rest as described in that issue:
- Add Compat Tool: `Ctrl+N`
- Add Install Location: `Ctrl+Shift+N`
- Remove Compat Tool: `Delete`, `Ctrl+Backspace` (for keyboards without delete key)
- About: `F1`, `Ctrl+,`
- Compat Tool Info: `Alt+Enter`
- Games List: `Ctrl+G`

For the compatibility tools, the `PupguiInstallDialog` could have a method to set the selected compatibility tool. We could then pass an optional parameter to `MainWindow#btn_add_version_clicked` which would specify the tool. A lambda something like this would  then be attached to the shortcut:

```python
# MainWindow
def setup_ui(self):
    # ...
    QShortcut(QKeySequence('Ctrl+Alt+T'), self.ui).activated.connect(lambda: self.btn_add_version_clicked(compat_tool='Proton-tkg'))
    # ...
```

<hr>

Aside from having to modify some of the install dialog logic, the cost to implement the majority of these shortcuts seems quite low (one line each!), which is always a good thing :smile: 