### PR TITLE
SteamTinkerLaunch: minor description fix

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -37,7 +37,7 @@ On <b>Steam Deck</b>, relevant dependencies will be installed for you. If you ar
 More information is available on the SteamTinkerLaunch Installation wiki page.
 <br/><br/>
 SteamTinkerLaunch has a number of <b>Optional Dependencies</b> which have to be installed separately for extra functionality. Please see the Optional Dependencies section
-of the SteamTinkerLaunch Installation guide on its GitHub page..''')}
+of the SteamTinkerLaunch Installation guide on its GitHub page.''')}
 
 
 class CtInstaller(QObject):

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch_git.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch_git.py
@@ -32,7 +32,7 @@ On <b>Steam Deck</b>, relevant dependencies will be installed for you. If you ar
 More information is available on the SteamTinkerLaunch Installation wiki page.
 <br/><br/>
 SteamTinkerLaunch has a number of <b>Optional Dependencies</b> which have to be installed separately for extra functionality. Please see the Optional Dependencies section
-of the SteamTinkerLaunch Installation guide on its GitHub page..''')}
+of the SteamTinkerLaunch Installation guide on its GitHub page.''')}
 
 
 class CtInstaller(stlCtInstaller):


### PR DESCRIPTION
Remove double '..' from the end of the tool description.

Pretty sure I noticed this a while ago and just forgot about it, until I was copypasting something from this description into an STL issue :sweat_smile: 