### PR TITLE
Bump steam dependency version to match requirements.txt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     vdf>=3.4
     inputs==0.5
     pyxdg>=0.27
-    steam>=1.1.0
+    steam>=1.4.4
     PyYAML==6.0
     zstandard>=0.19.0
 


### PR DESCRIPTION
The `install_requires` dependencies for `setup.cfg` mostly match that of `requirements.txt`. The only exception is the `steam` library which is still at `1.1.0`, when really it should be `1.4.4` (as this has the updated magic for VDF parsing, see #157). This PR bumps that requirement version.

This hasn't affected anything and `>= 1.1.0` should probably always use the most up-to-date `steam` dependency, I can't envision a reasonable case when it wouldn't without explicit user intervention. I don't think there's any harm in keeping these in sync, though.

I believe `setup.cfg` is used by setuptools, though I am not exactly sure how this file applies in that context to ProtonUp-Qt.