### PR TITLE
(v2.8.1 fix) Default tar extract mode to 'r:', remove successfully extracted tkg archives

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_protontkg.py
+++ b/pupgui2/resources/ctmods/ctmod_protontkg.py
@@ -198,10 +198,12 @@ class CtInstaller(QObject):
         if tkg_archive.endswith('.tar.gz'):  # Legacy archives from GitHub releases
             if not extract_tar(tkg_archive, install_dir, mode='gz'):
                 return False
+            remove_if_exists(tkg_archive)
         elif tkg_archive.endswith('.zip'):  # GitHub Actions builds
             tkg_extract_tmp = os.path.join(temp_dir, f'tkg_extract_tmp')
             if not extract_zip(tkg_archive, tkg_extract_tmp):
                 return False
+            remove_if_exists(tkg_archive)
 
             if zst_glob := glob.glob(f'{tkg_extract_tmp}/*.tar.zst'):
                 # Extract .tar.zst nested inside .zip
@@ -220,6 +222,7 @@ class CtInstaller(QObject):
                 remove_extractfiles = [ '.BUILDINFO', '.INSTALL', '.MTREE', '.PKGINFO' ]
                 for rmfile in remove_extractfiles:
                     remove_if_exists(os.path.join(install_dir, rmfile))
+                remove_if_exists(tkg_zst)
             elif tar_glob := glob.glob(f"{tkg_extract_tmp}/*.tar"): 
                 # Regular .tar
                 tkg_tar = tar_glob[0]
@@ -228,6 +231,7 @@ class CtInstaller(QObject):
                 remove_if_exists(tkg_tar_extract_path)
                 if not extract_tar(tkg_tar, install_dir):
                     return False
+                remove_if_exists(tkg_tar)
         else:
             self.__set_download_progress_percent(-1)
             return False

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -584,7 +584,8 @@ def extract_zip(zip_path: str, extract_path: str) -> bool:
     return False
 
 
-def extract_tar(tar_path: str, extract_path: str, mode: str = 'r') -> bool:
+# Default mode 'r:' is for regular tars
+def extract_tar(tar_path: str, extract_path: str, mode: str = 'r:') -> bool:
 
     """
     Extracts a Tar archive at tar_path to extract_path using tarfile. Returns True if tar extracts successfully, otherwise False.


### PR DESCRIPTION
Fixes two issues I (introduced and) found while testing the v2.8.1 Flatpak. They are not specific to Flatpak, I just found them during testing flathub/net.davidotek.pupgui2#18.

## `extract_tar` doesn't work for regular `.tar` files
This is due to a bug where the default mode is `r` and gets garbled into `r:r`. This produces the error "unknown compression type 'r'". This happens because `if not mode.startswith('r:')` then we set it to `r:{mode}`. When the mode is left to the default parameter, which is `r`, this gets garbled to `r:r` (because `{mode}` is `r`). Having `r` on its own is also a valid argument to `tarfile.extractall`, but changing the default parameter to `r:` is very "elegant" and doesn't require any refactoring.

The fix for this bug is to set the default parameter to `r:`. Setting `r:*` is also valid. When having the default as `r:`, the startswith check will pass and we won't garble the mode parameter.

This is a regression from #250, and is the main "urgent" regression as it breaks Proton-tkg.

## Incorrect Archive Globbing in Temp Dir
If there were two, say, `tar.zst` files in the temp dir, then the wrong one may be extracted. Since we just "glob" for the extension and assume there will only be one. To fix this, we clean up archives after extraction with a `remove_if_exists`. I considered updating the extraction functions to do this automatically, or take a parameter to do this, but I figured that might not be very useful since this behaviour is specific to Proton-tkg and its flavours (since we don't glob elsewhere afaik).

I ran into this issue when testing different Tkg flavours, and noticed the incorrect archive was being extracted. Existing archives will be cleaned up when ProtonUp-Qt is closed, as the temp dir is cleared.

This regression is possibly from #238, I am not sure. Since this is more of an edge case and has a workaround, this one is a bit less "urgent" but I fixed it here anyway. 

<hr>

Not sure if this warrants another release, since Proton-tkg is broken on v2.8.1 AppImage/source. I have no preference either way :smile:
