### PR TITLE
DXVK Async: Make DXVK Async inherit from DXVK

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
+++ b/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
@@ -2,7 +2,7 @@
 # DXVK with async patch for Lutris: https://github.com/Sporif/dxvk-async/
 # Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
 
-from PySide6.QtCore import QObject, QCoreApplication
+from PySide6.QtCore import QCoreApplication
 
 from pupgui2.resources.ctmods.ctmod_z0dxvk import CtInstaller as DXVKInstaller
 


### PR DESCRIPTION
Another code refactor like #262, but this time for DXVK and DXVK Async.

This PR allows DXVK Async to inherit from the DXVK ctmod, removing a lot of the repeated code between the two ctmods. The ctmods were so similar that no changes at all were needed to the DXVK ctmod, which is why there's only a diff for DXVK Async.

If you compare the code for DXVK and DXVK Async, they are almost identical. Even the archive formats for releases are identical and have been for several releases at least ([DXVK releases](https://github.com/doitsujin/dxvk/releases/) and [DXVK Async](https://github.com/Sporif/dxvk-async/releases/) releases), they both use `.tar.gz`.

In fact, the only difference between the ctmods (aside from the ctmod URLs being different) is that DXVK checks where it should be extracted to because it now supports Heroic. Before that they were very similar.

Another benefit of this change is that it would make it trivial to add Heroic support for DXVK Async. We won't need to copy the extraction directory check or change any other logic, as that is all taken care off by the parent DXVK ctmod. All we would need to do is add `'heroicwine', 'heroicproton'` to the `CT_LAUNCHERS` list for DXVK Async. The only reason I didn't do it in this PR is because it may be a good idea to test this separately, though I'd be happy to add it for this PR as well.

So the main benefits to this PR are:
1. Less duplicated code, always nice to see :smile: 
2. Makes it easy to extend support to Heroic (or other launchers in future) as the logic only has to be added to the parent class

<hr>

There may be other reasons why this is not desired, such as a preference to have explicitly different ctmods for projects from different repos. But if it is desired, it would probably be possible to extend this kind of inheritance to other DXVK ctmods as well, such as DXVK Nightly and D8VK. That might require a little bit more work more akin to the recent changes for vkd3d (extraction logic changes, etc). This pattern may also make it easier to add support for other DXVK variations, such as DXVK Async-gpl (#243) and D8VK stable. This PR could be considered a "proof-of-concept" for applying this inheritance pattern to DXVK.

Hope my explanation and rationale made sense.

Thanks! :smile: 