### PR TITLE
SteamTinkerLaunch: rename 'xwinfo' to 'xwininfo'

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -190,7 +190,7 @@ class CtInstaller(QObject):
                 'xprop': host_which('xprop'),
                 'xrandr': host_which('xrandr'),
                 'xxd': host_which('xxd'),
-                'xwinfo': host_which('xwininfo'),
+                'xwininfo': host_which('xwininfo'),
                 'yad >= 7.2': yad_exe and yad_ver >= 7.2
             }
 


### PR DESCRIPTION
FIxes #300.

There is an AUR package called `xwinfo` ([repo](https://github.com/baskerville/xwinfo)), which seems similar (equivalent?) to `xwininfo`. When installing SteamTinkerLaunch, if ProtonUp-Qt can't find `which xwininfo`, instead of using this name, displays the `xwininfo` dependency name as `xwinfo`. Even if `xwinfo` is installed it will not return anything for `which xwininfo`, as its command name is `xwinfo`. SteamTinkerLaunch also expects to find a command `xwininfo`, it is not compatible with `xwinfo`. It could be possible for SteamTinkerLaunch to use `xwinfo` if it is truly equivalent to `xwininfo`, but I'd honestly rather stick to official packages only for a dependency like this.

This PR fixes the SteamTinkerLaunch dependencies screen to now show `xwininfo` as the dependency name instead of `xwinfo`. We even run `host_which('xwininfo')`. Not sure why we used `xwinfo` back then, but I don't think there's any strong reason to keep it :-)

So while the package name alone is not a huge issue, it's the fact that `xwinfo` uses the command name `xwinfo` instead of `xwininfo`. Phew! Hope that makes sense.

Thanks!