### PR TITLE
DXVK: Update dxvk-async to use Ph42oN GitLab repo

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -91,7 +91,10 @@ LUTRIS_WEB_URL = 'https://lutris.net/games/'
 EPIC_STORE_URL = 'https://store.epicgames.com/p/'
 
 GITHUB_API = 'https://api.github.com/'
-GITLAB_API = 'https://gitlab.com/api/'  # TODO should be a list of known GitLab instances
+# GitLab can have any self-hosted instance, so we store a list of known GitLab instances
+GITLAB_API = [
+    'https://gitlab.com/api/'
+]
 
 GITLAB_API_RATELIMIT_TEXT = [
     'Rate limit exceeded; see https://docs.gitlab.com/ee/user/gitlab_com/#gitlabcom-specific-rate-limits for more details',

--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -89,3 +89,6 @@ STEAM_STL_FISH_VARIABLES = os.path.join(HOME_DIR, '.config/fish/fish_variables')
 
 LUTRIS_WEB_URL = 'https://lutris.net/games/'
 EPIC_STORE_URL = 'https://store.epicgames.com/p/'
+
+GITHUB_API = 'https://api.github.com/'
+GITLAB_API = 'https://gitlab.com/api/'

--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -91,4 +91,10 @@ LUTRIS_WEB_URL = 'https://lutris.net/games/'
 EPIC_STORE_URL = 'https://store.epicgames.com/p/'
 
 GITHUB_API = 'https://api.github.com/'
-GITLAB_API = 'https://gitlab.com/api/'
+GITLAB_API = 'https://gitlab.com/api/'  # TODO should be a list of known GitLab instances
+
+GITLAB_API_RATELIMIT_TEXT = [
+    'Rate limit exceeded; see https://docs.gitlab.com/ee/user/gitlab_com/#gitlabcom-specific-rate-limits for more details',
+    'Rate limit exceeded',
+    'Retry later'
+]

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -82,8 +82,8 @@ class MainWindow(QObject):
 
         self.rs = requests.Session()
         self.web_access_tokens = {
-            'github': os.getenv('PUPGUI_GHA_TOKENS'),
-            'gitlab': os.getenv('PUPGUI_GLA_TOKENS'),
+            'github': os.getenv('PUPGUI_GHA_TOKEN'),
+            'gitlab': os.getenv('PUPGUI_GLA_TOKEN'),
         }
 
         self.ct_loader = ctloader.CtLoader(main_window=self)

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -81,8 +81,11 @@ class MainWindow(QObject):
         super(MainWindow, self).__init__()
 
         self.rs = requests.Session()
-        if token := os.getenv('PUPGUI_GHA_TOKEN'):
-            self.rs.headers.update({'Authorization': f'token {token}'})
+        self.web_access_tokens = {
+            'github': os.getenv('PUPGUI_GHA_TOKENS'),
+            'gitlab': os.getenv('PUPGUI_GLA_TOKENS'),
+        }
+
         self.ct_loader = ctloader.CtLoader(main_window=self)
 
         for ctobj in self.ct_loader.get_ctobjs():

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -87,45 +87,6 @@ class CtInstaller(QObject):
         asset_condition = lambda asset: 'native' not in [asset.get('name', ''), asset.get('url', '')]  # 'name' for github asset, 'url' for gitlab asset
         return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag, asset_condition=asset_condition)
 
-    def __fetch_github_data(self, tag):
-        """
-        Fetch GitHub release information
-        Return Type: dict
-        Content(s):
-            'version', 'date', 'download'
-        """
-        url = self.CT_URL + (f'/tags/{tag}' if tag else '/latest')
-        data = self.rs.get(url).json()
-        if 'tag_name' not in data:
-            return None
-
-        values = {'version': data['tag_name'], 'date': data['published_at'].split('T')[0]}
-        for asset in data['assets']:
-            if asset['name'].endswith('tar.gz') and 'native' not in asset['name']:
-                values['download'] = asset['browser_download_url']
-                values['size'] = asset['size']
-        return values
-
-    def __fetch_gitlab_data(self, tag):
-        """
-        Fetch GItLab release information
-        Return Type: dict
-        Content(s):
-            'version', 'date', 'download'
-        """
-
-        # GitLab docs: https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name
-        url = f'{self.CT_URL}/{tag if tag else "latest"}'
-        data = self.rs.get(url).json()
-        if 'tag_name' not in data:
-            return None
-
-        values = { 'version': data['tag_name'], 'date': data['released_at'].split('T')[0] }
-        for asset in data.get('assets', {}):
-            if 'tar.gz' in asset.get('sources', {}).get('format'):
-                values['download'] = asset['url']
-        return values
-
     def is_system_compatible(self):
         """
         Are the system requirements met?
@@ -145,11 +106,8 @@ class CtInstaller(QObject):
         Download and install the compatibility tool
         Return Type: bool
         """
