### PR TITLE
Fixed non steam game names not shown

### DIFF
--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -127,8 +127,10 @@ def get_steam_shortcuts_list(steam_config_folder: str, compat_tools: dict=None) 
                 app.app_id = appid
                 app.shortcut_id = sid
                 app.shortcut_path = svalue.get('StartDir')
-                app.app_type='game'
+                app.app_type = 'game'
                 app.game_name = svalue.get('AppName')
+                if app.game_name == None or app.game_name == '':
+                    app.game_name = svalue.get('appname')
                 if ct := compat_tools.get(str(appid)):
                     app.compat_tool = ct.get('name')
                 apps.append(app)

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -128,9 +128,7 @@ def get_steam_shortcuts_list(steam_config_folder: str, compat_tools: dict=None) 
                 app.shortcut_id = sid
                 app.shortcut_path = svalue.get('StartDir')
                 app.app_type = 'game'
-                app.game_name = svalue.get('AppName')
-                if app.game_name == None or app.game_name == '':
-                    app.game_name = svalue.get('appname')
+                app.game_name = svalue.get('AppName') or svalue.get('appname')
                 if ct := compat_tools.get(str(appid)):
                     app.compat_tool = ct.get('name')
                 apps.append(app)


### PR DESCRIPTION
For some reason, my steam deck has AppName as lowercase in the .steam/steam/userdata/xxxxx/config/shortcuts.vdf
This is a quick fix that supports both uppercase and lowercase variations.