### PR TITLE
Config: Read GitHub and GitLab tokens from Config File

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -27,7 +27,7 @@ from pupgui2.steamutil import get_steam_acruntime_list, get_steam_app_list, get_
 from pupgui2.heroicutil import is_heroic_launcher, get_heroic_game_list
 from pupgui2.util import apply_dark_theme, create_compatibilitytools_folder, get_installed_ctools, remove_ctool
 from pupgui2.util import install_directory, available_install_directories, get_install_location_from_directory_name
-from pupgui2.util import print_system_information, single_instance, download_awacy_gamelist, is_online, config_advanced_mode, compat_tool_available
+from pupgui2.util import print_system_information, single_instance, download_awacy_gamelist, is_online, config_advanced_mode, config_github_access_token, config_gitlab_access_token, compat_tool_available
 
 
 class InstallWineThread(QThread):
@@ -82,8 +82,8 @@ class MainWindow(QObject):
 
         self.rs = requests.Session()
         self.web_access_tokens = {
-            'github': os.getenv('PUPGUI_GHA_TOKEN'),
-            'gitlab': os.getenv('PUPGUI_GLA_TOKEN'),
+            'github': config_github_access_token(),
+            'gitlab': config_gitlab_access_token(),
         }
 
         self.ct_loader = ctloader.CtLoader(main_window=self)

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -82,8 +82,8 @@ class MainWindow(QObject):
 
         self.rs = requests.Session()
         self.web_access_tokens = {
-            'github': config_github_access_token(),
-            'gitlab': config_gitlab_access_token(),
+            'github': os.getenv('PUPGUI_GHA_TOKEN') or config_github_access_token(),
+            'gitlab': os.getenv('PUPGUI_GLA_TOKEN') or config_gitlab_access_token(),
         }
 
         self.ct_loader = ctloader.CtLoader(main_window=self)

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -113,6 +113,36 @@ def apply_dark_theme(app: QApplication) -> None:
                 app.setPalette(QStyleFactory.create('fusion').standardPalette())
 
 
+def read_update_config_value(key: str, value, section: str = 'pupgui2', config_file: str = CONFIG_FILE):
+
+    """
+    Uses ConfigParser to read a value with a given key from a given section from a given cconfig file.
+    By default, will read a key and a value from the 'pupgui2' section in CONFIG_FILE path in constants.py.
+    """
+
+    config = ConfigParser()
+
+    # Read value if it exists in config
+    if os.path.exists(config_file):
+        config.read(config_file)
+        if config.has_option(section, key):
+            return config[section][key]
+
+    # Otherwise write value, skip write if no value passed
+    if not value:
+        return value
+
+    config.read(config_file)
+    if not config.has_section(section):
+        config.add_section(section)
+    config[section][key] = value
+    os.makedirs(os.path.dirname(config_file), exist_ok=True)
+
+    with open(config_file, 'w') as cfg:
+        config.write(cfg)
+    return value
+
+
 def config_theme(theme=None) -> str:
     """
     Read/update config for the theme
@@ -157,6 +187,24 @@ def config_advanced_mode(advmode=None) -> str:
         if config.has_option('pupgui2', 'advancedmode'):
             return config['pupgui2']['advancedmode']
     return advmode
+
+
+def config_github_access_token(github_token=None):
+
+    """
+    Read/update config for GitHub Access Token
+    """
+
+    return read_update_config_value('PUPGUI_GHA_TOKEN', github_token, section='pupgui2')
+
+
+def config_gitlab_access_token(gitlab_token=None):
+
+    """
+    Read/update config for GitLab Access Token
+    """
+
+    return read_update_config_value('PUPGUI_GLA_TOKEN', gitlab_token, section='pupgui2')
 
 
 def create_compatibilitytools_folder() -> None:

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -528,7 +528,7 @@ def ghapi_rlcheck(json: dict):
             print('Warning: GitHub API rate limit exceeded. See https://github.com/DavidoTek/ProtonUp-Qt/issues/161#issuecomment-1358200080 for details.')
             QApplication.instance().message_box_message.emit(
                 QCoreApplication.instance().translate('util.py', 'Warning: GitHub API rate limit exceeded!'),
-                QCoreApplication.instance().translate('util.py', 'GitHub API rate limit exceeded. You may need to wait a while or specify a GitHub API key if you have one with PUPGUI_GHA_TOKEN in \'config.ini\'.\n\nSee https://github.com/DavidoTek/ProtonUp-Qt/issues/161#issuecomment-1358200080 for details.'),
+                QCoreApplication.instance().translate('util.py', 'GitHub API rate limit exceeded. You may need to wait a while or specify a GitHub API key if you have one.\n\nSee https://github.com/DavidoTek/ProtonUp-Qt/issues/161#issuecomment-1358200080 for details.'),
                 QMessageBox.Warning
                 )
     return json
@@ -542,7 +542,7 @@ def glapi_rlcheck(json: dict):
             print('Warning: GitLab API rate limit exceeded. You may need to wait a while or specify a GitLab API token generated for the given instance.')
             QApplication.instance().message_box_message.emit(
                 QCoreApplication.instance().translate('util.py', 'Warning: GitLab API rate limit exceeded!'),
-                QCoreApplication.instance().translate('util.py', 'GitLab API rate limite exceeded. You may want to wait a while or specify a GitLab API key generated for this GitLab instance if you have one with PUPGUI_GLA_TOKEN in \'config.ini\'.'),
+                QCoreApplication.instance().translate('util.py', 'GitLab API rate limite exceeded. You may want to wait a while or specify a GitLab API key generated for this GitLab instance if you have one.'),
                 QMessageBox.Warning
             )
     return json

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -113,7 +113,7 @@ def apply_dark_theme(app: QApplication) -> None:
                 app.setPalette(QStyleFactory.create('fusion').standardPalette())
 
 
-def read_update_config_value(option: str, value, section: str = 'pupgui2', config_file: str = CONFIG_FILE):
+def read_update_config_value(option: str, value, section: str = 'pupgui2', config_file: str = CONFIG_FILE) -> str:
 
     """
     Uses ConfigParser to read a value with a given option from a given section from a given config file.
