### PR TITLE
Gamelist: Search game on AWACY when double-clicking status

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -70,7 +70,7 @@ PROTONDB_COLORS = {'platinum': '#b4c7dc', 'gold': '#cfb53b', 'silver': '#a6a6a6'
 STEAM_API_GETAPPLIST_URL = 'https://api.steampowered.com/ISteamApps/GetAppList/v2/'
 STEAM_APP_PAGE_URL = 'https://store.steampowered.com/app/'
 AWACY_GAME_LIST_URL = 'https://raw.githubusercontent.com/Starz0r/AreWeAntiCheatYet/master/games.json'
-AWACY_WEB_URL = 'https://areweanticheatyet.com/'
+AWACY_WEB_URL = 'https://areweanticheatyet.com/?search={GAMENAME}&sortOrder=&sortBy='
 LOCAL_AWACY_GAME_LIST = os.path.join(TEMP_DIR, 'awacy_games.json')
 PROTONDB_API_URL = 'https://www.protondb.com/api/v1/reports/summaries/{game_id}.json'
 PROTONDB_APP_PAGE_URL = 'https://protondb.com/app/'

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -158,7 +158,9 @@ class PupguiGameListDialog(QObject):
             lblicon_item = QTableWidgetItem()
             lblicon_item.setData(Qt.DisplayRole, game.awacy_status.value)
             lblicon_item.setTextAlignment(Qt.AlignCenter)
-            lblicon_item.setData(Qt.UserRole, AWACY_WEB_URL)
+
+            search_str = ("" if game.awacy_status == AWACYStatus.UNKNOWN else game.game_name)
+            lblicon_item.setData(Qt.UserRole, AWACY_WEB_URL.format(GAMENAME=search_str))
 
             self.ui.tableGames.setItem(i, 3, lblicon_item)
             self.ui.tableGames.setCellWidget(i, 3, lblicon)


### PR DESCRIPTION
When double-clicking the AreWeAntiCheatYet.com status in the gamelist dialog and the awacy status is known, the awacy site is opened with only the selected game displayed (game name in search).
If the status of the game is not known, https://areweanticheatyet.com/ will open normally.

Search URL: https://areweanticheatyet.com/?search={GAMENAME}&sortOrder=&sortBy=