### PR TITLE
vkd3d: Make vkd3d-lutris inherit from vkd3d-proton

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_vkd3dlutris.py
+++ b/pupgui2/resources/ctmods/ctmod_vkd3dlutris.py
@@ -2,134 +2,19 @@
 # vkd3d-lutris for Lutris: https://github.com/lutris/vkd3d/
 # Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
 
-import os
-import requests
+from PySide6.QtCore import QCoreApplication
 
-from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
-
-from pupgui2.util import ghapi_rlcheck, extract_tar
+from pupgui2.resources.ctmods.ctmod_vkd3dproton import CtInstaller as VKD3DInstaller
 
 
 CT_NAME = 'vkd3d-lutris'
 CT_LAUNCHERS = ['lutris']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_vkd3d-lutris', '''Fork of Wine's VKD3D which aims to implement the full Direct3D 12 API on top of Vulkan (Lutris Release).<br/><br/>https://github.com/lutris/docs/blob/master/HowToDXVK.md''')}
 
-class CtInstaller(QObject):
+class CtInstaller(VKD3DInstaller):
 
-    BUFFER_SIZE = 65536
     CT_URL = 'https://api.github.com/repos/lutris/vkd3d/releases'
     CT_INFO_URL = 'https://github.com/lutris/vkd3d/releases/tag/'
 
-    p_download_progress_percent = 0
-    download_progress_percent = Signal(int)
-
     def __init__(self, main_window = None):
-        super(CtInstaller, self).__init__()
-        self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
-
-    def get_download_canceled(self):
-        return self.p_download_canceled
-
-    def set_download_canceled(self, val):
-        self.p_download_canceled = val
-
-    download_canceled = Property(bool, get_download_canceled, set_download_canceled)
-
-    def __set_download_progress_percent(self, value : int):
-        if self.p_download_progress_percent == value:
-            return
-        self.p_download_progress_percent = value
-        self.download_progress_percent.emit(value)
-
-    def __download(self, url, destination):
-        """
-        Download files from url to destination
-        Return Type: bool
-        """
-        try:
-            file = self.rs.get(url, stream=True)
-        except OSError:
-            return False
-
-        self.__set_download_progress_percent(1) # 1 download started
-        f_size = int(file.headers.get('content-length'))
-        c_count = int(f_size / self.BUFFER_SIZE)
-        c_current = 1
-        destination = os.path.expanduser(destination)
-        os.makedirs(os.path.dirname(destination), exist_ok=True)
-        with open(destination, 'wb') as dest:
-            for chunk in file.iter_content(chunk_size=self.BUFFER_SIZE):
-                if self.download_canceled:
-                    self.download_canceled = False
-                    self.__set_download_progress_percent(-2) # -2 download canceled
-                    return False
-                if chunk:
-                    dest.write(chunk)
-                    dest.flush()
-                self.__set_download_progress_percent(int(min(c_current / c_count * 98.0, 98.0))) # 1-98, 100 after extract
-                c_current += 1
-        self.__set_download_progress_percent(99) # 99 download complete
-        return True
-
-    def __fetch_github_data(self, tag):
-        """
-        Fetch GitHub release information
-        Return Type: dict
-        Content(s):
-            'version', 'date', 'download', 'size', 'checksum'
-        """
-        url = self.CT_URL + (f'/tags/{tag}' if tag else '/latest')
-        data = self.rs.get(url).json()
-        if 'tag_name' not in data:
-            return None
-
-        values = {'version': data['tag_name'], 'date': data['published_at'].split('T')[0]}
-        for asset in data['assets']:
-            if asset['name'].endswith('tar.xz'):
-                values['download'] = asset['browser_download_url']
-                values['size'] = asset['size']
-        return values
-
-    def is_system_compatible(self):
-        """
-        Are the system requirements met?
-        Return Type: bool
-        """
-        return True
-
-    def fetch_releases(self, count=100):
-        """
-        List available releases
-        Return Type: str[]
-        """
-        return [release['tag_name'] for release in ghapi_rlcheck(self.rs.get(f'{self.CT_URL}?per_page={str(count)}').json()) if 'tag_name' in release]
-
-    def get_tool(self, version, install_dir, temp_dir):
-        """
-        Download and install the compatibility tool
-        Return Type: bool
-        """
-        data = self.__fetch_github_data(version)
-
-        if not data or 'download' not in data:
-            return False
-
-        vkd3d_tar = os.path.join(temp_dir, data['download'].split('/')[-1])
-        if not self.__download(url=data['download'], destination=vkd3d_tar):
-            return False
-
-        vkd3d_dir = os.path.abspath(os.path.join(install_dir, '../../runtime/vkd3d'))
-        if not extract_tar(vkd3d_tar, vkd3d_dir, mode='xz'):
-            return False
-
-        self.__set_download_progress_percent(100)
-
-        return True
-
-    def get_info_url(self, version):
-        """
-        Get link with info about version (eg. GitHub release page)
-        Return Type: str
-        """
-        return self.CT_INFO_URL + version
+        super().__init__(main_window)


