### PR TITLE
Wine-tkg: Use correct TKG_EXTRACT-NAME for Vanilla Wine-tkg

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_winetkg_vanilla_wine.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_vanilla_wine.py
@@ -16,7 +16,7 @@ class CtInstaller(TKGCtInstaller):
 
     BUFFER_SIZE = 65536
     PROTON_PACKAGE_NAME = 'wine-ubuntu.yml'
-    TKG_EXTRACT_NAME = 'wine_tkg'
+    TKG_EXTRACT_NAME = 'wine-tkg'
 
     p_download_progress_percent = 0
     download_progress_percent = Signal(int)


### PR DESCRIPTION
The `TKG_EXTRACT_NAME` for "Wine-tkg (Vanilla Wine)" in Lutris was set incorrectly as `wine_tkg` when it should be `wine-tkg`.
- "Wine-tkg (Vanilla Wine)" folders are named like: `wine-tkg-staging-fsync-git-WineVer-SHA` - With a *hyphen*
- "Wine-tkg (Valve Wine)" folders are named like `wine_tkgSHA` - With an *underscore*

This discrepancy results in "Wine-tkg (Valve Proton)" builds being *removed* when "Wine-tkg (Vanilla Proton)" builds are installed, as it looks for an existing archive to remove I guess.

This does mean that existing Wine-tkg builds for both Valve Proton and Vanilla Proton are removed if another version is updated, in other words it seems we can't have i.e two builds of Wine-tkg (Vanilla Wine) installed, as the existing one gets removed. I'm not sure why this is or if it affects Proton-tkg as well (since these Wine-tkg ctmods are subclasses of `TKGCtInstaller`). That could be investigated and potentially addressed as part of this PR too.