### PR TITLE
constants: store HOME_DIR instead of calling os.path.expanduser

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -20,6 +20,7 @@ BUILD_INFO = 'built from source'
 
 CONFIG_FILE = os.path.join(xdg_config_home, 'pupgui/config.ini')
 TEMP_DIR = os.path.join(os.getenv('XDG_CACHE_HOME'), 'tmp', 'pupgui2.a70200/') if os.path.exists(os.getenv('XDG_CACHE_HOME', '')) else '/tmp/pupgui2.a70200/'
+HOME_DIR = os.path.expanduser('~')
 
 # support different Steam root directories
 # valid install dir should have config.vdf and libraryfolders.vdf, to ensure it is not an unused folder with correct directory structure
@@ -79,12 +80,12 @@ STEAM_BOXTRON_FLATPAK_APPSTREAM = 'appstream://com.valvesoftware.Steam.Compatibi
 STEAM_PROTONGE_FLATPAK_APPSTREAM = 'appstream://com.valvesoftware.Steam.CompatibilityTool.Proton-GE'
 STEAM_STL_FLATPAK_APPSTREAM = 'appstream://com.valvesoftware.Steam.Utility.steamtinkerlaunch'
 
-STEAM_STL_INSTALL_PATH = os.path.join(os.path.expanduser('~'), 'stl')
-STEAM_STL_CONFIG_PATH = os.path.join(os.path.expanduser('~'), '.config', 'steamtinkerlaunch')
-STEAM_STL_CACHE_PATH = os.path.join(os.path.expanduser('~'), '.cache', 'steamtinkerlaunch')
-STEAM_STL_DATA_PATH = os.path.join(os.path.expanduser('~'), '.local', 'share', 'steamtinkerlaunch')
+STEAM_STL_INSTALL_PATH = os.path.join(HOME_DIR, 'stl')
+STEAM_STL_CONFIG_PATH = os.path.join(HOME_DIR, '.config', 'steamtinkerlaunch')
+STEAM_STL_CACHE_PATH = os.path.join(HOME_DIR, '.cache', 'steamtinkerlaunch')
+STEAM_STL_DATA_PATH = os.path.join(HOME_DIR, '.local', 'share', 'steamtinkerlaunch')
 STEAM_STL_SHELL_FILES = [ '.bashrc', '.zshrc', '.kshrc' ]
-STEAM_STL_FISH_VARIABLES = os.path.join(os.path.expanduser('~'), '.config/fish/fish_variables')
+STEAM_STL_FISH_VARIABLES = os.path.join(HOME_DIR, '.config/fish/fish_variables')
 
 LUTRIS_WEB_URL = 'https://lutris.net/games/'
 EPIC_STORE_URL = 'https://store.epicgames.com/p/'

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import QFileDialog, QLineEdit
 from PySide6.QtUiTools import QUiLoader
 
 from pupgui2.util import config_custom_install_location, get_install_location_from_directory_name, get_dict_key_from_value, get_combobox_index_by_value
+from pupgui2.constants import HOME_DIR
 
 
 class PupguiCustomInstallDirectoryDialog(QObject):
@@ -83,7 +84,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         dialog.setFileMode(QFileDialog.Directory)
         dialog.setOption(QFileDialog.ShowDirsOnly)
         dialog.setWindowTitle(self.tr('Select Custom Install Directory — ProtonUp-Qt'))
-        dialog.setDirectory(os.path.expanduser('~'))
+        dialog.setDirectory(HOME_DIR)
         dialog.fileSelected.connect(self.ui.txtInstallDirectory.setText)
         dialog.open()
 

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -370,7 +370,7 @@ class CtInstaller(QObject):
                 pup_stl_path_date = f'# Added by ProtonUp-Qt on {datetime.datetime.now().strftime("%d-%m-%Y %H:%M:%S")}'
                 pup_stl_path_line = f'if [ -d "{stl_path}" ]; then export PATH="$PATH:{stl_path}"; fi'
                 present_shell_files = [
-                    os.path.join(os.path.expanduser('~'), f) for f in os.listdir(os.path.expanduser('~')) if os.path.isfile(os.path.join(os.path.expanduser('~'), f)) and f in constants.STEAM_STL_SHELL_FILES
+                    os.path.join(constants.HOME_DIR, f) for f in os.listdir(constants.HOME_DIR) if os.path.isfile(os.path.join(constants.HOME_DIR, f)) and f in constants.STEAM_STL_SHELL_FILES
                 ]
                 if os.path.exists(constants.STEAM_STL_FISH_VARIABLES):
                     present_shell_files.append(constants.STEAM_STL_FISH_VARIABLES)
