### PR TITLE
CID: Set title for file dialog

### DIFF
--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -82,6 +82,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         dialog = QFileDialog(self.ui)
         dialog.setFileMode(QFileDialog.Directory)
         dialog.setOption(QFileDialog.ShowDirsOnly)
+        dialog.setWindowTitle(self.tr('Select Custom Install Directory — ProtonUp-Qt'))
         dialog.setDirectory(os.path.expanduser('~'))
         dialog.fileSelected.connect(self.ui.txtInstallDirectory.setText)
         dialog.open()


### PR DESCRIPTION
Minor QOL change I thought to make when messing around with the file picker dialog. Instead of just saying "Find Directory" it is now a little bit more descriptive (which is good for users who are like me and might forget what they opened the dialog to do...)

Before:
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/96804dd2-c414-4725-ade4-7b083c5e236c)

After:
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/f64e108a-f897-40bc-a494-9aa644b57637)

Note: I'm not sure what this might do on Flatpak, because when running the Flatpak, ProtonUp-Qt appears to use xdg-portals to open the file dialog. Portals are, in short and in this instance, a way to have consistent cross-desktop file dialog behaviour by basically telling the desktop to "plug in" it's file dialog in place of one an application might use as a fallback, i.e. use a GTK file picker on GNOME. Portals can be used in other ways (such as for audio/screen sharing afaik) but the file picker is what we are concerned with here. There is [some information on GitHub](https://github.com/flatpak/xdg-desktop-portal) but it's still a little vague in my opinion :sweat_smile: 

The install dialog on ProtonUp-Qt Flatpak says "Select Folder - Portal", and at least in my testing (i.e. on Firefox), Portals usually have consistent names such as "Open File", "Save As", etc. Originally, I actually started messing around with the custom install dialog to see if there was a way to get it to use Portals when running from source but I was unsuccessful (I don't run Firefox Flatpak for example, but it still uses Portals).