### PR TITLE
Wine-GE: Match launcher naming schemes on extract

### DIFF
--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -210,9 +210,8 @@ class HeroicGame:
 
 
 class Launcher(Enum):
-
-    STEAM = 0
-    LUTRIS = 1
-    BOTTLES = 2
-    HEROIC = 3
-    UNKNOWN = 4
+    UNKNOWN = 0
+    STEAM = 1
+    LUTRIS = 2
+    BOTTLES = 3
+    HEROIC = 4

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -207,3 +207,12 @@ class HeroicGame:
         
         with open(game_config, 'r') as gcf:
             return json.load(gcf).get(self.app_name, {})
+
+
+class Launcher(Enum):
+
+    STEAM = 0
+    LUTRIS = 1
+    BOTTLES = 2
+    HEROIC = 3
+    UNKNOWN = 4

--- a/pupgui2/resources/ctmods/ctmod_00winege.py
+++ b/pupgui2/resources/ctmods/ctmod_00winege.py
@@ -183,10 +183,10 @@ class CtInstaller(QObject):
         launcher = get_launcher_from_installdir(install_dir)
         if launcher == Launcher.LUTRIS:
             # Lutris expects this name format for self-updating, see #294 -- ex: wine-ge-8-17-x86_64
-            launcher_name = original_name.lower().replace('lutris', 'wine').replace('proton', '') or original_name
+            launcher_name = original_name.lower().replace('lutris', 'wine').replace('proton', '')
         elif launcher == Launcher.HEROIC:
             # This matches Heroic Wine-GE naming convention -- ex: Wine-GE-Proton8-17
-            launcher_name = original_name.replace('lutris', 'Wine').rsplit('-', 1)[0] or original_name
+            launcher_name = original_name.replace('lutris', 'Wine').rsplit('-', 1)[0]
 
         return launcher_name or original_name
 

--- a/pupgui2/resources/ctmods/ctmod_00winege.py
+++ b/pupgui2/resources/ctmods/ctmod_00winege.py
@@ -8,7 +8,8 @@ import hashlib
 
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
-from pupgui2.util import ghapi_rlcheck, extract_tar
+from pupgui2.datastructures import Launcher
+from pupgui2.util import ghapi_rlcheck, extract_tar, get_launcher_from_installdir
 
 
 CT_NAME = 'Wine-GE'
@@ -179,10 +180,11 @@ class CtInstaller(QObject):
         """
 
         launcher_name = ''
-        if 'lutris/runners' in install_dir:
+        launcher = get_launcher_from_installdir(install_dir)
+        if launcher == Launcher.LUTRIS:
             # Lutris expects this name format for self-updating, see #294 -- ex: wine-ge-8-17-x86_64
             launcher_name = original_name.lower().replace('lutris', 'wine').replace('proton', '') or original_name
-        elif 'heroic/tools' in install_dir:
+        elif launcher == Launcher.HEROIC:
             # This matches Heroic Wine-GE naming convention -- ex: Wine-GE-Proton8-17
             launcher_name = original_name.replace('lutris', 'Wine').rsplit('-', 1)[0] or original_name
 

--- a/pupgui2/resources/ctmods/ctmod_d8vk.py
+++ b/pupgui2/resources/ctmods/ctmod_d8vk.py
@@ -7,7 +7,8 @@ import requests
 
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
-from pupgui2.util import ghapi_rlcheck, extract_zip
+from pupgui2.datastructures import Launcher
+from pupgui2.util import ghapi_rlcheck, extract_zip, get_launcher_from_installdir
 
 
 CT_NAME = 'D8VK (nightly)'
@@ -163,9 +164,10 @@ class CtInstaller(QObject):
         Return Type: str
         """
 
-        if 'lutris/runners' in install_dir:
+        launcher = get_launcher_from_installdir(install_dir)
+        if launcher == Launcher.LUTRIS:
             return os.path.abspath(os.path.join(install_dir, '../../runtime/dxvk'))
-        if 'heroic/tools' in install_dir:
+        if launcher == Launcher.HEROIC:
             return os.path.abspath(os.path.join(install_dir, '../dxvk'))
         else:
             return install_dir  # Default to install_dir

--- a/pupgui2/resources/ctmods/ctmod_vkd3dproton.py
+++ b/pupgui2/resources/ctmods/ctmod_vkd3dproton.py
@@ -7,7 +7,8 @@ import requests
 
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
-from pupgui2.util import ghapi_rlcheck, extract_tar, extract_tar_zst
+from pupgui2.datastructures import Launcher
+from pupgui2.util import ghapi_rlcheck, extract_tar, extract_tar_zst, get_launcher_from_installdir
 
 
 CT_NAME = 'vkd3d-proton'