### PR DESCRIPTION
vkd3d-lutris now inherits from the vkd3d-proton ctmod, changing only the CT_URL and CT_INFO_URL to point to the right location. This essentially removes all logic from vkd3d-lutris and the only thing it does is set its own CT_NAME etc, and its own URLs. inside the class, so that other method calls inside this class point to the correct vkd3d-lutris URLs. This is very similar to how Proton-tkg ctmods are implemented.

## Implementation
### Archive Fetching
I'll be referencing the Proton-tkg a bit here, because it's got a similar approach. 

vkd3d-proton has been updated to allow extracting both `.tar.zst` archives (vkd3d-proton) and `.tar.xz` archives (vkd3d-lutris). The check in `__fetch_github_data` also had to be updated, it was checking if the asset name ended with `.tar.zst` so I changed it to check for both archive formats. If the archive format were ever to change (which I think is unlikely), this check could be changed to check if `vkd3d in asset['name']`.

This is actually what Proton-tkg does currently (https://github.com/DavidoTek/ProtonUp-Qt/blob/main/pupgui2/resources/ctmods/ctmod_protontkg.py#L130). There could be issues with doing this, such as if a checksum was ever added or anything like that, but the same could be said for Proton-tkg and that implementation is working fine, so either approach would work here too I think (especially since vkd3d releases only have one asset aside from the source code archives: [vkd3d-proton releases](https://github.com/HansKristian-Work/vkd3d-proton/releases) and [vkd3d-lutris releases](https://github.com/lutris/vkd3d/releases)).

### Archive Extraction
Though they use different formats, both vkd3d archives have the same file structure - we just needed to use a different extraction method. Speaking of...

Since #250 was merged it was very straightforward to add the conditional logic for which archive to extract. In fact, I had a little fun with this part. For Proton-tkg, since that ctmod accounts for various different "flavours", to know how to extract each archive we check what it `endswith`. That way we know which function to call. Both `endswith` and the extraction methods like `extract_tar_zst` return booleans, so I was able to do a neat little trick here:

```python
has_extract_tar_zst = vkd3d_archive.endswith('.tar.zst') and extract_tar_zst(vkd3d_archive, vkd3d_dir)
has_extract_tar_xz = vkd3d_archive.endswith('.tar.xz') and extract_tar(vkd3d_archive, vkd3d_dir, mode='xz')
``` 

If the `endswith` check is true on the left, the `extract_` on the right will not be executed when `and`ing. If the `endswith` returns False, it won't try to call the extract function, which should make for a safe extraction check. And since both of these functions return a boolean, we can still do the `return False` part for failed archive extraction.

Really, I just thought this was a fun way to go about it, but if you'd prefer a more explicit check (along the lines of doing both of these checks in one if, or in a nested if, or two separate ifs) that's fine too :smile: 

### ctmod filename
I did consider renaming the ctmod filename, but I decided against it. The ctmod name is still `vkd3d-proton` by default, and also we didn't rename the Proton-tkg ctmod to anything like `ctmod_tkg`, so I figure keeping the filename the same is fine :-)

## Concerns
It isn't _impossible_ that these archive formats would change, but even if the ctmods were kept split, we would still need to update the logic to account for that case anyway, so I don't think that's an issue specific to using an implementation like this. For example if vkd3d-lutris updated to using `.tar.gz` instead, we'd need to check both formats for backwards compatibility in `vkd3d-lutris`. The same would be true for this approach (though which one is cleaner could be debated).

This concern would also apply to any ctmod where the archive format could change, or where we deal with multiple archive formats (such as with Proton-tkg).

<hr>

This change came about mainly because I was looking to add vkd3d to Heroic, and it caught my eye how similar the ctmods were. So I figured an attempt at a refactor here might be in order before looking to add Heroic support (the main change will be adding a `get_extract_dir` for vkd3d). I also think this approach is slightly cleaner, since it removes the heavily duplicated code. There was a lot of overlap between the ctmods with the main differences being the asset name check, and the extraction logic, both of which were pretty straightforward to add checks for in this ctmod.

Thanks! :-)