### PR TITLE
Removed translatable check on strings

### DIFF
--- a/pupgui2/resources/ui/pupgui2_mainwindow.ui
+++ b/pupgui2/resources/ui/pupgui2_mainwindow.ui
@@ -72,7 +72,7 @@
       <item>
        <widget class="QLabel" name="txtActiveDownloads">
         <property name="text">
-         <string>0</string>
+         <string notr="true">0</string>
         </property>
        </widget>
       </item>
@@ -89,7 +89,7 @@
          <string>Add Custom Install Directory...</string>
         </property>
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
I noticed there were strings that didn't need to be translated in the .ts files.
I didn't regenerate the .py file from the .ui file because, while not knowing how to name it, 
I don't want to mess up the project naming scheme your are currently using.