### PR TITLE
Ctinfo: Add Search Box

### DIFF
--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -130,6 +130,8 @@ class PupguiCtInfoDialog(QObject):
         self.ui.btnBatchUpdate.setVisible(self.is_batch_update_available and not self.ui.searchBox.isVisible())
         self.ui.searchBox.setFocus()
 
+        self.search_ctinfo_games(self.ui.searchBox.text() if self.ui.searchBox.isVisible() else '')
+
     def search_ctinfo_games(self, text):
         for row in range(self.ui.listGames.rowCount()):
             should_hide: bool = not text.lower() in self.ui.listGames.item(row, 1).text().lower()

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -282,10 +282,7 @@ class PupguiGameListDialog(QObject):
         self.ui.lblSteamRunningWarning.setVisible(self.should_show_steam_warning and not self.ui.searchBox.isVisible())
         self.ui.searchBox.setFocus()
 
-        if not self.ui.searchBox.isVisible():
-            self.search_gamelist_games('')
-        else:
-            self.search_gamelist_games(self.ui.searchBox.text())
+        self.search_gamelist_games(self.ui.searchBox.text() if self.ui.searchBox.isVisible() else '')
 
     def search_gamelist_games(self, text):
         for row in range(self.ui.tableGames.rowCount()):

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -53,6 +53,7 @@ class PupguiGameListDialog(QObject):
         elif is_heroic_launcher(self.launcher):
             self.setup_heroic_list_ui()
 
+        self.ui.btnSearch.setVisible(False)
         self.ui.searchBox.setVisible(False)  # Hide searchbox by default
 
         self.set_apply_btn_text()
@@ -66,8 +67,10 @@ class PupguiGameListDialog(QObject):
         self.ui.btnSearch.clicked.connect(self.btn_search_clicked)
         self.ui.searchBox.textChanged.connect(self.search_gamelist_games)
 
-        # Shortcuts
-        QShortcut(QKeySequence.Find, self.ui).activated.connect(self.btn_search_clicked)
+        # Hide Search button and disable shortcut if no games
+        if len(self.games) > 0:
+            self.ui.btnSearch.setVisible(True)
+            QShortcut(QKeySequence.Find, self.ui).activated.connect(self.btn_search_clicked)
 
     def setup_steam_list_ui(self):
         self.ui.tableGames.setHorizontalHeaderLabels([self.tr('Game'), self.tr('Compatibility Tool'), self.tr('Deck compatibility'), self.tr('Anticheat'), 'ProtonDB'])

--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -100,10 +100,30 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QPushButton" name="btnSearch">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Search games...</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset theme="search">
+         <normaloff>.</normaloff>.</iconset>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
     <widget class="QTableWidget" name="listGames">
+     <property name="focusPolicy">
+      <enum>Qt::ClickFocus</enum>
+     </property>
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
      </property>
@@ -145,8 +165,21 @@
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QPushButton" name="btnBatchUpdate">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="text">
         <string>Batch update</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="searchBox">
+       <property name="toolTip">
+        <string>e.g. Half-Life 3</string>
+       </property>
+       <property name="placeholderText">
+        <string>Search for a game...</string>
        </property>
       </widget>
      </item>
@@ -165,6 +198,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="btnClose">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
        <property name="text">
         <string>Close</string>
        </property>

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -19,6 +19,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QTableWidget" name="tableGames">
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
      </property>


### PR DESCRIPTION
This PR primarily adds a search box to the ctinfo dialog, available via a search button and a Ctrl+F shortcut, much like #204.

![image](https://user-images.githubusercontent.com/7917345/226415374-036cbffd-6f0b-4b41-912f-1e50a8ac4710.png) ![image](https://user-images.githubusercontent.com/7917345/226415401-8a2903b5-8972-48ad-b323-b14214305d3e.png)

When the "Batch update" button is visible, it is temporarily hidden and the search box is shown, very similar to how #204 handled the Steam running warning label.

<hr>

This PR also does a couple of other smaller tweaks:
- Games List: Only enable searching (shortcut and button) is there are any games found
- Adjust focus setting for various UI elements, so that an inactive selected indicator is not displayed on some elements i.e. the games list
- Ctinfo: Convert `btn_close_clicked` to lambda, as this method only called `self.ui.close()`

<hr>

Tested this PR with the following tools:
- Steam
    - GE-Proton
    - SteamTinkerLaunch
    - Luxtorpeda
- Lutris:
    - Lutris-Wine (installed by Lutris itself iirc)
    - Wine-GE
- Heroic:
    - Wine-GE

<hr>

Thanks :-)