+
         data = self.__fetch_data(version)
-        print(data)
-
-        return
-
         if not data or 'download' not in data:
             return False
 

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -5,6 +5,8 @@
 import os
 import requests
 
+from typing import Dict
+
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.util import extract_tar, fetch_project_releases, fetch_project_release_data
@@ -75,7 +77,7 @@ class CtInstaller(QObject):
         self.__set_download_progress_percent(99) # 99 download complete
         return True
 
-    def __fetch_data(self, tag: str = '') -> dict:
+    def __fetch_data(self, tag: str = '') -> Dict:
 
         """
         Fetch release information

--- a/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
+++ b/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
@@ -17,5 +17,8 @@ class CtInstaller(DXVKInstaller):
     CT_URL = 'https://gitlab.com/api/v4/projects/43488626/releases'
     CT_INFO_URL = 'https://gitlab.com/Ph42oN/dxvk-gplasync/-/releases/'
 
-    def __init__(self, main_window = None):
-        super().__init__(main_window)
+    def __init__(self, main_window = None, request_headers = {}):
+        if main_window and main_window.web_access_tokens.get('gitlab', None) and 'Authorization' not in request_headers:
+            request_headers['Authorization'] = f'Authorization: Bearer {main_window.web_access_tokens.get("gitlab", None)}'
+
+        super().__init__(main_window, request_headers)

--- a/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
+++ b/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
@@ -14,8 +14,8 @@ CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_z1dxvkasync
 
 class CtInstaller(DXVKInstaller):
 
-    CT_URL = 'https://api.github.com/repos/Sporif/dxvk-async/releases'
-    CT_INFO_URL = 'https://github.com/Sporif/dxvk-async/releases/tag/'
+    CT_URL = 'https://gitlab.com/api/v4/projects/43488626/releases'
+    CT_INFO_URL = 'https://gitlab.com/Ph42oN/dxvk-gplasync/-/releases/'
 
     def __init__(self, main_window = None):
         super().__init__(main_window)

--- a/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
+++ b/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
@@ -5,6 +5,7 @@
 from PySide6.QtCore import QCoreApplication
 
 from pupgui2.resources.ctmods.ctmod_z0dxvk import CtInstaller as DXVKInstaller
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'DXVK Async'
@@ -18,7 +19,4 @@ class CtInstaller(DXVKInstaller):
     CT_INFO_URL = 'https://gitlab.com/Ph42oN/dxvk-gplasync/-/releases/'
 
     def __init__(self, main_window = None, request_headers = {}):
-        if main_window and main_window.web_access_tokens.get('gitlab', None) and 'Authorization' not in request_headers:
-            request_headers['Authorization'] = f'Authorization: Bearer {main_window.web_access_tokens.get("gitlab", None)}'
-
-        super().__init__(main_window, request_headers)
+        super().__init__(main_window, build_headers_with_authorization(request_headers, main_window.web_access_tokens, 'gitlab'))

--- a/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
+++ b/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
@@ -9,7 +9,7 @@ from pupgui2.resources.ctmods.ctmod_z0dxvk import CtInstaller as DXVKInstaller
 
 CT_NAME = 'DXVK Async'
 CT_LAUNCHERS = ['lutris']
-CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_z1dxvkasync', '''Vulkan based implementation of Direct3D 9, 10 and 11 for Linux/Wine with async patch by Sporif.<br/><br/><b>Warning: Use only with singleplayer games!</b>''')}
+CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_z1dxvkasync', '''Vulkan based implementation of Direct3D 9, 10 and 11 for Linux/Wine with gplasync patch by Ph42oN.<br/><br/><b>Warning: Use only with singleplayer games!</b>''')}
 
 
 class CtInstaller(DXVKInstaller):

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -533,7 +533,7 @@ def get_assets_from_release(release_url: str, release: dict) -> Dict:
     if GITHUB_API in release_url:
         return release.get('assets', {})
     elif GITLAB_API in release_url:
-        return release.get('assets', {}).get('sources', {})
+        return release.get('assets', {}).get('links', {})
     else:
         return {}
 
@@ -545,10 +545,11 @@ def get_download_url_from_asset(release_url: str, asset: dict, release_format: s
     Return Type: str
     """
 
+    # Checks are identical for now but may be different for other APIs
     valid_asset: str = ''
