### PR TITLE
D8VK: Fix fetching new artifacts

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_d8vk.py
+++ b/pupgui2/resources/ctmods/ctmod_d8vk.py
@@ -80,7 +80,7 @@ class CtInstaller(QObject):
         Return Type: str
         """
         for artifact in self.rs.get(self.CT_URL + '?per_page=100').json()["artifacts"]:
-            if artifact['workflow_run']['head_sha'][:len(commit)] == commit and 'd8vk' in artifact['name']:  # Only get D8VK artifacts and not DXVK native artifacts
+            if artifact['workflow_run']['head_sha'][:len(commit)] == commit and any(dvk in artifact['name'] for dvk in ['dxvk', 'd8vk']):
                 artifact['workflow_run']['head_sha'] = commit
                 return artifact
         return None

--- a/pupgui2/resources/ctmods/ctmod_d8vk.py
+++ b/pupgui2/resources/ctmods/ctmod_d8vk.py
@@ -79,11 +79,16 @@ class CtInstaller(QObject):
         Get artifact from commit
         Return Type: str
         """
+        dxvk_found = None
         for artifact in self.rs.get(self.CT_URL + '?per_page=100').json()["artifacts"]:
             if artifact['workflow_run']['head_sha'][:len(commit)] == commit and any(dvk in artifact['name'] for dvk in ['dxvk', 'd8vk']):
                 artifact['workflow_run']['head_sha'] = commit
-                return artifact
-        return None
+                if 'd8vk' in artifact['name']:
+                    return artifact  # "d8vk" in the name -> old naming scheme -> return the d8vk artifact
+                else:
+                    dxvk_found = artifact
+        # found one artifact with "dxvk" in the name, but didn't find a "d8vk" artifact -> new naming scheme -> return the dxvk artifact
+        return dxvk_found
 
     def __fetch_github_data(self, tag):
         """


### PR DESCRIPTION
D8VK has changed how it builds and thus names artifacts, and so newer builds are not being detected with ProtonUp-Qt. This PR fixes the issue and allows newer D8VK builds to download again by checking on the new `dxvk` artifact name, whereas previously we checked on `d8vk`.

## Background
Originally, D8VK builds packaged two artifacts:
- `d8vk-<branchname>-hash`, which represents the actual D8VK build and is only a few MBs. This has always been the artifact that we wanted, as this is has the D8VK DLLs for use with Proton.
- `dxvk-<branchname>-hash`, which represents the DXVK native builds introduced with DXVK 2.0. This contains Linux libraries which can be used by game developers to package DXVK (or in this case, D8VK) as a native library for native Linux games (for an example of DXVK doing this, Portal with `-gamepadui` uses DXVK to translate DX9 to Vulkan).

The D8VK and DXVK native builds have different folder structures, and DXVK native builds would not be applicable when using Proton, so we made sure to download the D8VK artifact by checking the artifact name. If this sounds familiar, when DXVK 2.0 came out, #140 was needed to make sure we downloaded the correct DXVK artifact and not the DXVK native one. So the rationale around checking the branch name with D8VK made sense at the time.

You can see an example of how D8VK builds used to look here: https://github.com/AlpyneDreams/d8vk/actions/runs/5445176587 - You can see that they have the two mentioned artifacts.

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/a71d6074-5fbe-4e81-8ad8-34622cf03061)

All this to say, in short, currently on main we're checking for artifacts that have `d8vk` in them.

## Problem
Recently, D8VK changed its build system and now only packages one artifact. This artifact contains both the native Linux libraries *and* the Windows DLLs for Proton. This artifact uses the name `dxvk-<branch>-hash`. But because ProtonUp-Qt is looking for the old `d8vk` artifact names, when it checks newer builds, it can't find any artifacts with that name and so it doesn't download any artifacts because it doesn't think there are any valid ones available.

## Solution
The fix for this is to check for both `dxvk` and `d8vk` (for legacy artifacts and backwards compatibility). This is probably not wholly necessary because going forward all builds will likely just use `dxvk`, but this should also cover us in case they switch back to a different archive name (imo it makes a bit more sense to name the artifacts `d8vk` and I could see the name changing, but that's just my opinion :wink:).

Checking for `dxvk` now as well fixes the issue and allows D8VK builds to download successfully. Woohoo! You can see an example of a new D8VK build here: https://github.com/AlpyneDreams/d8vk/actions/runs/5456804847

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/6c132b44-d989-419b-a802-fe9ed8efd76d)

The D8VK folder structure now looks like this:

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/9512bd8b-9240-4f06-bc48-c7cf299111c8)

Previously, the `usr` folder was in the separate artifact (this is why #140 broke DXVK, the folder structure and such was incorrect). This would've been in the `dxvk` artifact, and the `x32` folder was part of a separate `d8vk` artifact.

Now, we only have one artifact which contains both builds of D8VK.

<hr>

Hope that makes it clear why this change is necessary :-) I came across this because I was trying to download D8VK with ProtonUp-Qt and was very confused as to why it wasn't working, as it had been working recently. Dang build system changes! :smile: 