### PR TITLE
Add a Steam Shortcut Editor

### DIFF
--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -52,7 +52,7 @@ class SteamApp:
     app_id = -1
     libraryfolder_id = -1
     libraryfolder_path = ''
-    shortcut_id = -1  # Will be a number >=0 if it is a Non-Steam shortcut
+    shortcut_id = ''  # dict key must be string (e.g. '1')
     shortcut_startdir = ''
     shortcut_exe = ''
     shortcut_icon = ''
@@ -83,9 +83,6 @@ class SteamApp:
             return self.deck_compatibility.get('configuration').get('recommended_runtime', '')
         except:
             return ''
-
-    def get_shortcut_id_str(self) -> str:
-        return str(self.shortcut_id)
 
 
 class BasicCompatTool:

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -48,6 +48,20 @@ class MsgBoxResult:
     is_checked : bool = None
 
 
+class SteamUser:
+    long_id = -1
+    account_name = ''
+    persona_name = ''
+    most_recent = False
+    timestamp = -1
+
+    def get_short_id(self) -> int:
+        """
+        Returns the shortened Steam user id
+        """
+        return self.long_id & 0xFFFFFFFF
+
+
 class SteamApp:
     app_id = -1
     libraryfolder_id = -1

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -54,6 +54,9 @@ class SteamApp:
     libraryfolder_path = ''
     shortcut_id = -1  # Will be a number >=0 if it is a Non-Steam shortcut
     shortcut_path = ''
+    shortcut_exe = ''
+    shortcut_icon = ''
+    shortcut_user = ''
     game_name = ''
     compat_tool = ''
     app_type = ''

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -53,7 +53,7 @@ class SteamApp:
     libraryfolder_id = -1
     libraryfolder_path = ''
     shortcut_id = -1  # Will be a number >=0 if it is a Non-Steam shortcut
-    shortcut_path = ''
+    shortcut_startdir = ''
     shortcut_exe = ''
     shortcut_icon = ''
     shortcut_user = ''

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -54,6 +54,8 @@ class PupguiGameListDialog(QObject):
         elif is_heroic_launcher(self.launcher):
             self.setup_heroic_list_ui()
 
+        self.ui.btnShortcutEditor.setVisible(self.launcher == 'steam')
+
         self.ui.btnSearch.setVisible(False)
         self.ui.searchBox.setVisible(False)  # Hide searchbox by default
 
@@ -86,8 +88,6 @@ class PupguiGameListDialog(QObject):
         self.ui.tableGames.setColumnWidth(0, 300)
         self.ui.tableGames.setColumnWidth(3, 70)
         self.ui.tableGames.setColumnWidth(4, 70)
-
-        self.ui.btnShortcutEditor.setVisible(True)
     
     def setup_lutris_list_ui(self):
         self.ui.tableGames.setHorizontalHeaderLabels([self.tr('Game'), self.tr('Runner'), self.tr('Install Location'), self.tr('Installed Date'), ''])
@@ -99,8 +99,6 @@ class PupguiGameListDialog(QObject):
         self.ui.tableGames.setColumnWidth(3, 30)
         self.ui.tableGames.setColumnHidden(4, True)
 
-        self.ui.btnShortcutEditor.setVisible(False)
-
     def setup_heroic_list_ui(self):
         self.ui.tableGames.setHorizontalHeaderLabels([self.tr('Game'), self.tr('Compatibility Tool'), self.tr('Install Location'), self.tr('Runner'), ''])
         self.update_game_list_heroic()
@@ -110,8 +108,6 @@ class PupguiGameListDialog(QObject):
         self.ui.tableGames.setColumnWidth(2, 250)
         self.ui.tableGames.setColumnWidth(3, 40)
         self.ui.tableGames.setColumnHidden(4, True)
