### PR TITLE
Games List: Unfocus ProtonDB Rating after Click

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -60,7 +60,7 @@ def PALETTE_DARK():
     palette_dark.setColor(QPalette.HighlightedText, Qt.black)
     return palette_dark
 
-PROTONDB_COLORS = {'platinum': '#b4c7dc', 'gold': '#4f492c', 'silver': '#a6a6a6', 'bronze': '#cd7f32', 'borked': '#ff0000'}
+PROTONDB_COLORS = {'platinum': '#b4c7dc', 'gold': '#cfb53b', 'silver': '#a6a6a6', 'bronze': '#cd7f32', 'borked': '#ff0000', 'pending': '#748472' }
 
 STEAM_API_GETAPPLIST_URL = 'https://api.steampowered.com/ISteamApps/GetAppList/v2/'
 STEAM_APP_PAGE_URL = 'https://store.steampowered.com/app/'

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -319,6 +319,7 @@ class PupguiGameListDialog(QObject):
                         trending=game.protondb_summary.get('trendingTier', '?')))
 
             self.ui.tableGames.removeCellWidget(self.ui.tableGames.currentRow(), 4)
+            pdb_item.setSelected(False)
 
     def queue_ctool_change_steam(self, ctool_name: str, game: SteamApp):
         """ add compatibility tool changes to queue (Steam) """


### PR DESCRIPTION
When clicking the button to fetch the ProtonDB rating, it focused the cell with the rating. This made the color less obvious as it would use the focus color which drowned out the rating color. This PR defocuses that cell after revealing the rating.

There is also a minor change to the color used for the gold rating to match the one used on ProtonDB (the other colors already matched), and to add a color for "pending" as on the system theme it was just black and not very visible. Though to be honest I am not totally happy with the color - I tried to go for something distinct enough to stand out (though not obnoxiously so) and different enough to distinguish it from the other ratings. If there is a better color in mind please suggest/change it directly :-)

![image](https://user-images.githubusercontent.com/7917345/228004555-ef76722d-dddf-4045-a0ac-7a7c9a872c53.png)

Thanks!