### PR TITLE
Roberta: Use fetch_project_releases and fetch_project_release_data

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_roberta.py
+++ b/pupgui2/resources/ctmods/ctmod_roberta.py
@@ -9,7 +9,7 @@ from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 from PySide6.QtWidgets import QMessageBox
 
 from pupgui2.util import ghapi_rlcheck, host_which, extract_tar, write_tool_version
-from pupgui2.util import build_headers_with_authorization
+from pupgui2.util import build_headers_with_authorization, fetch_project_release_data, fetch_project_releases
 
 
 CT_NAME = 'Roberta'
@@ -30,6 +30,7 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
+        self.release_format = 'tar.xz'
 
         self.rs = requests.Session()
         rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
@@ -86,17 +87,8 @@ class CtInstaller(QObject):
         Content(s):
             'version', 'date', 'download', 'size'
         """
-        url = self.CT_URL + (f'/tags/{tag}' if tag else '/latest')
-        data = self.rs.get(url).json()
-        if 'tag_name' not in data:
-            return None
 
-        values = {'version': data['tag_name'], 'date': data['published_at'].split('T')[0]}
-        for asset in data['assets']:
-            if asset['name'].endswith('tar.xz'):
-                values['download'] = asset['browser_download_url']
-                values['size'] = asset['size']
-        return values
+        return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag)
 
     def is_system_compatible(self):
         """
@@ -122,7 +114,8 @@ class CtInstaller(QObject):
         List available releases
         Return Type: str[]
         """
-        return [release['tag_name'] for release in ghapi_rlcheck(self.rs.get(f'{self.CT_URL}?per_page={str(count)}').json()) if 'tag_name' in release]
+
+        return fetch_project_releases(self.CT_URL, self.rs, count=count)
 
     def get_tool(self, version, install_dir, temp_dir):
         """

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -551,8 +551,6 @@ def fetch_project_releases(releases_url: str, rs: requests.Session, count=100) -
     """
     releases_api_url: str = f'{releases_url}?per_page={str(count)}'
 
-    print(rs.headers)
-
     releases: dict = {}
     tag_key: str = ''
     if GITHUB_API in releases_url:


### PR DESCRIPTION
Updates the Roberta ctmod to use `util#fetch_project_releases` and `util#fetch_project_release_data` from #302.

I chose Roberta as a straightforward and lower-cost way to proof this method out for other ctmods :-)