### PR TITLE
Proton-tkg: Pass count arg when fetching workflow runs

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_protontkg.py
+++ b/pupgui2/resources/ctmods/ctmod_protontkg.py
@@ -149,7 +149,7 @@ class CtInstaller(QObject):
         for workflow in self.rs.get(f'{self.CT_WORKFLOW_URL}?per_page={str(count)}').json().get("workflows", {}):
             if workflow['state'] != "active" or self.PROTON_PACKAGE_NAME not in workflow['path']:
                 continue
-            tags.extend(str(run['id']) for run in self.rs.get(workflow["url"] + "/runs").json()["workflow_runs"] if run['conclusion'] == "success")
+            tags.extend(str(run['id']) for run in self.rs.get(workflow["url"] + f"/runs?per_page={str(count)}").json()["workflow_runs"] if run['conclusion'] == "success")
 
         return tags
 


### PR DESCRIPTION
Partially Fixes #236.

The GitHub API call to fetch workflow runs for Proton-tkg was not taking into account the `count` parameter given to the `__fetch_workflows` method. This PR fixes that by passing a `per_page={count}` to the API call. The API URL will now look something this like: https://api.github.com/repos/Frogging-Family/wine-tkg-git/actions/workflows/29745300/runs?per_page=100

This was discovered to be causing issues as the "Proton-tkg (Wine Master)" CI has had a significant number of failures recently, so ProtonUp-Qt was falling back to only displaying the releases.  By default, this API only displays the last 30 builds. Since ProtonUp-Qt filters to only show successful builds (as there are no build artifacts for failed builds), and the last 30+ builds have failed, the `tags` returned from `__fetch_workflows` was empty.

<hr>

Currently all other Proton-tkg and Wine-tkg builds are unaffected as they do not have a significant amount of failures, but this issue would impact any workflow that ProtonUp-Qt tries to download from if the last 30 builds failed for a given workflow: https://api.github.com/repos/Frogging-Family/wine-tkg-git/actions/workflows/29745300/runs

The "drawback" to adding this is that the time to load "Proton-tkg (Wine Master)" builds, since it's trying to fetch more artifacts. The solution to this would be to restrict the `count` passed to the method calls for the ctmod rather than anything being wrong with adding the `per_page` parameter to the API call. We pass `count` to other GitHub API calls, so it makes sense to pass it here too, it's just that now that we correctly pass it there is a slightly increased delay (for me it adds around about 2-3 seconds I think).

<hr>

I opened #236 as I wasn't sure if I could debug this, I was looking into it for a while and didn't make much progress so I figured I'd report it. Of course, once I opened the bug report, I figure out how to resolve it :sweat_smile: 