-
-        self.ui.btnShortcutEditor.setVisible(False)
 
     def update_game_list_steam(self, cached=True):
         """ update the game list for the Steam launcher """

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -307,7 +307,7 @@ class PupguiGameListDialog(QObject):
 
     def btn_shortcut_editor_clicked(self):
         self.ui.close()
-        PupguiShortcutDialog(self.install_loc.get('vdf_dir'), self.ui)
+        PupguiShortcutDialog(self.install_loc.get('vdf_dir'), self.game_property_changed, self.ui)
 
     def search_gamelist_games(self, text):
         for row in range(self.ui.tableGames.rowCount()):

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -12,6 +12,7 @@ from PySide6.QtUiTools import QUiLoader
 from pupgui2.constants import PROTONDB_COLORS, STEAM_APP_PAGE_URL, AWACY_WEB_URL, PROTONDB_APP_PAGE_URL, LUTRIS_WEB_URL
 from pupgui2.datastructures import AWACYStatus, SteamApp, SteamDeckCompatEnum, LutrisGame, HeroicGame
 from pupgui2.lutrisutil import get_lutris_game_list
+from pupgui2.pupgui2shortcutdialog import PupguiShortcutDialog
 from pupgui2.steamutil import steam_update_ctools, get_steam_game_list
 from pupgui2.steamutil import is_steam_running, get_steam_ctool_list
 from pupgui2.steamutil import get_protondb_status
@@ -66,6 +67,7 @@ class PupguiGameListDialog(QObject):
         self.ui.btnApply.clicked.connect(self.btn_apply_clicked)
         self.ui.btnSearch.clicked.connect(self.btn_search_clicked)
         self.ui.btnRefreshGames.clicked.connect(self.btn_refresh_games_clicked)
+        self.ui.btnShortcutEditor.clicked.connect(self.btn_shortcut_editor_clicked)
         self.ui.searchBox.textChanged.connect(self.search_gamelist_games)
 
         # Hide Search button and disable shortcut if no games
@@ -84,6 +86,8 @@ class PupguiGameListDialog(QObject):
         self.ui.tableGames.setColumnWidth(0, 300)
         self.ui.tableGames.setColumnWidth(3, 70)
         self.ui.tableGames.setColumnWidth(4, 70)
+
+        self.ui.btnShortcutEditor.setVisible(True)
     
     def setup_lutris_list_ui(self):
         self.ui.tableGames.setHorizontalHeaderLabels([self.tr('Game'), self.tr('Runner'), self.tr('Install Location'), self.tr('Installed Date'), ''])
@@ -95,6 +99,8 @@ class PupguiGameListDialog(QObject):
         self.ui.tableGames.setColumnWidth(3, 30)
         self.ui.tableGames.setColumnHidden(4, True)
 
+        self.ui.btnShortcutEditor.setVisible(False)
+
     def setup_heroic_list_ui(self):
         self.ui.tableGames.setHorizontalHeaderLabels([self.tr('Game'), self.tr('Compatibility Tool'), self.tr('Install Location'), self.tr('Runner'), ''])
         self.update_game_list_heroic()
@@ -104,6 +110,8 @@ class PupguiGameListDialog(QObject):
         self.ui.tableGames.setColumnWidth(2, 250)
         self.ui.tableGames.setColumnWidth(3, 40)
         self.ui.tableGames.setColumnHidden(4, True)
+
+        self.ui.btnShortcutEditor.setVisible(False)
 
     def update_game_list_steam(self, cached=True):
         """ update the game list for the Steam launcher """
@@ -300,6 +308,10 @@ class PupguiGameListDialog(QObject):
         self.ui.searchBox.setFocus()
 
         self.search_gamelist_games(self.ui.searchBox.text() if self.ui.searchBox.isVisible() else '')
