### PR TITLE
Proton-tkg: Remove unnecessary variables from subclasses

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_protontkg_winemaster.py
+++ b/pupgui2/resources/ctmods/ctmod_protontkg_winemaster.py
@@ -2,7 +2,7 @@
 # Proton-Tkg https://github.com/Frogging-Family/wine-tkg-git
 # Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
 
-from PySide6.QtCore import QCoreApplication, Signal
+from PySide6.QtCore import QCoreApplication
 
 from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstaller  # Use ProtonTKg Ctmod as base
 

--- a/pupgui2/resources/ctmods/ctmod_protontkg_winemaster.py
+++ b/pupgui2/resources/ctmods/ctmod_protontkg_winemaster.py
@@ -17,11 +17,7 @@ This build is based on <b>Wine Master</b>.''')}
 
 class CtInstaller(TKGCtInstaller):
 
-    BUFFER_SIZE = 65536
     PROTON_PACKAGE_NAME = 'proton-arch-nopackage.yml'
-
-    p_download_progress_percent = 0
-    download_progress_percent = Signal(int)
 
     def __init__(self, main_window = None):
         super().__init__(main_window)

--- a/pupgui2/resources/ctmods/ctmod_winetkg_valve_otherdistro.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_valve_otherdistro.py
@@ -14,11 +14,7 @@ CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_winetkg_val
 
 class CtInstaller(TKGCtInstaller):
 
-    BUFFER_SIZE = 65536
     PROTON_PACKAGE_NAME = 'wine-valvexbe'
-
-    p_download_progress_percent = 0
-    download_progress_percent = Signal(int)
 
     def __init__(self, main_window = None):
         super().__init__(main_window)

--- a/pupgui2/resources/ctmods/ctmod_winetkg_valve_otherdistro.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_valve_otherdistro.py
@@ -2,7 +2,7 @@
 # Proton-Tkg https://github.com/Frogging-Family/wine-tkg-git
 # Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
 
-from PySide6.QtCore import QCoreApplication, Signal
+from PySide6.QtCore import QCoreApplication
 
 from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstaller  # Use ProtonTKg Ctmod as base
 

--- a/pupgui2/resources/ctmods/ctmod_winetkg_vanilla_wine.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_vanilla_wine.py
@@ -2,7 +2,7 @@
 # Proton-Tkg https://github.com/Frogging-Family/wine-tkg-git
 # Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
 
-from PySide6.QtCore import QCoreApplication, Signal
+from PySide6.QtCore import QCoreApplication
 
 from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstaller  # Use ProtonTKg Ctmod as base
 

--- a/pupgui2/resources/ctmods/ctmod_winetkg_vanilla_wine.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_vanilla_wine.py
@@ -14,11 +14,7 @@ CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_winetkg_van
 
 class CtInstaller(TKGCtInstaller):
 
-    BUFFER_SIZE = 65536
     PROTON_PACKAGE_NAME = 'wine-ubuntu.yml'
-
-    p_download_progress_percent = 0
-    download_progress_percent = Signal(int)
 
     def __init__(self, main_window = None):
         super().__init__(main_window)


### PR DESCRIPTION
Removes some duplicated variables from the Proton-tkg subclasses, like the buffer size and signal. These are already set by the main Proton-tkg class and the values didn't change for the subclasses, so we don't need to set them.

Did a quick spot check and this didn't break anything, Tkgs still downloaded successfully for Lutris, Heroic and Steam.

This is just minor code maintenance, and has no impact on functionality. So no screenshots for this one :-)