### PR TITLE
Custom Install Directory Dialog Overhaul

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -204,9 +204,8 @@ class MainWindow(QObject):
                 self.ui.comboInstallLocation.setCurrentIndex(i)
 
         self.updating_combo_install_location = False
-        # Update compat list when custom install directoy is removed
+        # Update compat list when custom install directoy is removed -- Not called because of `self.updating_combo_install_location = False` -- Could be improved?
         if custom_install_dir is not None and len(custom_install_dir) <= 0:
-            # currentIndexChanged is not emitted automatically?
             self.ui.comboInstallLocation.currentIndexChanged.emit(self.ui.comboInstallLocation.currentIndex())
 
     def update_ui(self):

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -183,13 +183,13 @@ class MainWindow(QObject):
         t = threading.Thread(target=_set_default_statusbar_thread, args=[self.update_statusbar_message])
         t.start()
 
-    def update_combo_install_location(self):
+    def update_combo_install_location(self, custom_install_dir = None):
         self.updating_combo_install_location = True
 
         self.ui.comboInstallLocation.clear()
         self.combo_install_location_index_map = []
 
-        current_install_dir = install_directory()
+        current_install_dir = custom_install_dir or install_directory()
         for i, install_dir in enumerate(available_install_directories()):
             icon_name = get_install_location_from_directory_name(install_dir).get('icon')
             display_name = get_install_location_from_directory_name(install_dir).get('display_name')
@@ -199,6 +199,8 @@ class MainWindow(QObject):
                 self.ui.comboInstallLocation.addItem(install_dir)
             self.combo_install_location_index_map.append(install_dir)
             if current_install_dir == install_dir:
+                if custom_install_dir is not None:
+                    self.updating_combo_install_location = False
                 self.ui.comboInstallLocation.setCurrentIndex(i)
 
         self.updating_combo_install_location = False

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -204,6 +204,10 @@ class MainWindow(QObject):
                 self.ui.comboInstallLocation.setCurrentIndex(i)
 
         self.updating_combo_install_location = False
+        # Update compat list when custom install directoy is removed
+        if custom_install_dir is not None and len(custom_install_dir) <= 0:
+            # currentIndexChanged is not emitted automatically?
+            self.ui.comboInstallLocation.currentIndexChanged.emit(self.ui.comboInstallLocation.currentIndex())
 
     def update_ui(self):
         """ update ui contents """

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -361,7 +361,7 @@ class MainWindow(QObject):
             self.update_ui()
 
     def btn_manage_install_locations_clicked(self):
-        customid_dialog = PupguiCustomInstallDirectoryDialog(parent=self.ui)
+        customid_dialog = PupguiCustomInstallDirectoryDialog(install_directory(), parent=self.ui)
         customid_dialog.custom_id_set.connect(self.update_combo_install_location)
 
     def show_launcher_specific_information(self):

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -55,7 +55,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
 
         self.ui.btnSave.clicked.connect(self.btn_save_clicked)
         self.ui.btnDefault.clicked.connect(self.btn_default_clicked)
-        self.ui.btnCancel.clicked.connect(self.ui.close)
+        self.ui.btnClose.clicked.connect(self.ui.close)
 
         self.is_valid_custom_install_path = lambda path: len(path.strip()) > 0 and os.path.isdir(path) and os.access(path, os.W_OK)  # Maybe too expensive?
         self.ui.txtInstallDirectory.textChanged.connect(lambda text: self.ui.btnSave.setEnabled(self.is_valid_custom_install_path(text)))

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -47,13 +47,13 @@ class PupguiCustomInstallDirectoryDialog(QObject):
             display_name for display_name in self.install_locations_dict.values()
         ])
 
-        self.set_selected_launcher(get_dict_key_from_value(self.install_locations_dict, self.launcher) or '')
+        self.set_selected_launcher(self.install_locations_dict[self.launcher] or 'steam')  # Default combobox selection to "Steam" if unknown launcher for some reason
 
         self.ui.btnSave.clicked.connect(self.btn_save_clicked)
         self.ui.btnDefault.clicked.connect(self.btn_default_clicked)
         self.ui.btnClose.clicked.connect(self.ui.close)
 