+
+    def btn_shortcut_editor_clicked(self):
+        self.ui.close()
+        PupguiShortcutDialog(self.install_loc.get('vdf_dir'), self.ui)
 
     def search_gamelist_games(self, text):
         for row in range(self.ui.tableGames.rowCount()):

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -50,7 +50,7 @@ class PupguiShortcutDialog(QObject):
         for i, shortcut in enumerate(self.shortcuts):
             txt_name = QLineEdit(shortcut.game_name)
             txt_exe = QLineEdit(shortcut.shortcut_exe)
-            txt_path = QLineEdit(shortcut.shortcut_path)
+            txt_path = QLineEdit(shortcut.shortcut_startdir)
             txt_icon = QLineEdit(shortcut.shortcut_icon)
 
             txt_name.editingFinished.connect(lambda i=i: self.txt_changed(i, 0))
@@ -91,9 +91,9 @@ class PupguiShortcutDialog(QObject):
                 self.ui.tableShortcuts.cellWidget(index, col).setText(self.shortcuts[index].shortcut_exe)
         elif col == 2:
             if os.path.exists(text.replace('"', '')):
-                self.shortcuts[index].shortcut_path = text
+                self.shortcuts[index].shortcut_startdir = text
             else:
-                self.ui.tableShortcuts.cellWidget(index, col).setText(self.shortcuts[index].shortcut_path)
+                self.ui.tableShortcuts.cellWidget(index, col).setText(self.shortcuts[index].shortcut_startdir)
         elif col == 3:
             self.shortcuts[index].shortcut_icon = text
 

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -119,11 +119,14 @@ class PupguiShortcutDialog(QObject):
             self.shortcuts[index].shortcut_icon = text
 
     def btn_save_clicked(self):
-        for s in self.shortcuts:
+        # remove all shortcuts that have no name or executable
+        filtered_shortcuts = list(filter(lambda s: s.game_name != '' and s.shortcut_exe != '', self.shortcuts))
+
+        for s in filtered_shortcuts:
             if s.app_id == -1:  # calculate app_id for new shortcuts
                 s.app_id = calc_shortcut_app_id(s.game_name, s.shortcut_exe)
 
