### PR TITLE
Heroic: Correctly display Browser games in Games List

### DIFF
--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -36,7 +36,7 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
         hg.heroic_path = heroic_path
         # Sideloaded games uses folder_name as their full install path, GOG games store a folder_name but this is *just* their install folder name
         # Prioritise getting install_path for GOG games as this is the GOG game equivalent to 'folder_name'
-        hg.install_path = get_gog_installed_game_entry(hg).get('install_path', '') if hg.runner.lower() == 'gog' else game.get('folder_name', '')
+        hg.install_path = get_gog_installed_game_entry(hg).get('install_path', '') or game.get('install', []).get('install_path', '') or game.get('browserUrl', '') or game.get('folder_name', '')
         hg.store_url = game.get('store_url', '')
         hg.art_cover = game.get('art_cover', '')  # May need to replace path if it has 'file:///app/blah in name - See example in #168
         hg.art_square = game.get('art_square', '')

--- a/pupgui2/heroicutil.py
+++ b/pupgui2/heroicutil.py
@@ -36,7 +36,7 @@ def get_heroic_game_list(heroic_path: str) -> List[HeroicGame]:
         hg.heroic_path = heroic_path
         # Sideloaded games uses folder_name as their full install path, GOG games store a folder_name but this is *just* their install folder name
         # Prioritise getting install_path for GOG games as this is the GOG game equivalent to 'folder_name'
-        hg.install_path = get_gog_installed_game_entry(hg).get('install_path', '') or game.get('install', []).get('install_path', '') or game.get('browserUrl', '') or game.get('folder_name', '')
+        hg.install_path = get_gog_installed_game_entry(hg).get('install_path', '') or game.get('install', {}).get('install_path', '') or game.get('browserUrl', '') or game.get('folder_name', '')
         hg.store_url = game.get('store_url', '')
         hg.art_cover = game.get('art_cover', '')  # May need to replace path if it has 'file:///app/blah in name - See example in #168
         hg.art_square = game.get('art_square', '')

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -252,7 +252,7 @@ class PupguiGameListDialog(QObject):
                 compat_tool_tooltip += self.tr('\nType: {wine_type}').format(wine_type=game.wine_info.get("type", "").capitalize()) if game.wine_info.get('type', '') else ''
             else:
                 # Linux/Browser games
-                compat_item_text = self.tr(game.platform)
+                compat_item_text = self.tr('Browser') if game.platform.lower() == 'browser' else self.tr('Native')
                 compat_tool_tooltip = self.tr('Type: {PLATFORM}').format(PLATFORM=game.platform)
 
             compat_item.setText(compat_item_text)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -223,7 +223,7 @@ class PupguiGameListDialog(QObject):
 
     def update_game_list_heroic(self):
         heroic_dir = os.path.join(os.path.expanduser(self.install_loc.get('install_dir')), '../..')
-        self.games = list(filter(lambda heroic_game: (heroic_game.is_installed and len(heroic_game.runner) > 0 and not heroic_game.is_dlc), get_heroic_game_list(heroic_dir)))
+        self.games: List[HeroicGame] = list(filter(lambda heroic_game: (heroic_game.is_installed and len(heroic_game.runner) > 0 and not heroic_game.is_dlc), get_heroic_game_list(heroic_dir)))
 
         self.ui.tableGames.setRowCount(len(self.games))
 
@@ -238,8 +238,8 @@ class PupguiGameListDialog(QObject):
             title_item.setToolTip(title_tooltip)
 
             compat_item = QTableWidgetItem()
-            # If no wine_info, assume this is a native game -- May be more reliable than checking a platform string
-            if game.wine_info.get('name', ''):
+            # Wine games
+            if game.platform.lower() == 'windows':
                 compat_item_text = game.wine_info.get('name', '').split('-', 1)[1].strip()
                 compat_tool_bin_path = game.wine_info.get('bin', '')
 
@@ -251,15 +251,20 @@ class PupguiGameListDialog(QObject):
                     compat_item.setData(Qt.UserRole, lambda path: os.system(f'xdg-open "{compat_tool_folder}"'))
                 compat_tool_tooltip += self.tr('\nType: {wine_type}').format(wine_type=game.wine_info.get("type", "").capitalize()) if game.wine_info.get('type', '') else ''
             else:
-                compat_item_text = self.tr('Native')
-                compat_tool_tooltip = self.tr('Type: Native')
+                # Linux/Browser games
+                compat_item_text = self.tr(game.platform)
+                compat_tool_tooltip = self.tr('Type: {PLATFORM}').format(PLATFORM=game.platform)
 
             compat_item.setText(compat_item_text)
             compat_item.setToolTip(compat_tool_tooltip)
             compat_item.setTextAlignment(Qt.AlignCenter)
 
             install_path_item = QTableWidgetItem(game.install_path)
