### PR TITLE
Move requests session to ctmods

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -80,7 +80,6 @@ class MainWindow(QObject):
     def __init__(self):
         super(MainWindow, self).__init__()
 
-        self.rs = requests.Session()
         self.web_access_tokens = {
             'github': os.getenv('PUPGUI_GHA_TOKEN'),
             'gitlab': os.getenv('PUPGUI_GLA_TOKEN'),

--- a/pupgui2/resources/ctmods/ctmod_00protonge.py
+++ b/pupgui2/resources/ctmods/ctmod_00protonge.py
@@ -9,6 +9,7 @@ import hashlib
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.util import ghapi_rlcheck, extract_tar
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'GE-Proton'
@@ -28,7 +29,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_00winege.py
+++ b/pupgui2/resources/ctmods/ctmod_00winege.py
@@ -10,6 +10,7 @@ from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.datastructures import Launcher
 from pupgui2.util import ghapi_rlcheck, extract_tar, get_launcher_from_installdir
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'Wine-GE'
@@ -29,7 +30,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_boxtron.py
+++ b/pupgui2/resources/ctmods/ctmod_boxtron.py
@@ -9,6 +9,7 @@ from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 from PySide6.QtWidgets import QMessageBox
 
 from pupgui2.util import ghapi_rlcheck, host_which, extract_tar, write_tool_version
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'Boxtron'
@@ -29,7 +30,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_d8vk.py
+++ b/pupgui2/resources/ctmods/ctmod_d8vk.py
@@ -9,6 +9,7 @@ from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.datastructures import Launcher
 from pupgui2.util import ghapi_rlcheck, extract_zip, get_launcher_from_installdir
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'D8VK (nightly)'
@@ -29,7 +30,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs if main_window.rs else requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
+++ b/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
@@ -9,6 +9,7 @@ import requests
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.util import ghapi_rlcheck, extract_tar
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'Kron4ek Wine-Builds Vanilla'
@@ -28,7 +29,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_lutriswine.py
+++ b/pupgui2/resources/ctmods/ctmod_lutriswine.py
@@ -9,6 +9,7 @@ import hashlib
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.util import ghapi_rlcheck, extract_tar
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'Lutris-Wine'
@@ -28,7 +29,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -8,6 +8,7 @@ import requests
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.util import ghapi_rlcheck, extract_tar, write_tool_version
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'Luxtorpeda'
@@ -27,7 +28,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_northstarproton.py
+++ b/pupgui2/resources/ctmods/ctmod_northstarproton.py
@@ -8,6 +8,7 @@ import requests
 from PySide6.QtCore import QObject, Signal, Property, QCoreApplication
 
 from pupgui2.util import ghapi_rlcheck, extract_tar
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'Northstar Proton (Titanfall 2)'
@@ -27,7 +28,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_protontkg.py
+++ b/pupgui2/resources/ctmods/ctmod_protontkg.py
@@ -9,6 +9,7 @@ import requests
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.util import ghapi_rlcheck, extract_tar, extract_zip, extract_tar_zst, remove_if_exists
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'Proton Tkg'
@@ -32,7 +33,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_roberta.py
+++ b/pupgui2/resources/ctmods/ctmod_roberta.py
@@ -9,6 +9,7 @@ from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 from PySide6.QtWidgets import QMessageBox
 
 from pupgui2.util import ghapi_rlcheck, host_which, extract_tar, write_tool_version
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'Roberta'
@@ -29,7 +30,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_steamplaynone.py
+++ b/pupgui2/resources/ctmods/ctmod_steamplaynone.py
@@ -8,6 +8,7 @@ import requests
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.util import extract_tar
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'Steam-Play-None'
@@ -26,7 +27,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -12,6 +12,7 @@ from pupgui2.datastructures import MsgBoxType, MsgBoxResult
 from pupgui2.steamutil import get_fish_user_paths, remove_steamtinkerlaunch, get_external_steamtinkerlaunch_intall
 from pupgui2.util import host_which, config_advanced_mode
 from pupgui2.util import ghapi_rlcheck
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'SteamTinkerLaunch'
@@ -59,7 +60,11 @@ class CtInstaller(QObject):
         self.p_download_canceled = False
         self.remove_existing_installation = False
         self.main_window = main_window
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
+
         self.allow_git = allow_git
         proc_prefix = ['flatpak-spawn', '--host'] if os.path.exists('/.flatpak-info') else []
         self.distinfo = subprocess.run(

--- a/pupgui2/resources/ctmods/ctmod_vkd3dproton.py
+++ b/pupgui2/resources/ctmods/ctmod_vkd3dproton.py
@@ -9,6 +9,7 @@ from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.datastructures import Launcher
 from pupgui2.util import ghapi_rlcheck, extract_tar, extract_tar_zst, get_launcher_from_installdir
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'vkd3d-proton'
@@ -27,7 +28,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled

--- a/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
+++ b/pupgui2/resources/ctmods/ctmod_z1dxvkasync.py
@@ -18,5 +18,8 @@ class CtInstaller(DXVKInstaller):
     CT_URL = 'https://gitlab.com/api/v4/projects/43488626/releases'
     CT_INFO_URL = 'https://gitlab.com/Ph42oN/dxvk-gplasync/-/releases/'
 
-    def __init__(self, main_window = None, request_headers = {}):
-        super().__init__(main_window, build_headers_with_authorization(request_headers, main_window.web_access_tokens, 'gitlab'))
+    def __init__(self, main_window = None):
+        super().__init__(main_window)
+
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'gitlab')
+        self.rs.headers.update(rs_headers)

--- a/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
+++ b/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
@@ -8,6 +8,7 @@ import requests
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.util import ghapi_rlcheck, extract_zip
+from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'DXVK (nightly)'
@@ -27,7 +28,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.rs = main_window.rs or requests.Session()
+
+        self.rs = requests.Session()
+        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
+        self.rs.headers.update(rs_headers)
 
     def get_download_canceled(self):
         return self.p_download_canceled


### PR DESCRIPTION
Currently, all ctmods share a single requests session which may contain the authorization header for GitHub. With #302, fetching compatibility tools from GitLab is now possible too. This requires ctmods to be able to choose between the GitHub and GitLab authorization key.

This PR does following changes:
- Each ctmod has its own requests session
- The ctmods will read the authorization keys from `main_window.web_access_tokens` and build a header using `util.py#build_headers_with_authorization` which is added to the local requests session

See https://github.com/DavidoTek/ProtonUp-Qt/pull/302#issuecomment-1808909601 for details