-        write_steam_shortcuts_list(self.steam_config_folder, self.shortcuts, self.discarded_shortcuts)
+        write_steam_shortcuts_list(self.steam_config_folder, filtered_shortcuts, self.discarded_shortcuts)
         self.game_property_changed.emit(True)
         self.ui.close()
 

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -1,0 +1,105 @@
+import os
+import pkgutil
+
+from PySide6.QtCore import QObject, Signal, Slot, QDataStream, QByteArray, Qt
+from PySide6.QtWidgets import QLineEdit
+from PySide6.QtUiTools import QUiLoader
+
+from pupgui2.steamutil import get_steam_shortcuts_list, write_steam_shortcuts_list
+
+
+class PupguiShortcutDialog(QObject):
+
+    def __init__(self, steam_config_folder: str, parent=None):
+        """
+        ProtonUp-Qt Dialog for editing Steam shortcuts
+
+        Parameters:
+            steam_config_folder: str
+                Path to Steam config folder (e.g. ~/.steam/root as in install_directory())
+            parent: QObject
+                Parent QObject, e.g. the main window
+        """
+        super(PupguiShortcutDialog, self).__init__(parent)
+
+        self.steam_config_folder = steam_config_folder
+
+        self.shortcuts = []
+
+        self.load_ui()
+        self.setup_ui()
+        self.refresh_shortcut_list()
+        self.ui.show()
+
+    def load_ui(self):
+        data = pkgutil.get_data(__name__, 'resources/ui/pupgui2_shortcutdialog.ui')
+        ui_file = QDataStream(QByteArray(data))
+        self.ui = QUiLoader().load(ui_file.device())
+
+    def setup_ui(self):
+        self.ui.tableShortcuts.setHorizontalHeaderLabels([self.tr('App Name'), self.tr('Executable'), self.tr('Start Directory'), self.tr('Icon')])
+
+        self.ui.btnSave.clicked.connect(self.btn_save_clicked)
+        self.ui.btnClose.clicked.connect(self.btn_close_clicked)
+
+    def refresh_shortcut_list(self):
+        self.shortcuts = get_steam_shortcuts_list(self.steam_config_folder)
+
+        self.ui.tableShortcuts.setRowCount(len(self.shortcuts))
+
+        for i, shortcut in enumerate(self.shortcuts):
+            txt_name = QLineEdit(shortcut.game_name)
+            txt_exe = QLineEdit(shortcut.shortcut_exe)
+            txt_path = QLineEdit(shortcut.shortcut_path)
+            txt_icon = QLineEdit(shortcut.shortcut_icon)
+
+            txt_name.editingFinished.connect(lambda i=i: self.txt_changed(i, 0))
+            txt_exe.editingFinished.connect(lambda i=i: self.txt_changed(i, 1))
+            txt_path.editingFinished.connect(lambda i=i: self.txt_changed(i, 2))
+            txt_icon.editingFinished.connect(lambda i=i: self.txt_changed(i, 3))
+
+            self.ui.tableShortcuts.setCellWidget(i, 0, txt_name)
+            self.ui.tableShortcuts.setCellWidget(i, 1, txt_exe)
+            self.ui.tableShortcuts.setCellWidget(i, 2, txt_path)
+            self.ui.tableShortcuts.setCellWidget(i, 3, txt_icon)
+
+    def txt_changed(self, index: int, col: int) -> None:
+        """
+        Store changes in the table to self.shortcuts
+
+        Parameters:
+            index: int
+                Row index of the table / index of self.shortcuts
+            col: int
+                Column index of the table
+                0 = App Name
+                1 = Executable Path (verified by os.path.exists before saving)
+                2 = Start Directory
+                3 = Icon Path (verified by os.path.exists before saving)
+
+        Returns:
+            None
+        """
+        text = self.ui.tableShortcuts.cellWidget(index, col).text()
+
+        if col == 0:
+            self.shortcuts[index].game_name = text
+        elif col == 1:
+            if os.path.isfile(text.replace('"', '')):
+                self.shortcuts[index].shortcut_exe = text
+            else:
+                self.ui.tableShortcuts.cellWidget(index, col).setText(self.shortcuts[index].shortcut_exe)
+        elif col == 2:
+            if os.path.exists(text.replace('"', '')):
+                self.shortcuts[index].shortcut_path = text
+            else:
+                self.ui.tableShortcuts.cellWidget(index, col).setText(self.shortcuts[index].shortcut_path)
+        elif col == 3:
+            self.shortcuts[index].shortcut_icon = text
+
+    def btn_save_clicked(self):
+        write_steam_shortcuts_list(self.steam_config_folder, self.shortcuts, [])
+        self.ui.close()
+
+    def btn_close_clicked(self):
+        self.ui.close()

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -85,12 +85,22 @@ class PupguiShortcutDialog(QObject):
         if col == 0:
             self.shortcuts[index].game_name = text
         elif col == 1:
-            if os.path.isfile(text.replace('"', '')):
+            if os.path.isfile(text.replace('"', '', 2)):
+                if not text.startswith('"'):
+                    text = '"' + text
+                if not text.endswith('"'):
+                    text = text + '"'
+                self.ui.tableShortcuts.cellWidget(index, col).setText(text)
                 self.shortcuts[index].shortcut_exe = text
             else:
                 self.ui.tableShortcuts.cellWidget(index, col).setText(self.shortcuts[index].shortcut_exe)
         elif col == 2:
-            if os.path.exists(text.replace('"', '')):
+            if os.path.exists(text.replace('"', '', 2)):
+                if not text.startswith('"'):
+                    text = '"' + text
+                if not text.endswith('"'):
+                    text = text + '"'
+                self.ui.tableShortcuts.cellWidget(index, col).setText(text)
                 self.shortcuts[index].shortcut_startdir = text
             else:
                 self.ui.tableShortcuts.cellWidget(index, col).setText(self.shortcuts[index].shortcut_startdir)

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -9,6 +9,7 @@ from PySide6.QtUiTools import QUiLoader
 from pupgui2.datastructures import SteamApp
 from pupgui2.steamutil import calc_shortcut_app_id, get_steam_user_list, determine_most_recent_steam_user
 from pupgui2.steamutil import get_steam_shortcuts_list, write_steam_shortcuts_list
+from pupgui2.util import host_path_exists
 
 
 class PupguiShortcutDialog(QObject):
@@ -83,9 +84,9 @@ class PupguiShortcutDialog(QObject):
             col: int
                 Column index of the table
                 0 = App Name
-                1 = Executable Path (verified by os.path.exists before saving)
-                2 = Start Directory
-                3 = Icon Path (verified by os.path.exists before saving)
+                1 = Executable Path (verified by host_path_exists before saving)
+                2 = Start Directory (verified by host_path_exists before saving)
+                3 = Icon Path
 
         Returns:
             None
@@ -95,7 +96,7 @@ class PupguiShortcutDialog(QObject):
         if col == 0:
             self.shortcuts[index].game_name = text
         elif col == 1:
-            if os.path.isfile(text.replace('"', '', 2)):
+            if host_path_exists(text.replace('"', '', 2), is_file=True):
                 if not text.startswith('"'):
                     text = '"' + text
                 if not text.endswith('"'):
@@ -105,7 +106,7 @@ class PupguiShortcutDialog(QObject):
             else:
                 self.ui.tableShortcuts.cellWidget(index, col).setText(self.shortcuts[index].shortcut_exe)
         elif col == 2:
-            if os.path.exists(text.replace('"', '', 2)):
+            if host_path_exists(text.replace('"', '', 2), is_file=False):
                 if not text.startswith('"'):
                     text = '"' + text
                 if not text.endswith('"'):

--- a/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_gamelistdialog.ui
@@ -100,6 +100,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="btnShortcutEditor">
+       <property name="text">
+        <string>Shortcut Editor</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="btnSearch">
        <property name="text">
         <string>Search</string>

--- a/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
@@ -49,6 +49,13 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QPushButton" name="btnRemove">
+       <property name="text">
+        <string>Remove selected</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>700</width>
+    <height>350</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
@@ -49,7 +49,20 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QPushButton" name="btnAdd">
+       <property name="toolTip">
+        <string>Add a new shortcut. Currently only works if there is at least one other shortcut</string>
+       </property>
+       <property name="text">
+        <string>Add new</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="btnRemove">
+       <property name="toolTip">
+        <string>Click on a row, then click here to remove a shortcut</string>
+       </property>
        <property name="text">
         <string>Remove selected</string>
        </property>
@@ -70,6 +83,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="btnSave">
+       <property name="toolTip">
+        <string>Save changes and delete marked shortcuts</string>
+       </property>
        <property name="text">
         <string>Save</string>
        </property>
@@ -77,6 +93,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="btnClose">
+       <property name="toolTip">
+        <string>Close without saving changes or deleting shortcuts</string>
+       </property>
        <property name="text">
         <string>Close</string>
        </property>

--- a/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="PupguiShortcutDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Steam Shortcut Editor</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="tableShortcuts">
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="columnCount">
+      <number>4</number>
+     </property>
+     <attribute name="horizontalHeaderVisible">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>160</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnSave">
+       <property name="text">
+        <string>Save</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnClose">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
@@ -51,7 +51,7 @@
      <item>
       <widget class="QPushButton" name="btnAdd">
        <property name="toolTip">
-        <string>Add a new shortcut. Currently only works if there is at least one other shortcut</string>
+        <string>Add a new shortcut</string>
        </property>
        <property name="text">
         <string>Add new</string>