-        self.is_valid_custom_install_path = lambda path: len(path.strip()) > 0 and os.path.isdir(os.path.expanduser(path)) and os.access(os.path.expanduser(path), os.W_OK)  # Maybe too expensive?
+        self.is_valid_custom_install_path = lambda path: len(path.strip()) > 0 and os.path.isdir(os.path.expanduser(path)) and os.access(os.path.expanduser(path), os.W_OK)
         self.ui.txtInstallDirectory.textChanged.connect(lambda text: self.ui.btnSave.setEnabled(self.is_valid_custom_install_path(text)))
 
     def btn_save_clicked(self):

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -34,38 +34,35 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.txtIdBrowseAction = self.ui.txtInstallDirectory.addAction(QIcon.fromTheme('document-open'), QLineEdit.TrailingPosition)
         self.txtIdBrowseAction.triggered.connect(self.txt_id_browse_action_triggered)
 
-        self.ui.txtInstallDirectory.textChanged.connect(self.txt_install_directory_text_changed)
         self.ui.comboLauncher.addItems([
             'steam',
             'lutris',
             'heroicwine',
             'heroicproton',
             'bottles'
-            ])
+        ])
 
         self.ui.btnSave.clicked.connect(self.btn_save_clicked)
+        self.ui.btnDefault.clicked.connect(self.btn_default_clicked)
         self.ui.btnCancel.clicked.connect(self.ui.close)
 
-    def txt_install_directory_text_changed(self, text):
-        if text.strip() == '':
-            self.ui.btnSave.setText(self.tr('Reset'))
-        else:
-            self.ui.btnSave.setText(self.tr('Save'))
+        self.is_valid_custom_install_path = lambda path: len(path.strip()) > 0 and os.path.isdir(path) and os.access(path, os.W_OK)  # Maybe too expensive?
+        self.ui.txtInstallDirectory.textChanged.connect(lambda text: self.ui.btnSave.setEnabled(self.is_valid_custom_install_path(text)))
 
     def btn_save_clicked(self):
         install_dir = self.ui.txtInstallDirectory.text().strip()
         launcher = self.ui.comboLauncher.currentText()
 
-        if install_dir == '':
-            config_custom_install_location(install_dir='remove')
-            print('custom install directory: removed')
-
-        if os.path.exists(install_dir):
+        if self.is_valid_custom_install_path(install_dir):
             config_custom_install_location(install_dir, launcher)
-            print('custom install directory: set to', install_dir)
+            print(f'New Custom Install Directory set to: {install_dir}')
 
         self.custom_id_set.emit()
         self.ui.close()
+
+    def btn_default_clicked(self):
+        config_custom_install_location(install_dir='remove')
+        print('custom install directory: removed')
 
     def txt_id_browse_action_triggered(self):
         dialog = QFileDialog(self.ui)

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -6,7 +6,7 @@ from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QFileDialog, QLineEdit
 from PySide6.QtUiTools import QUiLoader
 
-from pupgui2.util import config_custom_install_location, get_install_location_from_directory_name, get_dict_key_from_value
+from pupgui2.util import config_custom_install_location, get_install_location_from_directory_name, get_dict_key_from_value, get_combobox_index_by_value
 
 
 class PupguiCustomInstallDirectoryDialog(QObject):
@@ -45,7 +45,6 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.txtIdBrowseAction = self.ui.txtInstallDirectory.addAction(QIcon.fromTheme('document-open'), QLineEdit.TrailingPosition)
         self.txtIdBrowseAction.triggered.connect(self.txt_id_browse_action_triggered)
 
-        # TODO refresh to default directory when removing custom directory
         self.ui.comboLauncher.addItems([
             display_name for display_name in self.install_locations_dict.values()
         ])
@@ -86,10 +85,8 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         dialog.fileSelected.connect(self.ui.txtInstallDirectory.setText)
         dialog.open()
 
-    # TODO break this out into a separate util function for use here and in install dialog?
     def set_selected_launcher(self, ctool_name: str):
         if ctool_name:
-            for i in range(self.ui.comboLauncher.count()):
-                if ctool_name == self.ui.comboLauncher.itemText(i):
-                    self.ui.comboLauncher.setCurrentIndex(i)
-                    return
+            index = get_combobox_index_by_value(self.ui.comboLauncher, ctool_name)
+            if index >= 0:
+                self.ui.comboLauncher.setCurrentIndex(index)

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -75,6 +75,8 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         config_custom_install_location(install_dir='remove')
         print('custom install directory: removed')
 
+        self.custom_id_set.emit()
+
     def txt_id_browse_action_triggered(self):
         dialog = QFileDialog(self.ui)
         dialog.setFileMode(QFileDialog.Directory)

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -1,58 +1,60 @@
 import os
+import pkgutil
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Signal, QDataStream, QByteArray, QObject
 from PySide6.QtGui import QIcon
-from PySide6.QtWidgets import QDialog, QFileDialog, QLabel, QPushButton, QLineEdit, QComboBox, QFormLayout
+from PySide6.QtWidgets import QFileDialog, QLabel, QPushButton, QLineEdit, QComboBox, QFormLayout
+from PySide6.QtUiTools import QUiLoader
 
 from pupgui2.util import config_custom_install_location
 
 
-class PupguiCustomInstallDirectoryDialog(QDialog):
+class PupguiCustomInstallDirectoryDialog(QObject):
 
     custom_id_set = Signal()
 
     def __init__(self, parent=None):
         super(PupguiCustomInstallDirectoryDialog, self).__init__(parent)
 
+        self.load_ui()
         self.setup_ui()
+        self.ui.show()
+
+        self.ui.setFixedSize(self.ui.size())
+
+    def load_ui(self):
+        data = pkgutil.get_data(__name__, 'resources/ui/pupgui2_custominstalldirectorydialog.ui')
+        ui_file = QDataStream(QByteArray(data))
+        loader = QUiLoader()
+        self.ui = loader.load(ui_file.device())
 
     def setup_ui(self):
-        self.setWindowTitle(self.tr('Custom Install Directory'))
-        self.setModal(True)
-        self.setMinimumSize(320, 120)
+        self.ui.setWindowTitle(self.tr('Custom Install Directory'))
 
-        formLayout = QFormLayout()
-        self.txtInstallDirectory = QLineEdit()
-        self.txtIdBrowseAction = self.txtInstallDirectory.addAction(QIcon.fromTheme('document-open'), QLineEdit.TrailingPosition)
+        self.txtIdBrowseAction = self.ui.txtInstallDirectory.addAction(QIcon.fromTheme('document-open'), QLineEdit.TrailingPosition)
         self.txtIdBrowseAction.triggered.connect(self.txt_id_browse_action_triggered)
-        self.comboLauncher = QComboBox()
-        self.btnSave = QPushButton(self.tr('Save'))
-        formLayout.addRow(QLabel(self.tr('Directory:')), self.txtInstallDirectory)
-        formLayout.addRow(QLabel(self.tr('Launcher:')), self.comboLauncher)
-        formLayout.addWidget(self.btnSave)
-        self.setLayout(formLayout)
 
