### PR TITLE
Use UI file for Install Dialog

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -317,11 +317,7 @@ class MainWindow(QObject):
             dialog = PupguiInstallDialog(install_loc, self.ct_loader, parent=self.ui)
             dialog.compat_tool_selected.connect(self.install_compat_tool)
             dialog.is_fetching_releases.connect(self.set_fetching_releases)
-            dialog.setup_ui()
             dialog.set_selected_compat_tool(compat_tool)
-            dialog.show()
-            dialog.setFixedSize(dialog.size())
-
 
     def btn_remove_selcted_clicked(self):
         ctools_to_remove = []

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -237,7 +237,6 @@ class MainWindow(QObject):
             if ct.no_games == 0:
                 unused_ctools += 1
 
-            
         self.ui.txtActiveDownloads.setText(str(len(self.pending_downloads)))
         if len(self.pending_downloads) == 0:
             self.set_default_statusbar()
@@ -368,14 +367,14 @@ class MainWindow(QObject):
     def show_launcher_specific_information(self):
         install_loc = get_install_location_from_directory_name(install_directory())
         # For Steam Flatpak only: Show that GE-Proton and Boxtron are available directly from Flathub.
-        if 'steam' in install_loc.get('launcher') and 'Flatpak' in install_loc.get('display_name'):
+        if 'steam' in install_loc.get('launcher', '') and 'Flatpak' in install_loc.get('display_name', ''):
             self.ui.statusBar().showMessage(self.tr('Info: You can get GE-Proton / Boxtron directly from Flathub!'))
             self.ui.btnSteamFlatpakCtools.setVisible(True)
         else:
             self.ui.btnSteamFlatpakCtools.setVisible(False)
     
     def list_installed_versions_item_double_clicked(self, item):
-        # Show info about compatibility tool when double clicked in list
+        """ Show info about compatibility tool when double clicked in list """
         ct = self.compat_tool_index_map[self.ui.listInstalledVersions.row(item)]
         install_loc = get_install_location_from_directory_name(install_directory())
         cti_dialog = PupguiCtInfoDialog(self.ui, ctool=ct, install_loc=install_loc)
@@ -547,10 +546,9 @@ def main():
 
     apply_dark_theme(app)
 
-    window = MainWindow()
+    MainWindow()
 
     ret = app.exec()
-
     shutil.rmtree(TEMP_DIR, ignore_errors=True)
 
     # Flatpak workaround: Delete STL dir if it isn't installed (folder is always created for sandbox access)

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -47,35 +47,28 @@ class PupguiInstallDialog(QDialog):
         self.setLayout(vbox)
         self.btnInfo.clicked.connect(self.btn_info_clicked)
         self.btnInstall.clicked.connect(self.btn_install_clicked)
-        self.btnCancel.clicked.connect(self.btn_cancel_clicked)
+        self.btnCancel.clicked.connect(lambda: self.close())
         self.comboCompatTool.currentIndexChanged.connect(self.combo_compat_tool_current_index_changed)
         self.is_fetching_releases.connect(lambda x: self.comboCompatTool.setEnabled(not x))
         self.is_fetching_releases.connect(lambda x: self.btnInfo.setEnabled(not x))
         self.is_fetching_releases.connect(lambda x: self.btnInstall.setEnabled(not x))
 
-        for ctobj in self.ct_objs:
-            self.comboCompatTool.addItem(ctobj['name'])
+        self.comboCompatTool.addItems([ctobj['name'] for ctobj in self.ct_objs])
         self.comboCompatToolVersion.setStyleSheet('QComboBox { combobox-popup: 0; }')
 
     def btn_info_clicked(self):
         for ctobj in self.ct_objs:
             if ctobj['name'] == self.comboCompatTool.currentText():
                 ver = self.comboCompatToolVersion.currentText()
-                if ver == '':
-                    open_webbrowser_thread(ctobj['installer'].get_info_url(ver).replace('tag', ''))
-                else:
-                    open_webbrowser_thread(ctobj['installer'].get_info_url(ver))
+                open_webbrowser_thread(ctobj['installer'].get_info_url(ver) if ver else ctobj['installer'].get_info_url(ver).replace('tag', ''))
+                return
 
     def btn_install_clicked(self):