@@ -144,9 +145,10 @@ class CtInstaller(QObject):
         Return Type: str
         """
 
-        if 'lutris/runners' in install_dir:
+        launcher = get_launcher_from_installdir(install_dir)
+        if launcher == Launcher.LUTRIS:
             return os.path.abspath(os.path.join(install_dir, '../../runtime/vkd3d'))
-        if 'heroic/tools' in install_dir:
+        if launcher == Launcher.HEROIC:
             return os.path.abspath(os.path.join(install_dir, '../vkd3d'))
         else:
             return install_dir  # Default to install_dir

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -7,7 +7,8 @@ import requests
 
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
-from pupgui2.util import ghapi_rlcheck, extract_tar
+from pupgui2.datastructures import Launcher
+from pupgui2.util import ghapi_rlcheck, extract_tar, get_launcher_from_installdir
 
 
 CT_NAME = 'DXVK'
@@ -142,9 +143,10 @@ class CtInstaller(QObject):
         Return Type: str
         """
 
-        if 'lutris/runners' in install_dir:
+        launcher = get_launcher_from_installdir(install_dir)
+        if launcher == Launcher.LUTRIS:
             return os.path.abspath(os.path.join(install_dir, '../../runtime/dxvk'))
-        if 'heroic/tools' in install_dir:
+        if launcher == Launcher.HEROIC:
             return os.path.abspath(os.path.join(install_dir, '../dxvk'))
         else:
             return install_dir  # Default to install_dir

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import QApplication, QStyleFactory, QMessageBox, QCheckBo
 
 from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS, CONFIG_FILE, PALETTE_DARK, TEMP_DIR
 from pupgui2.constants import AWACY_GAME_LIST_URL, LOCAL_AWACY_GAME_LIST
-from pupgui2.datastructures import BasicCompatTool, CTType
+from pupgui2.datastructures import BasicCompatTool, CTType, Launcher
 from pupgui2.steamutil import remove_steamtinkerlaunch
 
 
@@ -654,3 +654,22 @@ def extract_tar_zst(zst_path: str, extract_path: str) -> bool:
         print(f'Could not extract archive \'{zst_path}\': {e}')
 
     return False
+
+
+def get_launcher_from_installdir(install_dir: str) -> Launcher:
+
+    """
+    Return the launcher type based on the install path given.
+    Return Type: Launcher (Enum)
+    """
+
+    if 'steam/compatibilitytools.d' in install_dir:
+        return Launcher.STEAM
+    elif 'lutris/runners' in install_dir:
+        return Launcher.LUTRIS
+    elif 'heroic/tools' in install_dir:
+        return Launcher.HEROIC
+    elif 'bottles/runners' in install_dir:
+        return Launcher.BOTTLES
+    else:
+        return Launcher.UNKNOWN

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -663,13 +663,13 @@ def get_launcher_from_installdir(install_dir: str) -> Launcher:
     Return Type: Launcher (Enum)
     """
 
-    if 'steam/compatibilitytools.d' in install_dir:
+    if 'steam/compatibilitytools.d' in install_dir.lower():
         return Launcher.STEAM
-    elif 'lutris/runners' in install_dir:
+    elif 'lutris/runners' in install_dir.lower():
         return Launcher.LUTRIS
-    elif 'heroic/tools' in install_dir:
+    elif 'heroic/tools' in install_dir.lower():
         return Launcher.HEROIC
-    elif 'bottles/runners' in install_dir:
+    elif 'bottles/runners' in install_dir.lower():
         return Launcher.BOTTLES
     else:
         return Launcher.UNKNOWN


### PR DESCRIPTION
Implements #294.

## Overview
This adds an extra step to Wine-GE installation which renames the extraction folder to be consistent with what the current launcher would name it.

Screenshots for Lutris and Heroic respectively:
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/1914ad86-0c45-4738-94ab-728871002226)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/478c7bd0-54c3-45f7-9d71-28959292580f)

## Implementation
We currently keep the name of the top-level archive (`lutris-GE-ProtonX-YY-x86_64`), but Lutris and Heroic do not use this name. For Lutris specifically, this apparently breaks auto-updating. For Heroic, I figured if we're making a change to be consistent for one launcher (Lutris) we should do it for all of them :-)

The launcher check is similar to what we use for DXVK (and elsewhere I believe), essentially checking for strong clues in the path to infer the launcher.

I am not sure what Bottles uses, as I don't use it, but if we need to make a change there it should be easy enough to add.

I could not see a straightforward way to set the extract name for the top-level folder with `tarfile`, it seems the general idea for that is read and extract each file into a specific folder, which I thought was overkill. I think it is more straightforward to just rename the folder after extraction is finished, though this does mean the folder name will not be updated until extraction completes (could be about 10 seconds or more). I doubt any users would see this, though.

## Considerations
I'm thinking since we've re-used this snippet quite a bit that it could be its own utility function, probably taking `install_dir` and returning an enum value so we could do a check like `if get_launcher_from_install_dir(install_dir) == Launchers.HEROIC`. We do some checks like this already, checking on strings with `install_loc.get('launcher')`, but in ctmods we just pass down `install_dir`. Though we could allow these `install_loc` checks to use the enum as well, it may be slightly nicer than checking directly on the string :slightly_smiling_face:

Not really a big deal either way though, just a thought I had during development that I wanted to share.

<hr>

Thanks!