-        self.txtInstallDirectory.textChanged.connect(self.txt_install_directory_text_changed)
-        self.comboLauncher.addItems([
+        self.ui.txtInstallDirectory.textChanged.connect(self.txt_install_directory_text_changed)
+        self.ui.comboLauncher.addItems([
             'steam',
             'lutris',
             'heroicwine',
             'heroicproton',
             'bottles'
             ])
-        self.btnSave.clicked.connect(self.btn_save_clicked)
 
-        self.show()
+        self.ui.btnSave.clicked.connect(self.btn_save_clicked)
+        self.ui.btnCancel.clicked.connect(self.ui.close)
 
     def txt_install_directory_text_changed(self, text):
         if text.strip() == '':
-            self.btnSave.setText(self.tr('Reset'))
+            self.ui.btnSave.setText(self.tr('Reset'))
         else:
-            self.btnSave.setText(self.tr('Save'))
+            self.ui.btnSave.setText(self.tr('Save'))
 
     def btn_save_clicked(self):
-        install_dir = self.txtInstallDirectory.text().strip()
-        launcher = self.comboLauncher.currentText()
+        install_dir = self.ui.txtInstallDirectory.text().strip()
+        launcher = self.ui.comboLauncher.currentText()
 
         if install_dir == '':
             config_custom_install_location(install_dir='remove')
@@ -63,12 +65,12 @@ class PupguiCustomInstallDirectoryDialog(QDialog):
             print('custom install directory: set to', install_dir)
 
         self.custom_id_set.emit()
-        self.close()
+        self.ui.close()
 
     def txt_id_browse_action_triggered(self):
-        dialog = QFileDialog(self)
+        dialog = QFileDialog(self.ui)
         dialog.setFileMode(QFileDialog.Directory)
         dialog.setOption(QFileDialog.ShowDirsOnly)
         dialog.setDirectory(os.path.expanduser('~'))
-        dialog.fileSelected.connect(self.txtInstallDirectory.setText)
+        dialog.fileSelected.connect(self.ui.txtInstallDirectory.setText)
         dialog.open()

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -43,6 +43,8 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.txtIdBrowseAction = self.ui.txtInstallDirectory.addAction(QIcon.fromTheme('document-open'), QLineEdit.TrailingPosition)
         self.txtIdBrowseAction.triggered.connect(self.txt_id_browse_action_triggered)
 
+        self.ui.txtInstallDirectory.setText(config_custom_install_location().get('install_dir', ''))
+
         self.ui.comboLauncher.addItems([
             display_name for display_name in self.install_locations_dict.values()
         ])
@@ -70,6 +72,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.ui.close()
 
     def btn_default_clicked(self):
+        self.ui.txtInstallDirectory.setText('')
         config_custom_install_location(install_dir='remove')
         print(f'Removed custom install directory')
 

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -3,7 +3,7 @@ import pkgutil
 
 from PySide6.QtCore import Signal, QDataStream, QByteArray, QObject
 from PySide6.QtGui import QIcon
-from PySide6.QtWidgets import QFileDialog, QLabel, QPushButton, QLineEdit, QComboBox, QFormLayout
+from PySide6.QtWidgets import QFileDialog, QLineEdit
 from PySide6.QtUiTools import QUiLoader
 
 from pupgui2.util import config_custom_install_location, get_install_location_from_directory_name, get_dict_key_from_value

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -73,7 +73,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
 
     def btn_default_clicked(self):
         self.ui.txtInstallDirectory.setText('')
-        config_custom_install_location(install_dir='remove')
+        config_custom_install_location(remove=True)
         print(f'Removed custom install directory')
 
         self.custom_id_set.emit('')

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -11,7 +11,7 @@ from pupgui2.util import config_custom_install_location, get_install_location_fr
 
 class PupguiCustomInstallDirectoryDialog(QObject):
 
-    custom_id_set = Signal()
+    custom_id_set = Signal(str)
 
     def __init__(self, install_dir, parent=None):
         super(PupguiCustomInstallDirectoryDialog, self).__init__(parent)
@@ -45,7 +45,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.txtIdBrowseAction = self.ui.txtInstallDirectory.addAction(QIcon.fromTheme('document-open'), QLineEdit.TrailingPosition)
         self.txtIdBrowseAction.triggered.connect(self.txt_id_browse_action_triggered)
 
-        # TODO select new install directory by default on save? (e.g. if we're on Lutris and set a custom directory for Steam, switch to Steam?)
+        # TODO refresh to default directory when removing custom directory
         self.ui.comboLauncher.addItems([
             display_name for display_name in self.install_locations_dict.values()
         ])
@@ -61,20 +61,22 @@ class PupguiCustomInstallDirectoryDialog(QObject):
 
     def btn_save_clicked(self):
         install_dir = os.path.expanduser(self.ui.txtInstallDirectory.text().strip())
+        if not install_dir.endswith(os.sep):
+            install_dir += '/'
         launcher = get_dict_key_from_value(self.install_locations_dict, self.ui.comboLauncher.currentText()) or ''
 
         if self.is_valid_custom_install_path(install_dir):
             config_custom_install_location(install_dir, launcher)
             print(f'New Custom Install Directory set to: {install_dir}')
 
-        self.custom_id_set.emit()
+        self.custom_id_set.emit(install_dir)
         self.ui.close()
 
     def btn_default_clicked(self):
         config_custom_install_location(install_dir='remove')
         print(f'Removed custom install directory')
 
-        self.custom_id_set.emit()
+        self.custom_id_set.emit('')
 
     def txt_id_browse_action_triggered(self):
         dialog = QFileDialog(self.ui)

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -46,7 +46,6 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.txtIdBrowseAction.triggered.connect(self.txt_id_browse_action_triggered)
 
         # TODO select new install directory by default on save? (e.g. if we're on Lutris and set a custom directory for Steam, switch to Steam?)
-
         self.ui.comboLauncher.addItems([
             display_name for display_name in self.install_locations_dict.values()
         ])
@@ -57,11 +56,11 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.ui.btnDefault.clicked.connect(self.btn_default_clicked)
         self.ui.btnClose.clicked.connect(self.ui.close)
 
-        self.is_valid_custom_install_path = lambda path: len(path.strip()) > 0 and os.path.isdir(path) and os.access(path, os.W_OK)  # Maybe too expensive?
+        self.is_valid_custom_install_path = lambda path: len(path.strip()) > 0 and os.path.isdir(os.path.expanduser(path)) and os.access(os.path.expanduser(path), os.W_OK)  # Maybe too expensive?
         self.ui.txtInstallDirectory.textChanged.connect(lambda text: self.ui.btnSave.setEnabled(self.is_valid_custom_install_path(text)))
 
     def btn_save_clicked(self):
-        install_dir = self.ui.txtInstallDirectory.text().strip()
+        install_dir = os.path.expanduser(self.ui.txtInstallDirectory.text().strip())
         launcher = get_dict_key_from_value(self.install_locations_dict, self.ui.comboLauncher.currentText()) or ''
 
         if self.is_valid_custom_install_path(install_dir):
@@ -73,7 +72,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
 
     def btn_default_clicked(self):
         config_custom_install_location(install_dir='remove')
-        print('custom install directory: removed')
+        print(f'Removed custom install directory')
 
         self.custom_id_set.emit()
 

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -31,8 +31,6 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.setup_ui()
         self.ui.show()
 
-        self.ui.setFixedSize(self.ui.size())
-
     def load_ui(self):
         data = pkgutil.get_data(__name__, 'resources/ui/pupgui2_custominstalldirectorydialog.ui')
         ui_file = QDataStream(QByteArray(data))

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -5,7 +5,7 @@ from PySide6.QtCore import Signal, QLocale, QDataStream, QByteArray
 from PySide6.QtWidgets import QDialog
 from PySide6.QtUiTools import QUiLoader
 
-from pupgui2.util import open_webbrowser_thread, config_advanced_mode
+from pupgui2.util import open_webbrowser_thread, config_advanced_mode, get_combobox_index_by_value
 
 
 class PupguiInstallDialog(QDialog):
@@ -91,7 +91,6 @@ class PupguiInstallDialog(QDialog):
     def set_selected_compat_tool(self, ctool_name: str):
         """ Set compat tool dropdown selected index to the index of the compat tool name passed """
         if ctool_name:
-            for i in range(self.ui.comboCompatTool.count()):
-                if ctool_name == self.ui.comboCompatTool.itemText(i):
-                    self.ui.comboCompatTool.setCurrentIndex(i)
-                    return
+            index = get_combobox_index_by_value(self.ui.comboCompatTool, ctool_name)
+            if index >= 1:
+                self.ui.comboCompatTool.setCurrentIndex(index)

--- a/pupgui2/resources/ui/pupgui2_custominstalldirectorydialog.ui
+++ b/pupgui2/resources/ui/pupgui2_custominstalldirectorydialog.ui
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PuiguiCustomInstallDirectoryDialog</class>
+ <widget class="QDialog" name="PuiguiCustomInstallDirectoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>350</width>
+    <height>150</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>350</width>
+    <height>150</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>350</width>
+    <height>150</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>331</width>
+     <height>182</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="txtDescription">
+      <property name="text">
+       <string>Specify a custom location for downloading and displaying a launcher's compatibility tools.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="1" column="0">
+       <widget class="QLabel" name="lblInstallDirectory">
+        <property name="text">
+         <string>Directory:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="txtInstallDirectory"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="lblLauncher">
+        <property name="text">
+         <string>Launcher:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="comboLauncher">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnSave">
+        <property name="text">
+         <string>Save</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnCancel">
+        <property name="text">
+         <string>Cancel</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pupgui2/resources/ui/pupgui2_custominstalldirectorydialog.ui
+++ b/pupgui2/resources/ui/pupgui2_custominstalldirectorydialog.ui
@@ -19,7 +19,7 @@
   <property name="maximumSize">
    <size>
     <width>350</width>
-    <height>250</height>
+    <height>150</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/pupgui2/resources/ui/pupgui2_custominstalldirectorydialog.ui
+++ b/pupgui2/resources/ui/pupgui2_custominstalldirectorydialog.ui
@@ -115,9 +115,9 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="btnCancel">
+       <widget class="QPushButton" name="btnClose">
         <property name="text">
-         <string>Cancel</string>
+         <string>Close</string>
         </property>
        </widget>
       </item>

--- a/pupgui2/resources/ui/pupgui2_custominstalldirectorydialog.ui
+++ b/pupgui2/resources/ui/pupgui2_custominstalldirectorydialog.ui
@@ -19,7 +19,7 @@
   <property name="maximumSize">
    <size>
     <width>350</width>
-    <height>150</height>
+    <height>250</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -82,6 +82,16 @@
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
+       <widget class="QPushButton" name="btnDefault">
+        <property name="toolTip">
+         <string>Reset the custom install directory back to default for this launcher</string>
+        </property>
+        <property name="text">
+         <string>Default</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -96,6 +106,9 @@
       </item>
       <item>
        <widget class="QPushButton" name="btnSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Save</string>
         </property>

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -474,3 +474,14 @@ def compat_tool_available(compat_tool: str, ctobjs: List[dict]) -> bool:
     """ Return whether a compat tool is available for a given launcher """
 
     return compat_tool in [ctobj['name'] for ctobj in ctobjs]
+
+def get_dict_key_from_value(d, searchval):
+    """
+    Fetch a given dictionary key from a given value.
+    Returns the given value if found, otherwise None.
+    """
+    for _, value in d.items():
+        if value == searchval:
+            return searchval
+    else:
+        return None

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -234,7 +234,7 @@ def install_directory(target=None) -> str:
     return ''
 
 
-def config_custom_install_location(install_dir=None, launcher='') -> Dict[str, str]:
+def config_custom_install_location(install_dir=None, launcher='', remove=False) -> Dict[str, str]:
     """
     Read/update config for the custom install location
     Write install_dir, launcher to config or read if install_dir=None or launcher=None
@@ -243,7 +243,7 @@ def config_custom_install_location(install_dir=None, launcher='') -> Dict[str, s
     """
     config = ConfigParser()
 
-    if install_dir and launcher:
+    if install_dir and launcher and not remove:
         config.read(CONFIG_FILE)
         if not config.has_section('pupgui2'):
             config.add_section('pupgui2')
@@ -252,7 +252,7 @@ def config_custom_install_location(install_dir=None, launcher='') -> Dict[str, s
         os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
         with open(CONFIG_FILE, 'w') as file:
             config.write(file)
-    elif install_dir == 'remove' and os.path.exists(CONFIG_FILE):
+    elif remove and os.path.exists(CONFIG_FILE):
         config.read(CONFIG_FILE)
         if config.has_option('pupgui2', 'custom_install_dir'):
             config.remove_option('pupgui2', 'custom_install_dir')

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -480,8 +480,23 @@ def get_dict_key_from_value(d, searchval):
     Fetch a given dictionary key from a given value.
     Returns the given value if found, otherwise None.
     """
-    for _, value in d.items():
+    for key, value in d.items():
         if value == searchval:
-            return searchval
+            return key
     else:
         return None
+
+def get_combobox_index_by_value(combobox, value: str) -> int:
+    """
+    Get the index in a combobox where a text value is located.
+    Returns an integer >= 0 if found, otherwise -1.
+
+    Return Type: int
+    """
+
+    if value:
+        for i in range(combobox.count()):
+            if value == combobox.itemText(i):
+                return i
+
+    return -1


### PR DESCRIPTION
I had some time so I decided to take a look at overhauling the custom install directory dialog, making several small tweaks that turned out to be quite an overhaul. This is not yet complete but I made enough progress that I'm ready to open it and get some feedback :-)

![image](https://user-images.githubusercontent.com/7917345/230695292-6554e715-6613-49a8-8652-331fab7be2bc.png)

## Overview
This PR overhauls the Custom Install Directory dialog in a number of ways:
- Convert the dialog to use a `.ui` file - This doesn't reduce the size of the file in the end but allows for consistency with the other dialogs.
- Add a short description on the purpose of this dialog - Phrasing improvements welcome! 
- Add a "Close" button, which allows for the dialog to be closed when running in GameScope (i.e. on Steam Deck).
- Add a "Default" button, which takes the place of the "Reset" functionality previously coupled to the "Save" button.
    - This emits `custom_id_set` when clicked, so the launcher dropdown on the main menu will update.
- Add some logic to the "Save" button which only enables it if a valid directory path is selected *and* if we can write to this directory.
    - This is only checked when the path is being entered, unless there is an existing check for custom install directories, there is no logic added in this PR (currently anyway) which validates that a given custom install directory still exists on boot of ProtonUp-Qt. So if a path disappeared I am not sure what would happen.
- Rework the launcher names in the dropdown, so instead of using something like `heroicwine`, it now says `Heroic (Wine)` - Very minor change I wanted to make :sweat_smile: 
- Select the current launcher in the combobox - So if the dialog is opened when we're on Lutris, it will select "Lutris".

## Implementation
I have a couple of reservations about the way I went about some things in this PR specifically that I wanted to comment on.
- `set_selected_launcher` is identical to the logic in the install dialog for checking the exact same thing -- Finding the index of a dropdown element based on the text and selecting that item. Maybe this could be broken out into a utility function?
- I created a method `get_dict_key_from_value`, which is used to get the "internal" name key (i.e. `heroicwine`) from the display text (i.e. `Heroic (Wine)`). This feels... not-pythonic at best. If there is a better way to go about this please do correct me :-) 
- There's an explicit call to emit the index changed signal when removing the selected custom install directory. This is because when the custom dir is selected in the main menu and then defaulted in the dialog, the launcher combobox value on the main menu updates (defaults to the first element) but it doesn't emit the signal. So when we send an empty string to the custom install directory signal (i.e. when the default button is pressed) we check for that and manually emit the index changed signal. I'd be happy to take any feedback to improve this! 

And of course feedback is welcome on the rest of the code, those are just items I specifically wanted to call out.

## Considerations
I don't have Bottles installed so I haven't tested any of these changes against it. However, for Steam (`steam` package from Arch repos), Lutris (`lutris-git` from AUR), and Heroic (Flatpak), things seem to work as expected.

When selecting "Bottles" and adding a custom install directory through, I noticed it just adds the path and does not set a display name. This happens in main as well. For example adding `/home/gaben/PressurizedBottles/`, the dropdown in the main menu only displays the path and not the launcher display name, nor any icon. This isn't something that broke in this PR but it is something that could be fixed here or in future.

<hr>

I'm not sure how often this feature is used (to be honest I haven't actually used it...), but I wanted to try my hand at improving it, so all feedback to better reach that end goal is welcome :-)

Thanks!

P.S. - Looks like the combined downloads and Flathub installs has surpassed 1 million, congrats! :-)

<hr>

## TODO
- [ ] Potentially improve how the custom install directory is written out (icon, display name)
- [x] Select the new directory in the main menu on "Save" 
- [x] Refresh compat tool list when removing currently selected custom dialog (dropdown value updates but compat tool list does not) 