### PR TITLE
Heroic: Type Hint cleanup

### DIFF
--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -29,27 +29,26 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
     for game in games_json:
         hg = HeroicGame()
 
-        hg.runner: str = game.get('runner', '')
-        hg.app_name: str = game.get('app_name', '')
-        hg.title: str = game.get('title', '')
-        hg.developer: str = game.get('developer', '')
-        hg.install: Dict[str, str] = game.get('install', {})
-        hg.heroic_path: str = heroic_path
+        hg.runner = game.get('runner', '')
+        hg.app_name = game.get('app_name', '')
+        hg.title = game.get('title', '')
+        hg.developer = game.get('developer', '')
+        hg.heroic_path = heroic_path
         # Sideloaded games uses folder_name as their full install path, GOG games store a folder_name but this is *just* their install folder name
         # Prioritise getting install_path for GOG games as this is the GOG game equivalent to 'folder_name'
-        hg.install_path: str = get_gog_installed_game_entry(hg).get('install_path', '') if hg.runner.lower() == 'gog' else game.get('folder_name', '')
-        hg.store_url: str = game.get('store_url', '')
-        hg.art_cover: str = game.get('art_cover', '')  # May need to replace path if it has 'file:///app/blah in name - See example in #168
-        hg.art_square: str = game.get('art_square', '')
-        hg.is_installed: bool = game.get('is_installed', False) or is_gog_game_installed(hg)  # Some installed gog games may not be marked properly in library.json, so cross-reference with installed.json
-        hg.wine_info: Dict[str, str] = hg.get_game_config().get('wineVersion', {})
+        hg.install_path = get_gog_installed_game_entry(hg).get('install_path', '') if hg.runner.lower() == 'gog' else game.get('folder_name', '')
+        hg.store_url = game.get('store_url', '')
+        hg.art_cover = game.get('art_cover', '')  # May need to replace path if it has 'file:///app/blah in name - See example in #168
+        hg.art_square = game.get('art_square', '')
+        hg.is_installed = game.get('is_installed', False) or is_gog_game_installed(hg)  # Some installed gog games may not be marked properly in library.json, so cross-reference with installed.json
+        hg.wine_info = hg.get_game_config().get('wineVersion', {})
         # Sideloaded games store platform in its library.json (it has no installed.json) under the 'install' object
         # GOG games store the platform for the version of the installed game in `installed.json` (as GOG games can target multiple platforms, installed will show if the user has the Windows or Linux version)
-        hg.platform: str = get_gog_installed_game_entry(hg).get('platform', '').capitalize() if hg.runner.lower() == 'gog' else game.get('install', {}).get('platform', '').capitalize()  # Capitalize ensures consistency
+        hg.platform = get_gog_installed_game_entry(hg).get('platform', '').capitalize() if hg.runner.lower() == 'gog' else game.get('install', {}).get('platform', '').capitalize()  # Capitalize ensures consistency
         # GOG and Epic store the exe name on its own, but sideloaded stores the full path, so for consistency get the basename for sideloaded apps
         # Native GOG games seem to just store the 'executable' as 'start.sh' script
-        hg.executable: str = get_gog_game_executable(hg) if hg.runner.lower() == 'gog' else os.path.basename(game.get('install', {}).get('executable', ''))
-        hg.is_dlc: bool = game.get('install', {}).get('is_dlc', False)
+        hg.executable = get_gog_game_executable(hg) if hg.runner.lower() == 'gog' else os.path.basename(game.get('install', {}).get('executable', ''))
+        hg.is_dlc = game.get('install', {}).get('is_dlc', False)
 
         hgs.append(hg)
 
@@ -59,21 +58,21 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
         for app_name, game_data in legendary_json.items():
             lg = HeroicGame()
 
-            lg.runner: str = 'legendary'  # Hardcoded 
-            lg.app_name: str = app_name  # installed.json key is always the app_name 
-            lg.title: str = game_data.get('title', '')
-            lg.developer: str = ''  # Not stored or stored elsewhere?
-            lg.heroic_path: str = heroic_path
-            lg.install_path: str = game_data.get('install_path', '') 
-            lg.store_url: str = f'{EPIC_STORE_URL}{re.sub("[^a-zA-Z0-9]", "-", lg.title.lower())}'
-            lg.art_cover: str = ''  # Not stored or stored elsewhere?
-            lg.art_square: str = ''  # Not stored or stored elsewhere?
-            lg.is_installed: str = True  # Games in Legendary `installed.json` should always be installed
-            lg.wine_info: Dict[str, str] = lg.get_game_config().get('wineVersion', {})  # Mirrors above, Legendary games should use the same GameConfig json structure
-            lg.platform: str = game_data.get('platform', '').capitalize()  # Legendary stores this in `installed.json` and like GOG this stores the platform for the version the user downloaded
-            lg.executable: str = game_data.get('executable', '')
+            lg.runner = 'legendary'  # Hardcoded 
+            lg.app_name = app_name  # installed.json key is always the app_name 
+            lg.title = game_data.get('title', '')
+            lg.developer = ''  # Not stored or stored elsewhere?
+            lg.heroic_path = heroic_path
+            lg.install_path = game_data.get('install_path', '')
+            lg.store_url = f'{EPIC_STORE_URL}{re.sub("[^a-zA-Z0-9]", "-", lg.title.lower())}'
+            lg.art_cover = ''  # Not stored or stored elsewhere?
+            lg.art_square = ''  # Not stored or stored elsewhere?
+            lg.is_installed = True  # Games in Legendary `installed.json` should always be installed
+            lg.wine_info = lg.get_game_config().get('wineVersion', {})  # Mirrors above, Legendary games should use the same GameConfig json structure
+            lg.platform = game_data.get('platform', '').capitalize()  # Legendary stores this in `installed.json` and like GOG this stores the platform for the version the user downloaded
+            lg.executable = game_data.get('executable', '')
             lg.store_url = ''  # TODO do legendary games have a store URL?
-            lg.is_dlc: bool = game_data.get('is_dlc', False)  # If not set for some reason, assume its not DLC
+            lg.is_dlc = game_data.get('is_dlc', False)  # If not set for some reason, assume its not DLC
 
             hgs.append(lg)
 


### PR DESCRIPTION
I made a pretty bad mistake when implementing the Heroic util stuff. For some reason I tried to type hint assigning the values to the HeroicGame object. I recently re-configured my vscodium install to get my development environment in order and this was something it yelled at me about this :sweat_smile: 

This also removes what appears to be an unused element, `hg.install`, which was not part of the HeroicGame data structure - I think this was discussed and removed from the data structure, but it seems I missed heroicutil.

As far as I know this shouldn't have caused any problems, but it's invalid usage of type hints, so my bad there.