### PR TITLE
Bump version to 2.8.2

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -22,7 +22,7 @@ AppDir:
     id: net.davidotek.pupgui2
     name: ProtonUp-Qt
     icon: net.davidotek.pupgui2
-    version: 2.8.1
+    version: 2.8.2
     exec: usr/bin/python3
     exec_args: "-m pupgui2 $@"
 

--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -6,7 +6,7 @@ from PySide6.QtGui import QColor, QPalette
 
 
 APP_NAME = 'ProtonUp-Qt'
-APP_VERSION = '2.8.1'
+APP_VERSION = '2.8.2'
 APP_ID = 'net.davidotek.pupgui2'
 APP_ICON_FILE = os.path.join(xdg_config_home, 'pupgui/appicon256.png')
 APP_GHAPI_URL = 'https://api.github.com/repos/Davidotek/ProtonUp-qt/releases'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ProtonUp-Qt
-version = 2.8.1
+version = 2.8.2
 description = Install Wine- and Proton-based compatibility tools
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/share/metainfo/net.davidotek.pupgui2.appdata.xml
+++ b/share/metainfo/net.davidotek.pupgui2.appdata.xml
@@ -69,11 +69,22 @@
   <content_rating type="oars-1.0" />
 
   <releases>
+    <release version="2.8.2" date="2023-08-06">
+      <description>
+        <p>Changes/Improvements:</p>
+        <ul>
+          <li>Heroic: Added support for DXVK and vkd3d</li>
+          <li>Heroic: Display Amazon Games and Browser Games correctly</li>
+          <li>Fix regression where Proton-Tkg could not be extracted</li>
+        </ul>
+        <p>Various improvements and bug fixes. See GitHub for more details.<br/>Also thanks to sonic2kk and the other contributers!</p>
+      </description>
+    </release>
     <release version="2.8.1" date="2023-07-04">
       <description>
         <p>Changes:</p>
         <ul>
-          <li>Added Heroic support for Wine-GE, Proton-GE and D8VK</li>
+          <li>Added Heroic support for Wine-Tkg, Proton-Tkg and D8VK</li>
           <li>Added Italian translations</li>
         </ul>
         <p>Improvements:</p>


### PR DESCRIPTION
Release includes:
- Fix Tkg Tar file extraction regression from 2.8.1 #267 (already included in Flatpak, not yet in official release https://github.com/DavidoTek/ProtonUp-Qt/issues/261#issuecomment-1666538892)
- DXVK for Heroic #263 
- vkd3d for Heroic #268 
- Amazon Games for Heroic #271 
- Browser Games for Heroic #272 

I will see if there is anything else we can include, otherwise I will merge this soon.