### PR TITLE
Fix regression: Only show batch update button if search bar invisible

### DIFF
--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -66,7 +66,7 @@ class PupguiCtInfoDialog(QObject):
                 self.update_game_list_steam(cached=cached)
                 if 'Proton' in self.ctool.displayname and self.ctool.ct_type == CTType.CUSTOM:  # 'batch update' option for Proton-GE
                     self.is_batch_update_available = True
-                    self.ui.btnBatchUpdate.setVisible(True)
+                    self.ui.btnBatchUpdate.setVisible(not self.ui.searchBox.isVisible())
                     self.ui.btnBatchUpdate.clicked.connect(self.btn_batch_update_clicked)
         elif self.install_loc.get('launcher') == 'lutris':
             self.update_game_list_lutris()


### PR DESCRIPTION
https://github.com/DavidoTek/ProtonUp-Qt/pull/215 added a refresh button to the ctinfo dialog.

This PR fixes that both the `Batch update` button and the Search bar should not be visible at the same time when clicking the refresh button.