### PR TITLE
Heroic: Add D8VK

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -236,6 +236,12 @@ class MainWindow(QObject):
             heroic_game_list = get_heroic_game_list(heroic_dir)
             for ct in self.compat_tool_index_map:
                 ct.no_games = len([game for game in heroic_game_list if game.is_installed and ct.displayname in game.wine_info.get('name', '')])
+            
+            # Get DXVK/VKD3D installs for Heroic
+            dxvk_dir = os.path.join(install_directory(), '../dxvk')
+            vkd3d_dir = os.path.join(install_directory(), '../vkd3d')
+            self.get_installed_versions('dxvk', dxvk_dir)
+            self.get_installed_versions('vkd3d', vkd3d_dir)
 
         for ct in self.compat_tool_index_map:
             self.ui.listInstalledVersions.addItem(ct.get_displayname(unused_tr=self.tr('unused')))

--- a/pupgui2/resources/ctmods/ctmod_d8vk.py
+++ b/pupgui2/resources/ctmods/ctmod_d8vk.py
@@ -167,7 +167,7 @@ class CtInstaller(QObject):
         """
 
         if 'lutris/runners' in install_dir:
-            return os.path.abspath(os.path.join(install_dir, '../../runners/wine'))
+            return os.path.abspath(os.path.join(install_dir, '../../runtime/dxvk'))
         if 'heroic/tools' in install_dir:
             return os.path.abspath(os.path.join(install_dir, '../dxvk'))
         else:

--- a/pupgui2/resources/ctmods/ctmod_d8vk.py
+++ b/pupgui2/resources/ctmods/ctmod_d8vk.py
@@ -13,7 +13,7 @@ from pupgui2.util import ghapi_rlcheck
 
 
 CT_NAME = 'D8VK (nightly)'
-CT_LAUNCHERS = ['lutris', 'advmode']
+CT_LAUNCHERS = ['lutris', 'heroicwine', 'heroicproton', 'advmode']
 CT_DESCRIPTION = {}
 CT_DESCRIPTION['en'] = QCoreApplication.instance().translate('ctmod_d8vk', '''Vulkan-based implementation of Direct3D 8/9/10/11 (Nightly).<br/><br/><b>Warning: Nightly version is unstable, use with caution!</b>''')
 
@@ -135,7 +135,7 @@ class CtInstaller(QObject):
         if not data or 'download' not in data:
             return False
 
-        dxvk_dir = os.path.join(install_dir, '../../runtime/dxvk')
+        dxvk_dir = self.get_extract_dir(install_dir)
         dxvk_install_dir = os.path.join(dxvk_dir, 'd8vk-git-' + data['version'])
         destination = temp_dir
         destination += data['download'].split('/')[-1]
@@ -159,3 +159,16 @@ class CtInstaller(QObject):
         Return Type: str
         """
         return self.CT_INFO_URL + version
+
+    def get_extract_dir(self, install_dir: str) -> str:
+        """
+        Return the directory to extract D8VK archive based on the current launcher
+        Return Type: str
+        """
+
+        if 'lutris/runners' in install_dir:
+            return os.path.abspath(os.path.join(install_dir, '../../runners/wine'))
+        if 'heroic/tools' in install_dir:
+            return os.path.abspath(os.path.join(install_dir, '../dxvk'))
+        else:
+            return install_dir  # Default to install_dir


### PR DESCRIPTION
This PR adds support for installing D8VK for Heroic, as requested in #208.

Heroic stores DXVK versions in its `tools` directory, under the `dxvk` folder. The folder structure of DXVK versions that it expects matches Lutris and so no change was needed to the extraction logic. It simply expects a folder in the `tools` directory with the name of the tool, and then the `x32` folder for the required DLLs.

Though this PR Is for *D****8****VK*, this project is a fork of DXVK and operates similarly, so from Heroic's perspective D8VK would be treated as a separate DXVK "version" :-)

Two main changes were needed for this PR:
1. Updating `ctmod_d8vk` to check which directory to extract into using some checks in the current launcher's path. For Heroic and Lutris we have two different extraction directories, so we infer the launcher type in the ctmod and use that to determine where to extract to. This is essentially the approached I mentioned in https://github.com/DavidoTek/ProtonUp-Qt/discussions/208#discussioncomment-5754955
2. Update the main UI to display DXVK and vkd3d runtimes. This was not done previously because ProtonUp-Qt doesn't give the ability to install anything except a handful of Wine/Proton versions for Heroic. However this PR implements a DXVK runtime, and also, Heroic allows you to download custom DXVK versions I believe, so giving users the visibility into these tools (and cleanup/remove them) is useful in general :smile: 

The ctmod was updated to include `heroicproton` and `heroicwine` as sources. It is more common for Wine to not include a DXVK runtime, but as far as I know, selecting a DXVK version with Heroic will override the DLLs and force that DXVK version. It is also still possible to get builds of Proton without DXVK, such as Kron4ek Wine (not (yet) available for Heroic with ProtonUp-Qt), so this change should be applicable for both Heroic Wine and Heroic Proton.

I have tested this change with Heroic AppImage and Heroic Flatpak, so I was able to confirm that both config directories worked as expected.

<hr>

This was implemented as kind of a proof-of-concept, but the logic here would also apply to DXVK and vkd3d (Proton and vkd3d from Lutris). This would cover the "others" mentioned in #208. I didn't want to include those in this PR, at least initially, in case there are any reservations around adding this functionality or anything that needs ironed out first :-)

Thanks!