### PR TITLE
Config: Use read_update_config_value for advancedmode and theme

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -150,21 +150,7 @@ def config_theme(theme=None) -> str:
     Return Type: str
     """
 
-    config = ConfigParser()
-
-    if theme:
-        config.read(CONFIG_FILE)
-        if not config.has_section('pupgui2'):
-            config.add_section('pupgui2')
-        config['pupgui2']['theme'] = theme
-        os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
-        with open(CONFIG_FILE, 'w') as file:
-            config.write(file)
-    elif os.path.exists(CONFIG_FILE):
-        config.read(CONFIG_FILE)
-        if config.has_option('pupgui2', 'theme'):
-            return config['pupgui2']['theme']
-    return theme
+    return read_update_config_value('theme', theme, section='pupgui2')
 
 
 def config_advanced_mode(advmode=None) -> str:
@@ -173,21 +159,8 @@ def config_advanced_mode(advmode=None) -> str:
     Write advmode to config or read if advmode=None
     Return Type: str
     """
-    config = ConfigParser()
 
-    if advmode:
-        config.read(CONFIG_FILE)
-        if not config.has_section('pupgui2'):
-            config.add_section('pupgui2')
-        config['pupgui2']['advancedmode'] = advmode
-        os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
-        with open(CONFIG_FILE, 'w') as file:
-            config.write(file)
-    elif os.path.exists(CONFIG_FILE):
-        config.read(CONFIG_FILE)
-        if config.has_option('pupgui2', 'advancedmode'):
-            return config['pupgui2']['advancedmode']
-    return advmode
+    return read_update_config_value('advancedmode', advmode, section='pupgui2')
 
 
 def config_github_access_token(github_token=None):

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -121,7 +121,6 @@ def read_update_config_value(option: str, value, section: str = 'pupgui2', confi
     """
 
     config = ConfigParser()
-    config_value = ''
 
     # Write value if given
     if value:
@@ -133,14 +132,13 @@ def read_update_config_value(option: str, value, section: str = 'pupgui2', confi
 
         with open(config_file, 'w') as cfg:
             config.write(cfg)
-        config_value = value
     # If no value, attempt to read from config
     elif os.path.exists(config_file):
         config.read(config_file)
         if config.has_option(section, option):
-            config_value = config[section][option]
+            value = config[section][option]
 
-    return config_value
+    return value
 
 
 def config_theme(theme=None) -> str:


### PR DESCRIPTION
This PR replaces the logic in `util#config_theme` and `util#config_advanced_mode` to use the generic function `util#read_update_config_value` from #306, a change which was discussed in passing in that PR.

The logic in these functions was used as a template to create `read_update_config_value`, so there should be no compatibility breaking changes. The option names are also have not been changed. This change just makes the code slightly cleaner :-)

This PR does not touch `install_directory` or `config_custom_install_location`, as discussed we could implement this in future if we feel we need such a change.

Thanks!