### PR TITLE
D8VK: Update branch name

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_d8vk.py
+++ b/pupgui2/resources/ctmods/ctmod_d8vk.py
@@ -120,7 +120,7 @@ class CtInstaller(QObject):
         tags = []
         for artifact in ghapi_rlcheck(self.rs.get(self.CT_URL + '?per_page=' + str(count)).json()).get("artifacts", {}):
             workflow = artifact['workflow_run']
-            if not workflow["head_branch"] == "master" or artifact["expired"]:
+            if not workflow["head_branch"] == "main" or artifact["expired"]:
                 continue
             if workflow['head_sha'][:7] not in tags:  # Downloads wrong releases sometimes? Folder structure looks wrong -- Maybe wrong one downloaded from nightly link or wrong suite? (maybe only ever other entry is right and we're filtering the "proper" ones)
                 tags.append(workflow['head_sha'][:7])


### PR DESCRIPTION
[D8VK apparently uses `main` as its default branch now](https://github.com/AlpyneDreams/d8vk/branches), which breaks the download check. Since it skips any workflows that aren't based on the `head_branch` being `master` it was skipping all of them and not fetching any releases.

I'm not sure when the branch name changed but when investigating an implementation of D8VK for Heroic I came across this issue (not in this PR). D8VK seems to work fine now with this change.