@@ -121,26 +121,26 @@ def read_update_config_value(option: str, value, section: str = 'pupgui2', confi
     """
 
     config = ConfigParser()
+    config_value = ''
 
-    # Read value if it exists in config
-    if os.path.exists(config_file):
+    # Write value if given
+    if value:
+        config.read(config_file)
+        if not config.has_section(section):
+            config.add_section(section)
+        config[section][option] = value
+        os.makedirs(os.path.dirname(config_file), exist_ok=True)
+
+        with open(config_file, 'w') as cfg:
+            config.write(cfg)
+        config_value = value
+    # If no value, attempt to read from config
+    elif os.path.exists(config_file):
         config.read(config_file)
         if config.has_option(section, option):
-            return config[section][option]
+            config_value = config[section][option]
 
-    # Otherwise write value, skip write if no value passed
-    if not value:
-        return value
-
-    config.read(config_file)
-    if not config.has_section(section):
-        config.add_section(section)
-    config[section][option] = value
-    os.makedirs(os.path.dirname(config_file), exist_ok=True)
-
-    with open(config_file, 'w') as cfg:
-        config.write(cfg)
-    return value
+    return config_value
 
 
 def config_theme(theme=None) -> str:
@@ -149,21 +149,8 @@ def config_theme(theme=None) -> str:
     Write theme to config or read if theme=None
     Return Type: str
     """
-    config = ConfigParser()
 
-    if theme:
-        config.read(CONFIG_FILE)
-        if not config.has_section('pupgui2'):
-            config.add_section('pupgui2')
-        config['pupgui2']['theme'] = theme
-        os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
-        with open(CONFIG_FILE, 'w') as file:
-            config.write(file)
-    elif os.path.exists(CONFIG_FILE):
-        config.read(CONFIG_FILE)
-        if config.has_option('pupgui2', 'theme'):
-            return config['pupgui2']['theme']
-    return theme
+    return read_update_config_value('theme', theme, section='pupgui2')
 
 
 def config_advanced_mode(advmode=None) -> str:

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -150,7 +150,21 @@ def config_theme(theme=None) -> str:
     Return Type: str
     """
 
-    return read_update_config_value('theme', theme, section='pupgui2')
+    config = ConfigParser()
+
+    if theme:
+        config.read(CONFIG_FILE)
+        if not config.has_section('pupgui2'):
+            config.add_section('pupgui2')
+        config['pupgui2']['theme'] = theme
+        os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
+        with open(CONFIG_FILE, 'w') as file:
+            config.write(file)
+    elif os.path.exists(CONFIG_FILE):
+        config.read(CONFIG_FILE)
+        if config.has_option('pupgui2', 'theme'):
+            return config['pupgui2']['theme']
+    return theme
 
 
 def config_advanced_mode(advmode=None) -> str:

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -113,11 +113,11 @@ def apply_dark_theme(app: QApplication) -> None:
                 app.setPalette(QStyleFactory.create('fusion').standardPalette())
 
 
-def read_update_config_value(key: str, value, section: str = 'pupgui2', config_file: str = CONFIG_FILE):
+def read_update_config_value(option: str, value, section: str = 'pupgui2', config_file: str = CONFIG_FILE):
 
     """
-    Uses ConfigParser to read a value with a given key from a given section from a given cconfig file.
-    By default, will read a key and a value from the 'pupgui2' section in CONFIG_FILE path in constants.py.
+    Uses ConfigParser to read a value with a given option from a given section from a given config file.
+    By default, will read a option and a value from the 'pupgui2' section in CONFIG_FILE path in constants.py.
     """
 
     config = ConfigParser()
@@ -125,8 +125,8 @@ def read_update_config_value(key: str, value, section: str = 'pupgui2', config_f
     # Read value if it exists in config
     if os.path.exists(config_file):
         config.read(config_file)
-        if config.has_option(section, key):
-            return config[section][key]
+        if config.has_option(section, option):
+            return config[section][option]
 
     # Otherwise write value, skip write if no value passed
     if not value:
@@ -135,7 +135,7 @@ def read_update_config_value(key: str, value, section: str = 'pupgui2', config_f
     config.read(config_file)
     if not config.has_section(section):
         config.add_section(section)
-    config[section][key] = value
+    config[section][option] = value
     os.makedirs(os.path.dirname(config_file), exist_ok=True)
 
     with open(config_file, 'w') as cfg:

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -527,7 +527,7 @@ def ghapi_rlcheck(json: dict):
             print('Warning: GitHub API rate limit exceeded. See https://github.com/DavidoTek/ProtonUp-Qt/issues/161#issuecomment-1358200080 for details.')
             QApplication.instance().message_box_message.emit(
                 QCoreApplication.instance().translate('util.py', 'Warning: GitHub API rate limit exceeded!'),
-                QCoreApplication.instance().translate('util.py', 'GitHub API rate limit exceeded. You may need to wait a while or specify a GitHub API key if you have one.\n\nSee https://github.com/DavidoTek/ProtonUp-Qt/issues/161#issuecomment-1358200080 for details.'),
+                QCoreApplication.instance().translate('util.py', 'GitHub API rate limit exceeded. You may need to wait a while or specify a GitHub API key if you have one with PUPGUI_GHA_TOKEN in \'config.ini\'.\n\nSee https://github.com/DavidoTek/ProtonUp-Qt/issues/161#issuecomment-1358200080 for details.'),
                 QMessageBox.Warning
                 )
     return json
@@ -541,7 +541,7 @@ def glapi_rlcheck(json: dict):
             print('Warning: GitLab API rate limit exceeded. You may need to wait a while or specify a GitLab API token generated for the given instance.')
             QApplication.instance().message_box_message.emit(
                 QCoreApplication.instance().translate('util.py', 'Warning: GitLab API rate limit exceeded!'),
-                QCoreApplication.instance().translate('util.py', 'GitLab API rate limite exceeded. You may want to wait a while or specify a GitLab API key generated for this GitLab instance if you have one.'),
+                QCoreApplication.instance().translate('util.py', 'GitLab API rate limite exceeded. You may want to wait a while or specify a GitLab API key generated for this GitLab instance if you have one with PUPGUI_GLA_TOKEN in \'config.ini\'.'),
                 QMessageBox.Warning
             )
     return json

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -196,7 +196,7 @@ def config_github_access_token(github_token=None):
     Read/update config for GitHub Access Token
     """
 
-    return read_update_config_value('PUPGUI_GHA_TOKEN', github_token, section='pupgui2')
+    return read_update_config_value('github_api_token', github_token, section='pupgui2')
 
 
 def config_gitlab_access_token(gitlab_token=None):
@@ -205,7 +205,7 @@ def config_gitlab_access_token(gitlab_token=None):
     Read/update config for GitLab Access Token
     """
 
-    return read_update_config_value('PUPGUI_GLA_TOKEN', gitlab_token, section='pupgui2')
+    return read_update_config_value('gitlab_api_token', gitlab_token, section='pupgui2')
 
 
 def create_compatibilitytools_folder() -> None:


### PR DESCRIPTION
This PR implements the backend for #305, it does not contain any GUI changes.

## Overview
Right now we pass GitHub (and GitLab) access tokens via an environment variable. This works, but it has to be appended every time. On one hand, this is not so bad because tokens expire, but on the other hand until they expire (which could be months) if you want to keep using them to avoid a rate limit, you have to append them as an environment variable. For Flatpak, this can be configured from a tool to set Flatpak environment variables, such as Flatseal.

However it was requested to read these values from the config file instead. This PR implements the ability to read these variables from the config file instead of having to pass them as environment variables. Right now the main benefit to this is that it's more "coupled" to ProtonUp-Qt and means a user doesn't have to fiddle with Flatpak permissions or edit Desktop entry environment variables. But in future this will have the larger benefit of being configurable from a GUI, we can expose it on the GUI pretty easily I think.

## Implementation
### Replacing Environment Variables
With this PR, a user can set `PUPGUI_GHA_TOKEN` or `PUPGUI_GLA_TOKEN` in the `config.ini`, under the `pupgui2` section (this matches the environment variable names), and ProtonUp-Qt will read this when setting the values for the MainWindow `web_access_tokens` dictionary. This **replaces** the environment variables.

The reason I went with replacing environment variables is that in future, we will expose this on the GUI, and so would negate the need for the environment variable. Having an option to force a config option via an environment variable is something I did consider. For example, a user might want to pass `PUPGUI_GHA_TOKEN` as an environment variable.

I don't see an intuitive way to know which should take priority -- Would a user be more likely or less likely to expect the environment variable to take priority? For example if no value is in the config they might expect the environment variable to take priority, but if they set it they might think that the environment variable should be ignored. Another user might have an entirely different idea. Therefore, I thought it best to simply rip the band-aid off and go all-in on using the config file to define these variables only. Complicating the logic to check for both a config file or environment variable option doesn't seem worth it to me.

Also, afaik we don't allow other config options to be overridden with environment variables, and I don't think the breaking compatibility is super important here, especially if we document this on release and have the option to set these values on the GUI after release.

For this reason, I went with replacing the environment variables with the config file values.

### Generic Config Read/Write Function
No prizes for guessing this one, I went with my favourite approach for this: Generic functions!

When I was looking at how to implement this feature, I noticed the pattern of parsing the config file using util functions like `config_blah_blah`. But the code was very repetitive between functions, basically boiling down to "if option in config section, read and return value, otherwise write option to config section if not falsey". So I made this a generic function for this called `read_update_config_value`. It does exactly what the other config parsing functions do for theme and advanced mode, but generically.

This function takes an `option` (i.e. `PUPGUI_GHA_TOKEN`), a `value` for this option (i.e. `gha-123foo456bar`), a optional section (defaults to `pupgui2` since it's the most common), and an optional config file (defaults to `CONFIG_FILE`, but I allowed this to be overridden in case we ever need to modify another config file, it was a low-cost change that helps extensibility).

The idea behind this functions is that other util functions for specific config files can call it with the option, value, and section information populated. In this PR, we have two new util functions that call it are `config_github_access_token` and `config_gitlab_access_token`. These function names follow the convention mentioned earlier. These are basically "wrapper" functions, with the idea being, we call these functions so that we don't have to know the key/section name when calling these functions. The functions themselves are aware of that, and all we have to do is call them and say "hey, write this value out for the config file value you control".

This means `config_gitlab_access_token` for example is always aware of the config file option it has to update and the section it has to update it in, but whatever is calling `config_gitlab_access_token` doesn't have to know that at all. I thought this was a cleaner way to architect it. Hope that explanation makes sense :-)

This should be generic enough that we can re-use it for `config_advanced_mode` and `config_theme`, but I didn't test it because I wasn't sure if it should go in this PR. If acceptable though I am happy to do that in this PR :slightly_smiling_face: 

### Section and Option Naming
These config file values go into the same `config.ini` that all other options to into, as defined in `constants.py`. I chose to use the `pupgui2` section as it seemed like other options went there. If we want a separate section though, that's fine by me :smile: 

The INI currently seems to have a "naming scheme" of all lowercase, singleword options (i.e. `advancedmode`). The names I chose for the access tokens goes against this, and it was simply in the interest of matching the environment variable names. But it can be easily changed if preferred, maybe something simple like `githubtoken` and `gitlabtoken`. Once these options are on the GUI though this will really not matter, and because of the way the functions are written, only the function controlling a given option needs to have the option name change.

<hr>

Some of the functionality of the web tokens may be pending changes following #302, but for now this PR does populate `web_access_tokens` with the values from the INI file. If desired we can use the new function I created to read/update config file values for theme and advanced mode, or it can go in a separate PR following this one.

Thanks!