### PR TITLE
Remove Qt .desktop file prefix

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -524,7 +524,7 @@ def main():
     app.setApplicationName(APP_NAME)
     app.setApplicationVersion(APP_VERSION)
     app.setWindowIcon(QIcon.fromTheme('net.davidotek.pupgui2'))
-    app.setDesktopFileName('net.davidotek.pupgui2.desktop')
+    app.setDesktopFileName('net.davidotek.pupgui2')
 
     lang = QLocale.languageToCode(QLocale().language())
     lname = QLocale().name()


### PR DESCRIPTION
With PySide 6.5.2, `QGuiApplication::setDesktopFileName` expects the id without suffix `.desktop`:

```yaml
Platform: KDE Flatpak runtime 6.5 Linux-6.2.0-32-generic-x86_64-with-glibc2.35
QGuiApplication::setDesktopFileName: the specified desktop file name ends with .desktop. For compatibility reasons, the .desktop suffix will be removed. Please specify a desktop file name without .desktop suffix
```

## Changes

```diff
- app.setDesktopFileName('net.davidotek.pupgui2.desktop')
+ app.setDesktopFileName('net.davidotek.pupgui2')
```