### PR TITLE
Heroic: Add Wine-tkg and Proton-tkg sources

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_protontkg.py
+++ b/pupgui2/resources/ctmods/ctmod_protontkg.py
@@ -196,7 +196,7 @@ class CtInstaller(QObject):
             zst_glob = glob.glob(f'{install_folder}/*.tar.zst')
             if len(zst_glob) > 0:
                 # Wine-tkg is .tar.zst
-                tkg_dir = os.path.abspath(os.path.join(install_dir, '../../runners/wine')) if 'lutris' in install_dir else install_dir
+                tkg_dir = os.path.abspath(os.path.join(install_dir, '../../runners/wine')) if 'lutris/runners' in install_dir else install_dir
 
                 tkg_archive_name = zst_glob[0]  # Should only ever be 1 really, so assume the first is the zst archive we're looking for
 

--- a/pupgui2/resources/ctmods/ctmod_protontkg.py
+++ b/pupgui2/resources/ctmods/ctmod_protontkg.py
@@ -196,7 +196,8 @@ class CtInstaller(QObject):
             zst_glob = glob.glob(f'{install_folder}/*.tar.zst')
             if len(zst_glob) > 0:
                 # Wine-tkg is .tar.zst
-                tkg_dir = os.path.abspath(os.path.join(install_dir, '../../runners/wine'))
+                tkg_dir = os.path.abspath(os.path.join(install_dir, '../../runners/wine')) if 'lutris' in install_dir else install_dir
+
                 tkg_archive_name = zst_glob[0]  # Should only ever be 1 really, so assume the first is the zst archive we're looking for
 
                 temp_download = os.path.join(install_folder, tkg_archive_name)

--- a/pupgui2/resources/ctmods/ctmod_protontkg.py
+++ b/pupgui2/resources/ctmods/ctmod_protontkg.py
@@ -196,7 +196,7 @@ class CtInstaller(QObject):
             zst_glob = glob.glob(f'{install_folder}/*.tar.zst')
             if len(zst_glob) > 0:
                 # Wine-tkg is .tar.zst
-                tkg_dir = os.path.abspath(os.path.join(install_dir, '../../runners/wine')) if 'lutris/runners' in install_dir else install_dir
+                tkg_dir = self.get_extract_dir(install_dir)
 
                 tkg_archive_name = zst_glob[0]  # Should only ever be 1 really, so assume the first is the zst archive we're looking for
 
@@ -240,6 +240,17 @@ class CtInstaller(QObject):
         self.__set_download_progress_percent(100)
 
         return True