-        current_version = self.comboCompatTool.currentText()
         self.compat_tool_selected.emit({
             'name': self.comboCompatTool.currentText(),
             'version': self.comboCompatToolVersion.currentText(),
             'install_dir': self.install_location['install_dir']
         })
-        self.close()
-
-    def btn_cancel_clicked(self):
         self.close()
 
     def combo_compat_tool_current_index_changed(self):

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -24,7 +24,7 @@ class PupguiInstallDialog(QDialog):
         self.ui.show()
 
     def load_ui(self):
-        data = pkgutil.get_data(__name__, 'resources/ui/pupgui2_ctinstalldialog.ui')
+        data = pkgutil.get_data(__name__, 'resources/ui/pupgui2_installdialog.ui')
         ui_file = QDataStream(QByteArray(data))
         self.ui = QUiLoader().load(ui_file.device())
 

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -66,7 +66,7 @@ class PupguiInstallDialog(QDialog):
                     vers = ctobj['installer'].fetch_releases()
                     # Stops install dialog UI elements from being enabled when rate-limited to prevent switching/installing tools
                     if len(vers) > 0:
-                        self.ui.comboCompatToolVersion.addItems([ver for ver in vers])
+                        self.ui.comboCompatToolVersion.addItems(vers)
                         self.ui.comboCompatToolVersion.setCurrentIndex(0)
                         self.is_fetching_releases.emit(False)
                 t = threading.Thread(target=update_releases)

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -54,7 +54,7 @@ class PupguiInstallDialog(QDialog):
             'version': self.ui.comboCompatToolVersion.currentText(),
             'install_dir': self.install_location['install_dir']
         })
-        self.close()
+        self.ui.close()
 
     def combo_compat_tool_current_index_changed(self):
         """ fetch and show available releases for selected compatibility tool """

--- a/pupgui2/resources/ui/pupgui2_ctinstalldialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinstalldialog.ui
@@ -6,14 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>314</width>
-    <height>279</height>
+    <width>320</width>
+    <height>280</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>320</width>
+    <height>280</height>
+   </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>314</width>
-    <height>279</height>
+    <width>320</width>
+    <height>280</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -22,62 +28,19 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <widget class="QWidget" name="horizontalLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>240</y>
-     <width>301</width>
-     <height>41</height>
-    </rect>
-   </property>
-   <layout class="QHBoxLayout" name="button_box">
-    <item>
-     <spacer name="horizontalSpacer">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>40</width>
-        <height>20</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
-    <item>
-     <widget class="QPushButton" name="btnInfo">
-      <property name="text">
-       <string>Info</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="btnInstall">
-      <property name="text">
-       <string>Install</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="btnCancel">
-      <property name="text">
-       <string>Cancel</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
   <widget class="QWidget" name="verticalLayoutWidget">
    <property name="geometry">
     <rect>
-     <x>10</x>
+     <x>9</x>
      <y>10</y>
-     <width>291</width>
-     <height>221</height>
+     <width>301</width>
+     <height>301</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="sizeConstraint">
+     <enum>QLayout::SetDefaultConstraint</enum>
+    </property>
     <item>
      <widget class="QLabel" name="lblCompatTool">
       <property name="text">
@@ -105,7 +68,7 @@
     <item>
      <widget class="QLabel" name="lblTxtDescription">
       <property name="text">
-       <string>Description</string>
+       <string>Description:</string>
       </property>
      </widget>
     </item>
@@ -121,6 +84,44 @@
        <bool>true</bool>
       </property>
      </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="button_box">
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnInfo">
+        <property name="text">
+         <string>Info</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnInstall">
+        <property name="text">
+         <string>Install</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnCancel">
+        <property name="text">
+         <string>Cancel</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
     <item>
      <spacer name="verticalSpacer">