@@ -398,7 +398,7 @@ class CtInstaller(QObject):
             print('Adding SteamTinkerLaunch as a compatibility tool...')
             subprocess.run(stl_proc_prefix + ['./steamtinkerlaunch', 'compat', 'add'])
 
-            os.chdir(os.path.expanduser('~'))
+            os.chdir(constants.HOME_DIR)
 
         protondir = os.path.join(install_dir, 'SteamTinkerLaunch')
 

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -14,7 +14,7 @@ from PySide6.QtWidgets import QMessageBox, QApplication
 
 from pupgui2.constants import APP_NAME, APP_ID, APP_ICON_FILE
 from pupgui2.constants import LOCAL_AWACY_GAME_LIST, PROTONDB_API_URL
-from pupgui2.constants import STEAM_STL_INSTALL_PATH, STEAM_STL_CONFIG_PATH, STEAM_STL_SHELL_FILES, STEAM_STL_FISH_VARIABLES
+from pupgui2.constants import STEAM_STL_INSTALL_PATH, STEAM_STL_CONFIG_PATH, STEAM_STL_SHELL_FILES, STEAM_STL_FISH_VARIABLES, HOME_DIR
 from pupgui2.datastructures import SteamApp, AWACYStatus, BasicCompatTool, CTType
 
 
@@ -421,7 +421,7 @@ def remove_steamtinkerlaunch(compat_folder='', remove_config=True, ctmod_object=
     """
 
     try:
-        os.chdir(os.path.expanduser('~'))
+        os.chdir(HOME_DIR)
 
         # If the Steam Deck/ProtonUp-Qt installation path doesn't exist
         # Adding `prefix` to path to be especially sure the user didn't just make an `stl` folder
@@ -475,7 +475,7 @@ def remove_steamtinkerlaunch(compat_folder='', remove_config=True, ctmod_object=
         # Works by getting all the lines in all the hardcoded Shell files that we write out to during installation and
         # and filtering out any line(s) that reference ProtonUp-Qt, then it writes that updated file content back out to the Shell file
         present_shell_files = [
-            os.path.join(os.path.expanduser('~'), f) for f in os.listdir(os.path.expanduser('~')) if os.path.isfile(os.path.join(os.path.expanduser('~'), f)) and f in STEAM_STL_SHELL_FILES
+            os.path.join(HOME_DIR, f) for f in os.listdir(HOME_DIR) if os.path.isfile(os.path.join(HOME_DIR, f)) and f in STEAM_STL_SHELL_FILES
         ]
         if os.path.exists(STEAM_STL_FISH_VARIABLES) or shutil.which('fish'):
             present_shell_files.append(STEAM_STL_FISH_VARIABLES)


### PR DESCRIPTION
Noticed this when poking my nose around the codebase. I'm sure there are other examples but this is just a very minor improvement imo. Instead of calling `os.path.expanduser('~')` to get the home directory, we store it as a constant, the same way we store some other constant paths (like the configpath, or temp dir path).

I originally planned to include a change from using `os.getenv('XDG_CACHE_HOME')` to using `xdg.BaseDirectory.xdg_cache_home` but this would introduce a behaviour change, [since PyXDG falls back to `~/.cache`](https://pyxdg.readthedocs.io/en/latest/basedirectory.html#xdg.BaseDirectory.xdg_cache_home).

This doesn't offer any speedups but looks cleaner than using `os.path.expanduser('~')` imo (and might help readibility).

`os.path.expanduser` is used in other places, mainly to expand install and config folders to ensure we have the full path, but I didn't touch those in this PR. :slightly_smiling_face: 