### PR TITLE
Add a Refresh Button to the Game List and Compat Tool Info dialog

### DIFF
--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -65,6 +65,7 @@ class PupguiGameListDialog(QObject):
         self.ui.tableGames.itemDoubleClicked.connect(self.item_doubleclick_action)
         self.ui.btnApply.clicked.connect(self.btn_apply_clicked)
         self.ui.btnSearch.clicked.connect(self.btn_search_clicked)
+        self.ui.btnRefreshGames.clicked.connect(self.btn_refresh_games_clicked)
         self.ui.searchBox.textChanged.connect(self.search_gamelist_games)
 
         # Hide Search button and disable shortcut if no games
@@ -104,9 +105,9 @@ class PupguiGameListDialog(QObject):
         self.ui.tableGames.setColumnWidth(3, 40)
         self.ui.tableGames.setColumnHidden(4, True)
 
-    def update_game_list_steam(self):
+    def update_game_list_steam(self, cached=True):
         """ update the game list for the Steam launcher """
-        self.games = get_steam_game_list(steam_config_folder=self.install_loc.get('vdf_dir'), cached=True)
+        self.games = get_steam_game_list(steam_config_folder=self.install_loc.get('vdf_dir'), cached=cached)
         ctools = [c if c != 'SteamTinkerLaunch' else 'Proton-stl' for c in sort_compatibility_tool_names(list_installed_ctools(self.install_dir, without_version=True), reverse=True)]
         ctools.extend(t.ctool_name for t in get_steam_ctool_list(steam_config_folder=self.install_loc.get('vdf_dir'), cached=True))
 
@@ -275,6 +276,15 @@ class PupguiGameListDialog(QObject):
     def btn_apply_clicked(self):
         self.update_queued_ctools_steam()
         self.ui.close()
+
+    def btn_refresh_games_clicked(self):
+        self.queued_changes = {}
+        if self.launcher == 'steam':
+            self.update_game_list_steam(cached=False)
+        elif self.launcher == 'lutris':
+            self.update_game_list_lutris()
+        elif is_heroic_launcher(self.launcher):
+            self.update_game_list_heroic()
 
     def btn_search_clicked(self):
         self.ui.searchBox.setVisible(not self.ui.searchBox.isVisible())

--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -101,6 +101,19 @@
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="btnRefreshGames">
+       <property name="toolTip">
+        <string>Refresh Games</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset theme="view-refresh"/>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="btnSearch">
        <property name="focusPolicy">
         <enum>Qt::NoFocus</enum>

--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -112,7 +112,8 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset theme="view-refresh"/>
+        <iconset theme="view-refresh">
+         <normaloff>.</normaloff>.</iconset>
        </property>
       </widget>
      </item>

--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -102,6 +102,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="btnRefreshGames">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Refresh Games</string>
        </property>

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -86,7 +86,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QToolButton" name="btnRefreshGames">
+      <widget class="QPushButton" name="btnRefreshGames">
        <property name="toolTip">
         <string>Refresh Games</string>
        </property>
@@ -94,8 +94,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset theme="view-refresh">
-         <normaloff>.</normaloff>.</iconset>
+        <iconset theme="view-refresh"/>
        </property>
       </widget>
      </item>

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -94,7 +94,8 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset theme="view-refresh"/>
+        <iconset theme="view-refresh">
+         <normaloff>.</normaloff>.</iconset>
        </property>
       </widget>
      </item>

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -86,6 +86,20 @@
       </spacer>
      </item>
      <item>
+      <widget class="QToolButton" name="btnRefreshGames">
+       <property name="toolTip">
+        <string>Refresh Games</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset theme="view-refresh">
+         <normaloff>.</normaloff>.</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="btnSearch">
        <property name="text">
         <string>Search</string>


### PR DESCRIPTION
With https://github.com/DavidoTek/ProtonUp-Qt/pull/211 and https://github.com/DavidoTek/ProtonUp-Qt/pull/214, caching of games has been enabled to increase the load times of the dialogs. This comes with the limitation that external changes are not registered, even when re-opening the game list or ctinfo dialogs.

This PR adds a refresh button to both the game list and the ctinfo dialog that updates the cached games and rebuilds the list of displayed games.
