### PR TITLE
Heroic: Add DXVK

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -11,7 +11,7 @@ from pupgui2.util import ghapi_rlcheck, extract_tar
 
 
 CT_NAME = 'DXVK'
-CT_LAUNCHERS = ['lutris']
+CT_LAUNCHERS = ['lutris', 'heroicwine', 'heroicproton']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_z0dxvk', '''Vulkan based implementation of Direct3D 9, 10 and 11 for Linux/Wine.<br/><br/>https://github.com/lutris/docs/blob/master/HowToDXVK.md''')}
 
 
@@ -121,7 +121,7 @@ class CtInstaller(QObject):
         if not self.__download(url=data['download'], destination=dxvk_tar):
             return False
 
-        dxvk_dir = os.path.join(install_dir, '../../runtime/dxvk')
+        dxvk_dir = self.get_extract_dir(install_dir)
         if not extract_tar(dxvk_tar, dxvk_dir, mode='gz'):
             return False
 
@@ -135,3 +135,16 @@ class CtInstaller(QObject):
         Return Type: str
         """
         return self.CT_INFO_URL + version
+
+    def get_extract_dir(self, install_dir: str) -> str:
+        """
+        Return the directory to extract DXVK archive based on the current launcher
+        Return Type: str
+        """
+
+        if 'lutris/runners' in install_dir:
+            return os.path.abspath(os.path.join(install_dir, '../../runtime/dxvk'))
+        if 'heroic/tools' in install_dir:
+            return os.path.abspath(os.path.join(install_dir, '../dxvk'))
+        else:
+            return install_dir  # Default to install_dir


### PR DESCRIPTION
This adds DXVK for `heroicwine` and `heroicproton`, mirroring the implementation for #245. I tested that this didn't break Lutris, and tested a couple of different DXVK versions (v2.2 and v2.0) for each.

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/5bd77830-ebfc-4c04-9426-173209723729)

DXVK versions are displayed on the main menu without any changes, because #245 added the logic to check for and display DXVK and vkd3d tools. The only change required here was changing the path that DXVK is extracted to.

An equivalent change can be made for VKD3D as well, though that can go in a separate PR that will depend on whether #262 is accepted or not ;-) 

Thanks!