### PR TITLE
util: Use GitHub rate_limit endpoint with greater is_online timeout

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -484,7 +484,7 @@ def ghapi_rlcheck(json: dict):
     return json
 
 
-def is_online(host='https://api.github.com/repos/', timeout=3) -> bool:
+def is_online(host='https://api.github.com/rate_limit/', timeout=5) -> bool:
     """
     Attempts to ping a given host using `requests`.
     Returns False if `requests` raises a `ConnectionError` or `Timeout` exception, otherwise returns True 


### PR DESCRIPTION
May help with #303.

### Changing default `host`
When skimming the code and doing tests on my own PC for #303, I noticed requests was coming back with a `<Response [404]>`. Turns out the repos endpoint doesn't exist, or no longer exists. This doesn't break `is_online`, as we don't care about the status code, we just care that we can reach `api.github.com`. But I figured it might be better practice to hit a valid endpoint.

One user reported that ProtonUp-Qt will report that they are offline for them no matter what. Since `is_online` simply uses requests to ping an endpoint with a given request, I have two theories:
1. They are rate-limited, but I don't think `requests` would throw a `ConnectionError` for a rate limt, and it's even less likely that they would throw a `Timeout` (these are the two exceptions we check for).
2. The request is timing out, and I think this may be the case. 

As noted, my money right now is on a timeout. Currently, we set the timeout to `3`, and this has been fine in all of my tests for about 10 months since this feature was added. Even on my Steam Deck this has worked fine, and for this test I just checked again and it still works fine.

### Changing `timeout`
My guess is then, that `is_online` is not forgiving enough for networks with higher latency. On devices like the Steam Deck or even some laptops, when Steam is opened, it could be using a lot of bandwidth (i.e. resuming downloading/updating games) automatically on top of the connection not being very strong. Therefore, the connection times out because it takes a little bit longer than 3 seconds. In my tests, the request on my network on my PC takes less than 0.2 seconds, 0.15s on average. And I can get `is_online` to return `False` (and ProtonUp-Qt displays "(Offline)") if I set the timeout to be 0.1 or less. I can get it to intermittently fail if I set it to 0.15.

I don't think we have any way to know if the connection is actually timing out, but that is just my assumption.

I have currently set the timeout to `5`, and it doesn't add any noticeable startup delay, but that is almost certainly because the request completes very quickly. If we set the timeout to, say, `30`, and someone on a very slow network did take close to that, ProtonUp-Qt would likely stall waiting for the request to complete and it means it could take up to 30 seconds.

I guess we have a balancing act here, I don't know if it's worth the effort to make this check threaded, and it probably doesn't make much sense to make it threaded *anyway* since we want to show this as early as possible. But maybe having a more lenient timeout could resolve the problems. `5` might be a bit low, so I'd be curious to hear what your thoughts are :smile: 