### PR TITLE
steamutil: Don't parse Proton Next as a game

### DIFF
--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -255,14 +255,6 @@ def update_steamapp_info(steam_config_folder: str, steamapp_list: List[SteamApp]
                     a.game_name = steam_app.get('data', {}).get('appinfo', {}).get('common', {}).get('name', '')
                     a.deck_compatibility = steam_app.get('data', {}).get('appinfo', {}).get('common', {}).get('steam_deck_compatibility', {})
 
-                    # Skip Proton Next, which exists but is not selectable in the Steam Client when there is no valid Proton Next version in testing
-                    # In this case, it is not available in the Steam Play manifest parsed by _get_steam_ctool_info (it is listed as an alias for the latest stable Proton)
-                    #
-                    # If there is ever a case where Proton Next is in use, it should be found by _get_steam_ctool_info and skipped properly as it will be in the ctool_map,
-                    # so this check is only for when Proton Next is installed but not available as a compatibility tool
-                    if a.app_id == 2230260:
-                        continue
-
                     if a.game_name.startswith('Proton') and a.game_name.endswith('Runtime'):
                         a.app_type = 'acruntime'
                     elif 'Steam Linux Runtime' in a.game_name:
@@ -273,6 +265,8 @@ def update_steamapp_info(steam_config_folder: str, steamapp_list: List[SteamApp]
                         ct = ctool_map.get(steam_app.get('appid'))
                         a.ctool_name = ct.get('name')
                         a.ctool_from_oslist = ct.get('from_oslist')
+                    elif a.app_id == 2230260:  # see https://github.com/DavidoTek/ProtonUp-Qt/pull/280
+                        a.app_type = 'useless-proton-next'
                     else:
                         a.app_type = 'game'
                     cnt += 1

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -254,6 +254,15 @@ def update_steamapp_info(steam_config_folder: str, steamapp_list: List[SteamApp]
                 if a := sapps.get(appid_str):
                     a.game_name = steam_app.get('data', {}).get('appinfo', {}).get('common', {}).get('name', '')
                     a.deck_compatibility = steam_app.get('data', {}).get('appinfo', {}).get('common', {}).get('steam_deck_compatibility', {})
+
+                    # Skip Proton Next, which exists but is not selectable in the Steam Client when there is no valid Proton Next version in testing
+                    # In this case, it is not available in the Steam Play manifest parsed by _get_steam_ctool_info (it is listed as an alias for the latest stable Proton)
+                    #
+                    # If there is ever a case where Proton Next is in use, it should be found by _get_steam_ctool_info and skipped properly as it will be in the ctool_map,
+                    # so this check is only for when Proton Next is installed but not available as a compatibility tool
+                    if a.app_id == 2230260:
+                        continue
+
                     if a.game_name.startswith('Proton') and a.game_name.endswith('Runtime'):
                         a.app_type = 'acruntime'
                     elif 'Steam Linux Runtime' in a.game_name:


### PR DESCRIPTION
Fixes an issue where Proton Next shows up as a game in the Games List, but it is not actually a game. We do this by explicitly skipping its AppID in [`update_steamapp_info`](https://github.com/DavidoTek/ProtonUp-Qt/blob/ac97072a0b42fd5f892be2d320819235b14a5921/pupgui2/steamutil.py#L238), should it be missing from `ctool_map`. It will only be missing from `ctool_map` if there is no current Proton Next version in testing.

## Background
Occasionally, Valve will release a "Proton Next" build, which essentially serves as a Release Candidate build of Proton. Despite what the name might imply, this is only used for a Release Candidate and not as a general early-access release, that is more along the lines of Proton Experimental (or its various Bleeding Edge branch betas) or Proton Hotfix for specific game patches.

Proton Next is available to download from the Steam Client, but it is never to my knowledge set as a recommended Proton version by Valve, since it is meant purely for testing an upcoming release.

Proton Next releases, as far as I can recall and find in searching, are only pushed as a Release Candidate for an upcoming Proton release. For example, Proton Next may be a release candidate for Proton 9 in the future. Once Proton 9 is out, Proton Next is still available and remains installed, but it is no longer available to be selected from the Steam Client. The Steam Play manifest will be updated to list Proton Next as an alias for the current stable Proton version. The aliases for Proton 8.0, the current stable release, are `'proton-next,proton_next,proton-8.0-1,proton-8.0-2,proton-8.0-3,proton-stable'`. If there was a new Proton Next released tomorrow, likely it would have its own manifest entry and would no longer be listed as an alias for the current stable Proton.

When there is no Proton Next version in testing, there is no entry for it in the Steam Play manifest, it is listed as an alias of the latest Proton stable (likely to point anything previously using Proton Next to the newest stable), and it is no longer available to be selected as a compatibility tool from the Steam Client.

I think this behaviour makes sense, as there would never be a need to use Proton Next once that Proton version is out. The previous Proton version, the current stable Proton version, or Proton Experimental should cover virtually all bases. If it happens to miss any, a custom Proton flavour should be able to handle it (there's a neat tool called ProtonUp-Qt that lets you download those :wink:). 

Here is an [article from GamingOnLinux](https://www.gamingonlinux.com/2022/11/valve-puts-up-proton-next-to-provide-easier-testing-of-future-upgrades/) detailing Proton Next a little bit more.

## Problem
Right now, I have Proton Next installed. However, there is no Proton Next version in testing right now. According to the Proton Next files, they were created on the 4th of February 2023, so they are old at this point.

In the ProtonUp-Qt game list, Proton Next shows up as a game. This is incorrect as it is not a game, and the reason it shows up is because it is not caught by ProtonUp-Qt's [`_get_steam_ctool_info`](https://github.com/DavidoTek/ProtonUp-Qt/blob/ac97072a0b42fd5f892be2d320819235b14a5921/pupgui2/steamutil.py#L205). The reason for this is that Proton Next is currently not listed in the Steam Play manifests that this function parses for, because it is not available as a usable compatibility tool, since the Proton version that this was a release candidate for has long since become the current stable Proton.

## Solution
In [`update_steamapp_info`](https://github.com/DavidoTek/ProtonUp-Qt/blob/ac97072a0b42fd5f892be2d320819235b14a5921/pupgui2/steamutil.py#L238), we loop through the list of Steam Apps and set various values such as marking tools as runtimes, as well as removing Steam's own compatibility tools from the Steam Play manifests (fetched from `_get_steam_ctool_info`), since these are not games. However Proton Next is missing from the `ctool_map` as it is not found by `_get_steam_ctool_info` on account of it not being present in the Steam Play manifests.

The solution I chose for this is to simply check for the Proton Next AppID in `update_steamapp_info` and skip over it in the loop. This should cover both scenarios: 
1. When Proton Next is not available as a valid Proton version (current behaviour at time of writing), it will not be caught in the functions `ctool_map`, so the `steam_app.get('appid') in ctool_map` check in this function will not catch Proton Next and it will end up filtering down through as a game. So when Proton Next is not available as a compatibility tool, we will not incorrectly flag it as a game.
    - When this behaviour is true, Proton Next is **not** available to use a compatibility tool from the Steam Client, so there is no need for ProtonUp-Qt to try and catch it.
3. When a new Proton Next version is released by Valve (perhaps for e.g. Proton 9), it should be listed in the Steam Play manifest as a separate entry, and so ProtonUp-Qt will catch it in `ctool_list` in the `update_steamapp_info` function. The skip will still be called but it will have no effect, and the `steam_app.get('appid') in ctool_map` will catch Proton Next as a valid compatibility tool because it will be available in `ctool_map` this time. So this skip should pose no risk to catching Proton Next when Valve release a version for testing.
    - When a new Proton Next version is available for testing, it will be selectable as a compatibility tool from the Steam Client.

When a new Proton Next version is available to test, the AppID will not change, it will simply be an update to Proton Next - There would not be "Proton Next - Proton 9.0" or anything like that, for example.

<hr>

The existing behaviour in ProtonUp-Qt should be able to handle Proton Next when a version is actually available to test, this PR just accounts for cases when Proton Next is installed but is simply aliased to the current stable Proton (i.e. there is no Proton Next version to test, it is superseded by the next stable.

Hope this all makes sense :-) Thanks!