+
+    def get_extract_dir(self, install_dir: str) -> str:
+        """
+        Return the directory to extract TkG archive based on the current launcher
+        Return Type: str
+        """
+
+        if 'lutris/runners' in install_dir:
+            return os.path.abspath(os.path.join(install_dir, '../../runners/wine'))
+        else:
+            return install_dir  # Default to install_dir
 
     def get_info_url(self, version):
         """

--- a/pupgui2/resources/ctmods/ctmod_protontkg.py
+++ b/pupgui2/resources/ctmods/ctmod_protontkg.py
@@ -16,7 +16,7 @@ from pupgui2.util import ghapi_rlcheck
 
 
 CT_NAME = 'Proton Tkg'
-CT_LAUNCHERS = ['steam']
+CT_LAUNCHERS = ['steam', 'heroicproton']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_protontkg', '''Custom Proton build for running Windows games, built with the Wine-tkg build system.''')}
 
 

--- a/pupgui2/resources/ctmods/ctmod_protontkg_winemaster.py
+++ b/pupgui2/resources/ctmods/ctmod_protontkg_winemaster.py
@@ -8,7 +8,7 @@ from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstall
 
 
 CT_NAME = 'Proton Tkg (Wine Master)'
-CT_LAUNCHERS = ['steam', 'advmode']
+CT_LAUNCHERS = ['steam', 'heroicproton', 'advmode']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_protontkg_winemaster', '''Custom Proton build for running Windows games, built with the Wine-tkg build system.
 <br/>
 <br/>

--- a/pupgui2/resources/ctmods/ctmod_winetkg_valve_otherdistro.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_valve_otherdistro.py
@@ -8,7 +8,7 @@ from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstall
 
 
 CT_NAME = 'Wine Tkg (Valve Wine)'
-CT_LAUNCHERS = ['lutris']
+CT_LAUNCHERS = ['lutris', 'heroicwine']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_winetkg_valve_otherdistro', '''Custom Wine build for running Windows games, built with the Wine-tkg build system.''')}
 
 

--- a/pupgui2/resources/ctmods/ctmod_winetkg_vanilla_wine.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_vanilla_wine.py
@@ -8,7 +8,7 @@ from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstall
 
 
 CT_NAME = 'Wine Tkg (Vanilla Wine)'
-CT_LAUNCHERS = ['lutris', 'advmode']
+CT_LAUNCHERS = ['lutris', 'heroicwine', 'advmode']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_winetkg_vanilla_ubuntu', '''Custom Wine build for running Windows games, built with the Wine-tkg build system.''')}
 
 


### PR DESCRIPTION
Implements part of a request from #232 to add Wine-tkg sources to Heroic, and also includes Proton-tkg sources for Heroic as well.

## Overview
Only Lutris supports Wine-tkg sources, and Steam only supports Proton-tkg sources. This PR enables Wine-tkg downloads for Heroic Wine, as well as Proton-tkg for Heroic Proton. Let the Heroic frogs be free! :frog: 

I explained in #191 that Proton isn't *really* meant for use outside of Steam, but for Heroic Proton we already facilitate downloading GE-Proton. Heroic has been acting up a little for me and it's a bit late at time of writing so I haven't checked, but I think Heroic actually looks for the Steam Linux Runtime when using Proton (which is a little unconventional, but SteamTinkerLaunch does the same, so it should be fine). I am not certain that Lutris does it or if it does I didn't see it when I skimmed the options (running `lutris-git` from the AUR). Also, Proton-tkg was once upon a time not built against the Steam Linux Runtime. I'm not sure if that is still the case as I don't see the note on the [Readme](https://github.com/Frogging-Family/wine-tkg-git/blob/master/proton-tkg/README.md) anymore and didn't check the git history on this file.

## Implementation
The Wine-tkg extraction directory was hardcoded in #178 to refer to the Lutris install directory (`../../runners/wine`). Some changes were needed to facilitate Heroic support. The solution I came to was to check if `install_dir` has `lutris/runners` in the name and if it does, then use the existing logic to build the Lutris extract dir. Otherwise default to `install_dir`. This saves having to do any sort of passing of the current launcher, as it can be inferred.

I think this check is fine as I don't think the path to Heroic Wine could ever include `lutris/runners`. In other words I believe the only time this should be the case is if a user is installing Tkg for Lutris. I initially just checked for `'lutris' in install_dir` and then I realised a given username might be or contain `lutris`, so I went with the more explicit check for this directory structure. Looking at the `constants.py` file this should work for Lutris Flatpak (`~/.var/app/net.lutris.Lutris/data/lutris/runners`) and AppImage/package manager Lutris (`~/.local/share/lutris/runners/wine/`).

Side note: A similar implementation *may* be possible for D8VK for Heroic as requested in #208, i.e. `dxvk_dir = os.path.join(install_dir, '../../runtime/dxvk') if 'lutris/runtime' in install_dir else install_dir`. I haven't tested this though and other considerations may be needed for that (i.e. heroictools` option, but that's a separate matter entirely).

<hr>

Once the fallback to `install_dir` when installing outside of Lutris was in place, things seem to just work. In my brief testing I didn't encounter anything (though it is kinda late for me, might've missed something). I also haven't tested how these tools work with Heroic, but since Heroic can see them once downloaded and since the folder structure is correct (it should be able to find the Wine binary) I don't see why it would run into any issues :-)

Thanks!

<hr>

P.S. - When testing I noticed that while the different Tkg builds have different naming conventions, it isn't always clear which version of Wine-tkg/Proton-tkg refers to which ctmod. This *could* be changed on our end but may not be absolutely necessary as I think generally we just stick to whatever the extracted archive name does, which is what would happen if a user installed the tool manually.