### PR TITLE
steamutil: Move shortcuts check inside try block, add logging for VDF file loading

### DIFF
--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -40,8 +40,10 @@ def get_steam_app_list(steam_config_folder: str, cached=False, no_shortcuts=Fals
     
     try:
         v = vdf.load(open(libraryfolders_vdf_file))
+        print(f'Successfully loaded {libraryfolders_vdf_file}.')
         c = vdf.load(open(config_vdf_file)).get('InstallConfigStore').get('Software').get('Valve').get('Steam').get('CompatToolMapping')
-        
+        print(f'Successfully loaded {config_vdf_file}.')
+
         for fid in v.get('libraryfolders'):
             if 'apps' not in v.get('libraryfolders').get(fid):
                 continue
@@ -67,11 +69,11 @@ def get_steam_app_list(steam_config_folder: str, cached=False, no_shortcuts=Fals
                 apps.append(app)
         apps = update_steamapp_info(steam_config_folder, apps)
         apps = update_steamapp_awacystatus(apps)
+
+        if not no_shortcuts:
+            apps.extend(get_steam_shortcuts_list(steam_config_folder, c))
     except Exception as e:
         print('Error: Could not get a list of all Steam apps:', e)
-
-    if not no_shortcuts:
-        apps.extend(get_steam_shortcuts_list(steam_config_folder, c))
 
     _cached_app_list = apps
     return apps

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -337,7 +337,8 @@ def steam_update_ctool(game: SteamApp, new_ctool=None, steam_config_folder='') -
     game_id = game.app_id
 
     try:
-        c = get_steam_vdf_compat_tool_mapping(vdf.load(open(config_vdf_file)))
+        d = vdf.load(open(config_vdf_file))
+        c = get_steam_vdf_compat_tool_mapping(d)
 
         if str(game_id) in c:
             if new_ctool is None:
@@ -365,7 +366,8 @@ def steam_update_ctools(games: Dict[SteamApp, str], steam_config_folder='') -> b
         return False
 
     try:
-        c = get_steam_vdf_compat_tool_mapping(vdf.load(open(config_vdf_file)))
+        d = vdf.load(open(config_vdf_file))
+        c = get_steam_vdf_compat_tool_mapping(d)
 
         for game, new_ctool in games.items():
             game_id = game.app_id

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -103,7 +103,7 @@ def get_steam_shortcuts_list(steam_config_folder: str, compat_tools: dict=None) 
 
     try:
         if not compat_tools:
-            compat_tools = vdf.load(open(config_vdf_file)).get('InstallConfigStore').get('Software').get('Valve').get('Steam').get('CompatToolMapping')
+            compat_tools = get_steam_vdf_compat_tool_mapping(vdf.load(open(config_vdf_file)))
 
         for file in os.listdir(users_folder):
             user_directory = os.path.join(users_folder,file)

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -37,12 +37,10 @@ def get_steam_app_list(steam_config_folder: str, cached=False, no_shortcuts=Fals
     config_vdf_file = os.path.join(os.path.expanduser(steam_config_folder), 'config.vdf')
 
     apps = []
-    
+
     try:
         v = vdf.load(open(libraryfolders_vdf_file))
-        print(f'Successfully loaded {libraryfolders_vdf_file}.')
         c = vdf.load(open(config_vdf_file)).get('InstallConfigStore').get('Software').get('Valve').get('Steam').get('CompatToolMapping')
-        print(f'Successfully loaded {config_vdf_file}.')
 
         for fid in v.get('libraryfolders'):
             if 'apps' not in v.get('libraryfolders').get(fid):
@@ -69,11 +67,11 @@ def get_steam_app_list(steam_config_folder: str, cached=False, no_shortcuts=Fals
                 apps.append(app)
         apps = update_steamapp_info(steam_config_folder, apps)
         apps = update_steamapp_awacystatus(apps)
-
-        if not no_shortcuts:
-            apps.extend(get_steam_shortcuts_list(steam_config_folder, c))
     except Exception as e:
         print('Error: Could not get a list of all Steam apps:', e)
+    else:
+        if not no_shortcuts:
+            apps.extend(get_steam_shortcuts_list(steam_config_folder, c))
 
     _cached_app_list = apps
     return apps

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -22,6 +22,18 @@ _cached_app_list = []
 _cached_steam_ctool_id_map = None
 
 
+def get_steam_vdf_compat_tool_mapping(vdf_file: dict):
+
+    c = vdf_file.get('InstallConfigStore').get('Software')
+
+    # Sometimes the key is 'Valve', sometimes 'valve', see #226
+    c = c.get('Valve') or c.get('valve')
+    if not c:
+        raise KeyError('Error! config.vdf InstallConfigStore.Software neither contains key "Valve" nor "valve" - config.vdf file may be invalid!')
+
+    return c.get('Steam').get('CompatToolMapping')
+
+
 def get_steam_app_list(steam_config_folder: str, cached=False, no_shortcuts=False) -> List[SteamApp]:
     """
     Returns a list of installed Steam apps and optionally game names and the compatibility tool they are using
@@ -40,8 +52,8 @@ def get_steam_app_list(steam_config_folder: str, cached=False, no_shortcuts=Fals
 
     try:
         v = vdf.load(open(libraryfolders_vdf_file))
-        c = vdf.load(open(config_vdf_file)).get('InstallConfigStore').get('Software').get('Valve').get('Steam').get('CompatToolMapping')
-
+        c = get_steam_vdf_compat_tool_mapping(vdf.load(open(config_vdf_file)))
+        
         for fid in v.get('libraryfolders'):
             if 'apps' not in v.get('libraryfolders').get(fid):
                 continue
@@ -325,8 +337,7 @@ def steam_update_ctool(game: SteamApp, new_ctool=None, steam_config_folder='') -
     game_id = game.app_id
 
     try:
-        d = vdf.load(open(config_vdf_file))
-        c = d.get('InstallConfigStore').get('Software').get('Valve').get('Steam').get('CompatToolMapping')
+        c = get_steam_vdf_compat_tool_mapping(vdf.load(open(config_vdf_file)))
 
         if str(game_id) in c:
             if new_ctool is None:
@@ -354,8 +365,7 @@ def steam_update_ctools(games: Dict[SteamApp, str], steam_config_folder='') -> b
         return False
 
     try:
-        d = vdf.load(open(config_vdf_file))
-        c = d.get('InstallConfigStore').get('Software').get('Valve').get('Steam').get('CompatToolMapping')
+        c = get_steam_vdf_compat_tool_mapping(vdf.load(open(config_vdf_file)))
 
         for game, new_ctool in games.items():
             game_id = game.app_id


### PR DESCRIPTION
Related to #226.

This moves the `if not no_shortcuts` check inside the `try` block to prevent a crash if `c` is not assigned. If something inside the `try` block fails early on, the libraryfolders VDF (`v`) or config VDF (`c`) variables may not be set appropriately and so a crash will occur when trying to reference `c` before it is assigned a value - If `v` throws an exception then `c` will never be set, or `c` is not loaded properly it could also be `None`. If the VDF library can read it though it should always return an empty dict, but if any of the `get`s fail it could end up being `None` I think (not sure, never had an exception get thrown with chained `get`s, not sure if it will just be `None`, take on the last return value, or if it will be unassigned thus triggering the crash).

This also adds some logging for the VDF file loading. Since it's come up a couple of times now that these files aren't parsed correctly it would be useful to see which file can't be loaded. This log message will get triggered each time the user switches to the Steam utility but for most users this should be invisible, it might just end up being "noisy" for those of us that run from the command line often. So perhaps the logging is less desirable but I can remove it. If it is desired I figured it would be better to catch that in this PR too.

<hr>

The root cause of #226 is still likely that a Steam file is corrupted or otherwise invalid, but this should prevent the crash in such a scenario (the Steam games list will probably still be blank though).