-    if GITHUB_API in release_url and asset['name'].endswith(release_format):
+    if GITHUB_API in release_url and asset.get('name', '').endswith(release_format):
         valid_asset = asset['browser_download_url']
-    elif GITLAB_API in release_url and release_format in asset.get('format', ''):
+    elif GITLAB_API in release_url and asset.get('name', '').endswith(release_format):
         valid_asset = asset['url']
     else:
         return ''

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -531,6 +531,8 @@ def fetch_project_releases(releases_url: str, rs: requests.Session, count=100) -
     """
     releases_api_url: str = f'{releases_url}?per_page={str(count)}'
 
+    print(rs.headers)
+
     releases: dict = {}
     tag_key: str = ''
     if GITHUB_API in releases_url:
@@ -617,6 +619,24 @@ def fetch_project_release_data(release_url: str, release_format: str, rs: reques
 
     return values
 
+
+def build_headers_with_authorization(request_headers: dict, authorization_tokens: dict, token_type: str):
+
+    request_headers['Authorization'] = ''  # Reset old authentication
+    token: str = authorization_tokens.get(token_type, '')
+    if not token:
+        print(f'No token of type {token_type} -- Returning')
+        
+        return request_headers
+
+    print(f'{token_type} token is {token}')
+
+    if token_type == 'github':
+        request_headers['Authorization'] = f'token {token}'
+    elif token_type == 'gitlab':
+        request_headers['Authorization'] = f'Bearer {token}'
+
+    return request_headers
 
 def compat_tool_available(compat_tool: str, ctobjs: List[dict]) -> bool:
     """ Return whether a compat tool is available for a given launcher """

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -624,12 +624,8 @@ def build_headers_with_authorization(request_headers: dict, authorization_tokens
 
     request_headers['Authorization'] = ''  # Reset old authentication
     token: str = authorization_tokens.get(token_type, '')
-    if not token:
-        print(f'No token of type {token_type} -- Returning')
-        
+    if not token:        
         return request_headers
-
-    print(f'{token_type} token is {token}')
 
     if token_type == 'github':
         request_headers['Authorization'] = f'token {token}'

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -499,6 +499,15 @@ def glapi_rlcheck(json: dict):
     return json
 
 
+def is_gitlab_instance(url: str) -> bool:
+    """
+    Check if a full API endpoint URL is in the list of known GitLab instances.
+    Return Type: bool
+    """
+
+    return any(instance in url for instance in GITLAB_API)
+
+
 def is_online(host='https://api.github.com/repos/', timeout=3) -> bool:
     """
     Attempts to ping a given host using `requests`.
@@ -527,7 +536,7 @@ def fetch_project_releases(releases_url: str, rs: requests.Session, count=100) -
     if GITHUB_API in releases_url:
         releases = ghapi_rlcheck(rs.get(releases_api_url).json())
         tag_key = 'tag_name'
-    elif GITLAB_API in releases_url:
+    elif is_gitlab_instance(releases_url):
         releases = glapi_rlcheck(rs.get(releases_api_url).json())
         tag_key = 'name'
     else:
@@ -545,7 +554,7 @@ def get_assets_from_release(release_url: str, release: dict) -> Dict:
 
     if GITHUB_API in release_url:
         return release.get('assets', {})
-    elif GITLAB_API in release_url:
+    elif is_gitlab_instance(release_url):
         return release.get('assets', {}).get('links', {})
     else:
         return {}