-            self.set_item_data_directory(install_path_item, game.install_path)
+            if game.platform.lower() == 'browser':
+                # Browser game paths are browserUrl, so the path won't exist -- Ignore this and set the tooltip and xdg-open action to open the URL 
+                self.set_item_data_directory(install_path_item, game.install_path, tooltip_exists=self.tr('Double-click to open in browser'), ignore_invalid_path=True)
+            else:
+                self.set_item_data_directory(install_path_item, game.install_path)
             
             runner_item = QTableWidgetItem(game.runner)
             runner_item.setTextAlignment(Qt.AlignCenter)
@@ -347,7 +352,8 @@ class PupguiGameListDialog(QObject):
 
     def set_item_data_directory(self, item: QTableWidgetItem, path: str,
                                     tooltip_exists: str = 'Double click to browse...',
-                                    tooltip_invalid: str = 'Install location does not exist!'):
+                                    tooltip_invalid: str = 'Install location does not exist!',
+                                    ignore_invalid_path: bool = False):
         """ Set the Qt.UserRole data for a QTableWidgetItem to a lambda which uses xdg-open to open a given path, if it exists. """
 
         # (hacky way to) show default tooltips in parameters while allowing translation (make sure they match the default parameters)
@@ -356,7 +362,7 @@ class PupguiGameListDialog(QObject):
         if tooltip_invalid == 'Install location does not exist!':
             tooltip_invalid = self.tr('Install location does not exist!')
 
-        if os.path.isdir(path):
+        if os.path.isdir(path) or ignore_invalid_path:
             item.setToolTip(tooltip_exists)
             item.setData(Qt.UserRole, lambda path: os.system(f'xdg-open "{path}"'))
         else:


### PR DESCRIPTION
## Overview
Heroic v2.9.0 added a feature for adding Browser games to your library. This works by giving the game a name, path, and a URL. Heroic will then run this game in its Browser, which is Chromium (with a spoofed browser agent to act like Google Chrome afaik).

ProtonUp-Qt can display these, but this PR fixes up their entries to make them a bit more useful.

Main branch:
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/4229028f-8802-4e94-86c7-b132176a024d)

This PR:
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/e6bbcd5f-af7d-4faf-9830-a3e2209a5144)

## Background
Browser games are treated internally like sideloaded apps, with their information stored in the `sideload_apps.json` file. They also still have an `app_name`. So there were no code changes required to get Browser games to display. Right now, ProtonUp-Qt _will_ display these browser games in the Heroic Games List, but with a couple of problems:
1. Compatibility Tool is listed as "Not Found", because Browser games actually have a Wine field but the Wine name in the Heroic JSON file is "Not Found" - Not sure why they store it like this, because there is no option (currently at least) to run a game in a browser with Wine or anything like that.
2. Install Location is listed as "`.`", because sideload apps have a `folder_name` key to store their installation folder name, that _is actually_ what the `folder_name` is in the JSON.

So the problems here are actually that ProtonUp-Qt is reading the information properly for Browser games, but that the information is not really useful for Browser games.

## Implementation
To make Browser game listings a bit more useful, a few changes were made:

### Properly Display Browser "Compatibility Tool" Name
Check on the `HeroicGame.platform` string when setting the "Compatibility Tool" name. This was not done initially out of concern that it may not be as reliable as checking for Wine information to differentiate between a Windows and native title. But now that we have Browser titles, I think it's safe to check on the platform string.

When we're using Windows we still build the compatibility tool string the same as normal, but in the else block, instead of hardcoding to "Native" we now set the `game.platform` string. This does mean that native titles will say "Linux" instead of "Native" now, but I don't think that's a big problem, and it saves on conditional logic to check "if platform is linux then set string and tooltip to Native". Doing it with the platform string is much more straightforward.

### Use `browserUrl` for the Install Location
The Install Location column has a bit of logic to try its best to find the Heroic installation path if we can't find it. But for Browser games we know this won't be set at all, so instead, when we're building the list of Heroic games with `get_heroic_game_list`, we check for `browserUrl` (set properly for Browser games and non-existent for all other sideload apps) before we check for `folder_name` (set to "`.`" for browser games and because it has a value, it would be truthy, so the check for `browserUrl` has to go before it, since that will be falsey for non-Browser sideload games).

### Double-Click action for Browser Games
When double clicking the "Install Location" for sideload/gog/legendary games, if the path exists, it will be opened in the file browser with `xdg-open`. But since the Browser URL set above doesn't fails at the `os.path.isdir` check, double-clicking would do nothing because we don't set the data on the list item.

To fix this, I added an optional parameter `ignore_invalid_path` to `set_item_data_directory` which is used to call `setData` on the list item passed to it even if the path doesn't exist. The default value for this parameter is `False`.

### Amending Tooltips
For the Compatibility Tool, as I hinted at earlier, the tooltip has been adjusted from saying `Platform: Native` to `Platform: {game.platform}`. It uses the platform string instead of being hardcoded.

For the Install Location, the tooltip was updated from saying `Double-click to browse` to `Double-click to open in browser`, to more accurately reflect what it does.

<hr>

That sums up the changes and rationale here. All feedback is welcome on this :-) 

Thanks! 