--- a/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Dialog</class>
+ <class>PupguiShortcutDialog</class>
  <widget class="QDialog" name="PupguiShortcutDialog">
   <property name="geometry">
    <rect>

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -629,8 +629,7 @@ def write_steam_shortcuts_list(steam_config_folder: str, shortcuts: List[SteamAp
 
         # update/add new shortcuts
         modified_shorcuts = shortcuts_by_user.get(userf, {})
-        for sid in list(modified_shorcuts.keys()) :
-            print(sid, type(sid))
+        for sid in list(modified_shorcuts.keys()):
             shortcut_modified: SteamApp = modified_shorcuts.get(sid)
             if sid in current_shortcuts:  # update existing shortcut
                 svalue_current = current_shortcuts.get(sid)

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -24,14 +24,19 @@ _cached_steam_ctool_id_map = None
 
 def get_steam_vdf_compat_tool_mapping(vdf_file: dict):
 
-    c = vdf_file.get('InstallConfigStore').get('Software')
+    s = vdf_file.get('InstallConfigStore', {}).get('Software', {})
 
     # Sometimes the key is 'Valve', sometimes 'valve', see #226
-    c = c.get('Valve') or c.get('valve')
+    c = s.get('Valve') or s.get('valve')
     if not c:
         raise KeyError('Error! config.vdf InstallConfigStore.Software neither contains key "Valve" nor "valve" - config.vdf file may be invalid!')
 
-    return c.get('Steam').get('CompatToolMapping')
+    m = c.get('Steam', {}).get('CompatToolMapping', {})
+
+    if not m:  # equal to m == {} , may occur after fresh Steam installation
+        print('Warning: CompatToolMapping is empty')
+
+    return m
 
 
 def get_steam_app_list(steam_config_folder: str, cached=False, no_shortcuts=False) -> List[SteamApp]:

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -126,7 +126,7 @@ def get_steam_shortcuts_list(steam_config_folder: str, compat_tools: dict=None) 
                 
                 app.app_id = appid
                 app.shortcut_id = sid
-                app.shortcut_path = svalue.get('StartDir')
+                app.shortcut_startdir = svalue.get('StartDir')
                 app.shortcut_exe = svalue.get('Exe')
                 app.shortcut_icon = svalue.get('icon')
                 app.shortcut_user = userf
@@ -629,14 +629,14 @@ def write_steam_shortcuts_list(steam_config_folder: str, shortcuts: List[SteamAp
             if svalue:  # sid already exists, update shortcut
                 svalue['AppName'] = shortcuts_by_user[userf][sid].game_name
                 svalue['Exe'] = shortcuts_by_user[userf][sid].shortcut_exe
-                svalue['StartDir'] = shortcuts_by_user[userf][sid].shortcut_path
+                svalue['StartDir'] = shortcuts_by_user[userf][sid].shortcut_startdir
                 svalue['icon'] = shortcuts_by_user[userf][sid].shortcut_icon
             else:  # sid doesn't exist, add new shortcut
                 shortcuts_vdf.setdefault('shortcuts', {})[sid] = {
                     'appid': shortcuts_by_user[userf][sid].app_id,
                     'AppName': shortcuts_by_user[userf][sid].game_name,
                     'Exe': shortcuts_by_user[userf][sid].shortcut_exe,
-                    'StartDir': shortcuts_by_user[userf][sid].shortcut_path,
+                    'StartDir': shortcuts_by_user[userf][sid].shortcut_startdir,
                     'icon': shortcuts_by_user[userf][sid].shortcut_icon,
                     'ShortcutPath': '',
                     'LaunchOptions': '',

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -7,6 +7,7 @@ import vdf
 import requests
 import threading
 import pkgutil
+import binascii
 from steam.utils.appcache import parse_appinfo
 
 from PySide6.QtCore import Signal
@@ -669,3 +670,20 @@ def write_steam_shortcuts_list(steam_config_folder: str, shortcuts: List[SteamAp
                 f.write(vdf.binary_dumps(shortcuts_vdf))
         except Exception as e:
             print(f'Error: Could not write_steam_shortcuts_list for user {userf}:', e)
+
+def calc_shortcut_app_id(appname: str, exe: str) -> int:
+    """
+    Calculates an app id for a shortcut based on the app name and executable.
+    Based on https://github.com/SteamGridDB/steam-rom-manager/blob/master/src/lib/helpers/steam/generate-app-id.ts
+
+    Parameters:
+        appname: str
+            game_name of the shortcut
+        exe: str
+            shortcut_exe
+
+    Returns:
+        int
+    """
+    key = exe + appname
+    return (binascii.crc32(key.encode()) | 0x80000000) - 0x100000000

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -730,3 +730,26 @@ def get_steam_user_list(steam_config_folder: str) -> List[SteamUser]:
         print('Error: Could not get a list of Steam users:', e)
 
     return users
+
+
+def determine_most_recent_steam_user(steam_users: List[SteamUser]) -> SteamUser:
+    """
+    Returns the Steam user that was logged-in most recent, otherwise the first user or None.
+    Looks for the first user with most_recent=True.
+
+    Parameters:
+        steam_users: List[SteamUser]
+            list of steam users, from get_steam_user_list()
+
+    Return Type: SteamUser|None
+    """
+    for user in steam_users:
+        if user.most_recent == True:
+            return user
+
+    if len(steam_users) > 0:
+        print(f'Warning: There is no most recent Steam user. Returning the first user {steam_users[0].get_short_id()}')
+        return steam_users[0]
+
+    print('Warning: No Steam users found. Returning None')
+    return None

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -452,6 +452,25 @@ def host_which(name: str) -> str:
     return None if which == '' else which
 
 
+def host_path_exists(path: str, is_file: bool) -> bool:
+    """
+    Returns whether the given path exists on the host system
+
+    Parameters:
+        path: str
+            Path which exists or not
+        is_file: bool
+            Whether to check for a file (is_file=True) or a directory (is_file=False)
+
+    Return Type: bool
+    """
+    path = os.path.expanduser(path)
+    proc_prefix = 'flatpak-spawn --host' if os.path.exists('/.flatpak-info') else ''
+    parameter = 'f' if is_file else 'd'  # check file using -f and directory using -d
+    ret = os.system(proc_prefix + ' bash -c \'if [ -' + parameter + ' "' + path + '" ]; then exit 1; else exit 0; fi\'')
+    return bool(ret) 
+
+
 def ghapi_rlcheck(json: dict):
     """ Checks if the given GitHub request response (JSON) contains a rate limit warning and warns the user """
     if type(json) == dict:


### PR DESCRIPTION
This PR adds a Shortcut Editor for Steam (both Native and Flatpak supported).

Currently, editing the App Name, Executable Path, Starting Directory and App Icon is supported.

![grafik](https://github.com/DavidoTek/ProtonUp-Qt/assets/54072917/ae187be5-9373-458b-a723-6cc52a064a72)

### TODO/DONE:

- [x] Add a Delete Button
   - Mark shortcut (red text) and delete it after pressing `Save`
- [x] Allow adding new shortcuts
   - Determine a user for new shortcuts like this: Check if there are already other shortcuts
      - If there are: Use the most common user across the other shortcuts
      - Otherwise: Determine which Steam user was most recently logged in
      - If there isn't any Steam user (e.g. fresh install): Return and don't do anything - currently no user feedback
- [x] Maybe resize the window a bit

### Later TODOs (for later PRs):

- Add a tool button that lets the user choose an executable/directory using a file dialog
- Modify the available columns / let the user choose
- Fix the Start In field automatically: https://github.com/DavidoTek/ProtonUp-Qt/pull/282#discussion_r1331177772