@@ -562,7 +571,7 @@ def get_download_url_from_asset(release_url: str, asset: dict, release_format: s
     valid_asset: str = ''
     if GITHUB_API in release_url and asset.get('name', '').endswith(release_format):
         valid_asset = asset['browser_download_url']
-    elif GITLAB_API in release_url and asset.get('name', '').endswith(release_format):
+    elif is_gitlab_instance(release_url) and asset.get('name', '').endswith(release_format):
         valid_asset = asset['url']
     else:
         return ''
@@ -590,7 +599,7 @@ def fetch_project_release_data(release_url: str, release_format: str, rs: reques
     if GITHUB_API in release_url:
         url += f'tags/{api_tag}'
         date_key = 'published_at'
-    elif GITLAB_API in release_url:
+    elif is_gitlab_instance(release_url):
         url += api_tag
         date_key = 'released_at'
     else:

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -500,7 +500,7 @@ def is_online(host='https://api.github.com/repos/', timeout=3) -> bool:
 
 
 # Only used for dxvk and dxvk-async right now, but is potentially useful to more ctmods?
-def fetch_project_releases(releases_url: str, rs: requests.Session, count=100) -> list[str]:
+def fetch_project_releases(releases_url: str, rs: requests.Session, count=100) -> List[str]:
 
     """
     List available releases for a given project URL hosted using requests.


### PR DESCRIPTION
~~*(NOTE: This PR is still in draft and not quite ready for testing just yet, while I work out a couple of remaining trouble areas with the archive we download from GitLab, the description of this PR should be pretty final but is mostly written up so I can document the work I have done thus far and amend as I go :slightly_smiling_face:)*~~

PR should be in a working state and ready for review now :-)

<hr>

Implements #243.

## Overview
This PR implements downloading the new DXVK Async project by Ph42oN from GitLab, replacing the `dxvk-async` project on GitHub by Sporif which is incompatible with newer DXVK versions.

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/c04c807f-cd0a-4972-9d87-cb09d4d4d1f6)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/92d30773-4c1a-4c21-9859-5df514be4be5)

## Background
The `dxvk-async` project on GitHub that we currently point to no longer sees active development. To my understanding, a change was introduced in upstream DXVK around v2.0 that broke `dxvk-async`, and for one reason or another, it will not be updated beyond DXVK v2.0.

Someone else picked up the mantle and made a `dxvk-async` compatible with the new GPL feature in newer DXVK releases (**G**raphics **P**ipe**L**ine, not to be confused with GNU GPL :wink:), and it was requested that ProtonUp-Qt point to this newer project instead. However, this project is hosted on GitLab, and much of the logic ProtonUp-Qt uses to get releases and assets and build the associated data from this to download a release is very much expecting a GitHub API response. A significant refactor would be required.

## The Refactor
The main reason I put off looking at this for so long, the refactor. First, I needed to look into the GItLab API response and what sort of structure it comes back with. But that was the easy part, the problem was I didn't want to simply litter the ctmod with "if gitlab -> do this, if github, do that" and then have to do that for any future ctmod that might use GItLab. I wanted to try and make something a bit more re-usable.

I originally considered starting off with creating a base ctmod class that could handle this, but this was... going to be a *lot* of work and I have tried figuring it out quite a few times locally. So I bit the bullet and thought well, let's just try and do this with some utility functions, we could always move them into a base ctmod class later :-) 

So that's exactly what I did, I created a number of re-usable util functions that abstract away the various components of the GitHub vs GitLab API call. We can call one function to get all of the tags, for example, giving it the URL and some other information, and that function handles whether we're using GitHub or GitLab, and parses the information we need. I also tried to make them as generic as possible, which is why `get_download_url_from_asset` takes the crazy `asset_condition: Optional[Callable]` -- Each ctmod will needs its own filter rules for assets, so I figured the ctmod should pass the condition as a lambda. This gets filtered through the initial call, so it can be used anywhere it's needed, such as if we need to filter on something that *isn't* the asset URL.

And because these functions can handle GitHub and GitLab, it should be possible to drop them into all ctmods, and in future, into a base ctmod class. I kept this kind of re-use and future development in mind when writing these functions. There may still be some extending needed in future, but I tried to keep the functions modular enough to the point where this would be possible. For example, if we needed to introduce a filter lambda parameter elsewhere.

This refactor was made with GitHub and GitLab in mind, as well as any future hosts we might need to call to, such as BitBucket, so we should be able to extent the logic semi-easily. One set of functions to rule them all :-)

I still don't know if these methods are architected in the best way. We're passing `release_url` quite a lot, for example. So as usual *all* feedback on my Python scribbles are more than welcome.

## Existing DXVK Functionality
This should not break existing DXVK functionality, and should hopefully be generic enough that if other DXVK ctmods are ever added or combined (such as if D8VK is combined and uses releases instead of the current broken nightlies), they should also be compatible.

One change I made that may potentially have an impact: `Content-Length` does not come back on the headers from GitLab, and one alternative I saw was to use `len(request.content)`. It seems to be working for these ctmods but i'm unsure if it has any potential Unforeseen Consequences. I wanted to call out this change just in case, even though it is currently working :-)

## Considerations
Should we make this a new ctmod? It would be straightforward, since the refactor uses generic methods called from the one DXVK ctmod. We would simply need to make the `dxvk-gplasync` a separate ctmod. and restore the URLs I changed in this PR. Though, I worry that a change like this would impact

In an entirely separate vein, should we *remove* the older DXVK Async altogether and rename this to be `dxvk-gplasync`? Or would the description update cover this?

<hr>

TODO:
- [x] The GitLab archive we download contains a lot of useless information, need to fix
- [x] Remove any typings not supported n Python 3.8