--- a/pupgui2/resources/ui/pupgui2_ctinstalldialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinstalldialog.ui
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PuiguiCtInstallerDialog</class>
+ <widget class="QDialog" name="PuiguiCtInstallerDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>314</width>
+    <height>279</height>
+   </rect>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>314</width>
+    <height>279</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Install Compatibility Tool</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <widget class="QWidget" name="horizontalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>240</y>
+     <width>301</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="button_box">
+    <item>
+     <spacer name="horizontalSpacer">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>40</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="QPushButton" name="btnInfo">
+      <property name="text">
+       <string>Info</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="btnInstall">
+      <property name="text">
+       <string>Install</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="btnCancel">
+      <property name="text">
+       <string>Cancel</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>291</width>
+     <height>221</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="lblCompatTool">
+      <property name="text">
+       <string>Compatibility tool:</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QComboBox" name="comboCompatTool">
+      <property name="focusPolicy">
+       <enum>Qt::StrongFocus</enum>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="lblCompatToolVersion">
+      <property name="text">
+       <string>Version:</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QComboBox" name="comboCompatToolVersion"/>
+    </item>
+    <item>
+     <widget class="QLabel" name="lblTxtDescription">
+      <property name="text">
+       <string>Description</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QTextEdit" name="txtDescription">
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>95</height>
+       </size>
+      </property>
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pupgui2/resources/ui/pupgui2_installdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_installdialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>PuiguiCtInstallerDialog</class>
- <widget class="QDialog" name="PuiguiCtInstallerDialog">
+ <class>PupguiInstallDialog</class>
+ <widget class="QDialog" name="PupguiInstallDialog">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
## Overview
This PR converts the install dialog to use a Qt Designer `.ui` file. This is more consistent with the other dialogs that ProtonUp-Qt uses, and allows for some cleanup of the install dialog class.

This also has an indirect benefit: it works around a PySide6 bug with Plasma Wayland, where dialogs on scaled displays don't render correctly until moved to a non-scaled display and back again.

![image](https://user-images.githubusercontent.com/7917345/226701012-1b1a5d08-cf94-4138-9a2e-504fadd375aa.png)

I attempted to keep the UI as close as possible to the existing install dialog but I did have to increase the size of the dialog just a small amount. On main, the dialog and its elements extend it to a size of `314x279`. However in Qt Designer, with the way it aligns elements, this meant that everything was slightly off-center; elements on the right had slightly more spacing than those on the left.

To allow for even spacing, the dialog dimensions were increased to `320x280`, as round figures that would divide evenly. I felt that a width of `310` was a bit too narrow and I felt giving the description box more room rather than less was a better compromise, so I rounded that size upward.

I hope the size change isn't too noticeable. I thought increasing the size was the better tradeoff than having the UI be slightly off-center. I'll provide a screenshot of main to compare with.

<details>
<summary>CtInstall dialog on Main</summary>

![image](https://user-images.githubusercontent.com/7917345/226702288-7330408d-5b52-4869-80f4-26812e238bb8.png)
</details>

<hr>

Another change I made was to disable the install dialog comboboxes and install button if no tags were found for the given tool, i.e. if GitHub is down, or the user is rate-limited.

I tried my best to rate-limit myself to get a screenshot of this, but *of course* I can't do it when I need to showcase something :sweat_smile: So please be sure to test this as well. I implemented this by changing the logic to not emitting `is_fetching_releases(False)` if the tags list is empty. This is a little bit hacky I suppose but I guess it also still follows logically, as if the user is rate limited or if GitHub is down, it never really *fetches* the releases.

<hr>

There were also some minor code cleanups done along the way that I noticed, like removing some unused variables, and replacing for loops to add items with `addItems` and a list comprehension to help streamline the code a little more. The logic for loading, setting up and showing the UI for the installer dialog was also moved into its `__init__` instead of in the `pupgui2` file where its called, which is again more consistent with other parts of the code. 

I felt this would be a good change for consistency. It could be done for other dialogs to but the CtInstaller dialog was the last "major" one as far as I could see that didn't use a UI file.

Thanks :-)