### PR TITLE
Boxtron: Use Subclass of Luxtorpeda

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_boxtron.py
+++ b/pupgui2/resources/ctmods/ctmod_boxtron.py
@@ -4,7 +4,7 @@
 
 from PySide6.QtCore import QCoreApplication
 
-from pupgui2.util import host_which
+from pupgui2.util import create_missing_dependencies_message
 from pupgui2.resources.ctmods.ctmod_luxtorpeda import CtInstaller as LuxtorpedaInstaller
 
 
@@ -24,23 +24,22 @@ class CtInstaller(LuxtorpedaInstaller):
         self.extract_dir_name = 'boxtron'
         self.deps = [ 'doxbox', 'inotifywait', 'timidity' ]
 
-    def is_system_compatible(self):
+    def is_system_compatible(self) -> bool:
         """
         Are the system requirements met?
         Return Type: bool
         """
 
-        # Could be a generic method in future? Not sure how re-usable this is between ctmods
-        tr_missing = QCoreApplication.instance().translate('ctmod_boxtron', 'missing')
-        tr_found = QCoreApplication.instance().translate('ctmod_boxtron', 'found')
+        # Skip check if we have no dependencies
+        if not self.deps:
+            return True
+
+        # TODO put this in Luxtorpeda base class, with no deps so we can skip it?
         msg_tr_title = QCoreApplication.instance().translate('ctmod_boxtron', 'Missing dependencies!')
 
-        if all(host_which(dep) for dep in self.deps):
-            return True
-        msg = QCoreApplication.instance().translate('ctmod_boxtron', 'You need {DEPS} for Boxtron.'.format(DEPS=', '.join(self.deps))) + '\n\n'
-        msg += '\n'.join(f'{dep_name}: {tr_missing if host_which(dep_name) else tr_found}' for dep_name in self.deps)
-        msg += '\n\n' + QCoreApplication.instance().translate('ctmod_boxtron', 'Will continue installing Boxtron anyway.')
-
-        self._emit_missing_dependencies(msg_tr_title, msg)
+        # Only emit warning if not success
+        msg, success = create_missing_dependencies_message('Boxtron', self.deps, 'ctmod_boxtron')
+        if not success:
+            self._emit_missing_dependencies(msg_tr_title, msg)
 
         return True  # install Boxtron anyway

--- a/pupgui2/resources/ctmods/ctmod_boxtron.py
+++ b/pupgui2/resources/ctmods/ctmod_boxtron.py
@@ -30,16 +30,4 @@ class CtInstaller(LuxtorpedaInstaller):
         Return Type: bool
         """
 
-        # Skip check if we have no dependencies
-        if not self.deps:
-            return True
-
-        # TODO put this in Luxtorpeda base class, with no deps so we can skip it?
-        msg_tr_title = QCoreApplication.instance().translate('ctmod_boxtron', 'Missing dependencies!')
-
-        # Only emit warning if not success
-        msg, success = create_missing_dependencies_message('Boxtron', self.deps, 'ctmod_boxtron')
-        if not success:
-            self._emit_missing_dependencies(msg_tr_title, msg)
-
-        return True  # install Boxtron anyway
+        return super().is_system_compatible(ct_name = 'Boxtron', deps = self.deps, tr_context = 'ctmod_boxtron')

--- a/pupgui2/resources/ctmods/ctmod_boxtron.py
+++ b/pupgui2/resources/ctmods/ctmod_boxtron.py
@@ -29,4 +29,4 @@ class CtInstaller(LuxtorpedaInstaller):
         Return Type: bool
         """
 
-        return super().is_system_compatible(ct_name = 'Boxtron')
+        return super().is_system_compatible(ct_name = CT_NAME)

--- a/pupgui2/resources/ctmods/ctmod_boxtron.py
+++ b/pupgui2/resources/ctmods/ctmod_boxtron.py
@@ -2,14 +2,10 @@
 # Boxtron
 # Copyright (C) 2021 DavidoTek, partially based on AUNaseef's protonup
 
-import os
-import requests
+from PySide6.QtCore import QCoreApplication
 
-from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
-from PySide6.QtWidgets import QMessageBox
-
-from pupgui2.util import ghapi_rlcheck, host_which, extract_tar, write_tool_version
-from pupgui2.util import build_headers_with_authorization
+from pupgui2.util import host_which
+from pupgui2.resources.ctmods.ctmod_luxtorpeda import CtInstaller as LuxtorpedaInstaller
 
 
 CT_NAME = 'Boxtron'
@@ -17,142 +13,34 @@ CT_LAUNCHERS = ['steam']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_boxtron', '''Steam Play compatibility tool to run DOS games using native Linux DOSBox.''')}
 
 
-class CtInstaller(QObject):
+class CtInstaller(LuxtorpedaInstaller):
 
     BUFFER_SIZE = 4096
     CT_URL = 'https://api.github.com/repos/dreamer/boxtron/releases'
     CT_INFO_URL = 'https://github.com/dreamer/boxtron/releases/tag/'
 
-    p_download_progress_percent = 0
-    download_progress_percent = Signal(int)
-    message_box_message = Signal((str, str, QMessageBox.Icon))
-
     def __init__(self, main_window = None):
-        super(CtInstaller, self).__init__()
-        self.p_download_canceled = False
-
-        self.rs = requests.Session()
-        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
-        self.rs.headers.update(rs_headers)
-
-    def get_download_canceled(self):
-        return self.p_download_canceled
-
-    def set_download_canceled(self, val):
-        self.p_download_canceled = val
-
-    download_canceled = Property(bool, get_download_canceled, set_download_canceled)
-
-    def __set_download_progress_percent(self, value : int):
-        if self.p_download_progress_percent == value:
-            return
-        self.p_download_progress_percent = value
-        self.download_progress_percent.emit(value)
-
-    def __download(self, url, destination):
-        """
-        Download files from url to destination
-        Return Type: bool
-        """
-        try:
-            file = self.rs.get(url, stream=True)
-        except OSError:
-            return False
-
-        self.__set_download_progress_percent(1) # 1 download started
-        f_size = int(file.headers.get('content-length'))
-        c_count = int(f_size / self.BUFFER_SIZE)
-        c_current = 1
-        destination = os.path.expanduser(destination)
-        os.makedirs(os.path.dirname(destination), exist_ok=True)
-        with open(destination, 'wb') as dest:
-            for chunk in file.iter_content(chunk_size=self.BUFFER_SIZE):
-                if self.download_canceled:
-                    self.download_canceled = False
-                    self.__set_download_progress_percent(-2) # -2 download canceled
-                    return False
-                if chunk:
-                    dest.write(chunk)
-                    dest.flush()
-                self.__set_download_progress_percent(int(min(c_current / c_count * 98.0, 98.0))) # 1-98, 100 after extract
-                c_current += 1
-        self.__set_download_progress_percent(99) # 99 download complete
-        return True
-
-    def __fetch_github_data(self, tag):
-        """
-        Fetch GitHub release information
-        Return Type: dict
-        Content(s):
-            'version', 'date', 'download', 'size'
-        """
-        url = self.CT_URL + (f'/tags/{tag}' if tag else '/latest')
-        data = self.rs.get(url).json()
-        if 'tag_name' not in data:
-            return None
-
-        values = {'version': data['tag_name'], 'date': data['published_at'].split('T')[0]}
-        for asset in data['assets']:
-            if asset['name'].endswith('tar.xz'):
-                values['download'] = asset['browser_download_url']
-                values['size'] = asset['size']
-        return values
+        super().__init__(main_window)
+        self.extract_dir_name = 'boxtron'
+        self.deps = [ 'doxbox', 'inotifywait', 'timidity' ]
 
     def is_system_compatible(self):
         """
         Are the system requirements met?
         Return Type: bool
         """
+
+        # Could be a generic method in future? Not sure how re-usable this is between ctmods
         tr_missing = QCoreApplication.instance().translate('ctmod_boxtron', 'missing')
         tr_found = QCoreApplication.instance().translate('ctmod_boxtron', 'found')
         msg_tr_title = QCoreApplication.instance().translate('ctmod_boxtron', 'Missing dependencies!')
 
-        if host_which('dosbox') and host_which('inotifywait') and host_which('timidity'):
+        if all(host_which(dep) for dep in self.deps):
             return True
-        msg = QCoreApplication.instance().translate('ctmod_boxtron', 'You need dosbox, inotify-tools and timidity for Boxtron.') + '\n\n'
-        msg += 'dosbox: ' + str(tr_missing if host_which('dosbox') is None else tr_found) + '\n'
-        msg += 'inotify-tools: ' + str(tr_missing if host_which('inotifywait') is None else tr_found) + '\n'
-        msg += 'timidity: ' + str(tr_missing if host_which('timidity') is None else tr_found)
+        msg = QCoreApplication.instance().translate('ctmod_boxtron', 'You need {DEPS} for Boxtron.'.format(DEPS=', '.join(self.deps))) + '\n\n'
+        msg += '\n'.join(f'{dep_name}: {tr_missing if host_which(dep_name) else tr_found}' for dep_name in self.deps)
         msg += '\n\n' + QCoreApplication.instance().translate('ctmod_boxtron', 'Will continue installing Boxtron anyway.')
 
-        self.message_box_message.emit(msg_tr_title, msg, QMessageBox.Warning)
+        self._emit_missing_dependencies(msg_tr_title, msg)
 
         return True  # install Boxtron anyway
-
-    def fetch_releases(self, count=100):
-        """
-        List available releases
-        Return Type: str[]
-        """
-        return [release['tag_name'] for release in ghapi_rlcheck(self.rs.get(f'{self.CT_URL}?per_page={str(count)}').json()) if 'tag_name' in release]
-
-    def get_tool(self, version, install_dir, temp_dir):
-        """
-        Download and install the compatibility tool
-        Return Type: bool
-        """
-        data = self.__fetch_github_data(version)
-
-        if not data or 'download' not in data:
-            return False
-
-
-        boxtron_tar = os.path.join(temp_dir, data['download'].split('/')[-1])
-        if not self.__download(url=data['download'], destination=boxtron_tar):
-            return False
-
-        boxtron_dir = os.path.join(install_dir, 'boxtron')
-        if not extract_tar(boxtron_tar, install_dir, mode='xz'):
-            return False
-        write_tool_version(boxtron_dir, version)
-
-        self.__set_download_progress_percent(100)
-
-        return True
-
-    def get_info_url(self, version):
-        """
-        Get link with info about version (eg. GitHub release page)
-        Return Type: str
-        """
-        return self.CT_INFO_URL + version

--- a/pupgui2/resources/ctmods/ctmod_boxtron.py
+++ b/pupgui2/resources/ctmods/ctmod_boxtron.py
@@ -30,4 +30,4 @@ class CtInstaller(LuxtorpedaInstaller):
         Return Type: bool
         """
 
-        return super().is_system_compatible(ct_name = 'Boxtron', deps = self.deps, tr_context = 'ctmod_boxtron')
+        return super().is_system_compatible(ct_name = 'Boxtron', tr_context = 'ctmod_boxtron')

--- a/pupgui2/resources/ctmods/ctmod_boxtron.py
+++ b/pupgui2/resources/ctmods/ctmod_boxtron.py
@@ -29,4 +29,4 @@ class CtInstaller(LuxtorpedaInstaller):
         Return Type: bool
         """
 
-        return super().is_system_compatible(ct_name = 'Boxtron', tr_context = 'ctmod_boxtron')
+        return super().is_system_compatible(ct_name = 'Boxtron')

--- a/pupgui2/resources/ctmods/ctmod_boxtron.py
+++ b/pupgui2/resources/ctmods/ctmod_boxtron.py
@@ -4,7 +4,6 @@
 
 from PySide6.QtCore import QCoreApplication
 
-from pupgui2.util import create_missing_dependencies_message
 from pupgui2.resources.ctmods.ctmod_luxtorpeda import CtInstaller as LuxtorpedaInstaller
 
 

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -9,7 +9,7 @@ from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 from PySide6.QtWidgets import QMessageBox
 
 from pupgui2.util import ghapi_rlcheck, extract_tar, write_tool_version
-from pupgui2.util import build_headers_with_authorization
+from pupgui2.util import build_headers_with_authorization, create_missing_dependencies_message
 
 
 CT_NAME = 'Luxtorpeda'
@@ -30,7 +30,9 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.extract_dir_name = 'luxtorpeda'  # Allows override for Boxtron/Roberta
+
+        # Allows override for Boxtron/Roberta
+        self.extract_dir_name = 'luxtorpeda'
 
         self.rs = requests.Session()
         rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
@@ -99,12 +101,23 @@ class CtInstaller(QObject):
                 values['size'] = asset['size']
         return values
 
-    def is_system_compatible(self):
+    def is_system_compatible(self, ct_name: str = 'Luxtorpeda', deps: list = [], tr_context: str = 'ctmod_luxtorpeda') -> bool:
         """
         Are the system requirements met?
         Return Type: bool
         """
-        return True
+
+        if not deps:
+            return True  # Skip check if we have no dependencies
+
+        # Emit warning if we generated a missing dependencies message
+        msg_tr_title = QCoreApplication.instance().translate(tr_context, 'Missing dependencies!')
+        msg, success = create_missing_dependencies_message(ct_name, deps, tr_context)
+        if not success:
+            self._emit_missing_dependencies(msg_tr_title, msg)
+
+        return True  # install Boxtron anyway
+
 
     def fetch_releases(self, count=100):
         """

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -102,7 +102,7 @@ class CtInstaller(QObject):
                 values['size'] = asset['size']
         return values
 
-    def is_system_compatible(self, ct_name: str = 'Luxtorpeda') -> bool:
+    def is_system_compatible(self, ct_name: str = CT_NAME) -> bool:
         """
         Are the system requirements met?
         Return Type: bool

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -30,7 +30,10 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-        self.extract_dir_name = 'luxtorpeda'  # Allows override for Boxtron/Roberta
+
+        # Allows override for Boxtron/Roberta
+        self.extract_dir_name = 'luxtorpeda'
+        self.deps = []
 
         self.rs = requests.Session()
         rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
@@ -99,18 +102,18 @@ class CtInstaller(QObject):
                 values['size'] = asset['size']
         return values
 
-    def is_system_compatible(self, ct_name: str = 'Luxtorpeda', deps: list = [], tr_context: str = 'ctmod_luxtorpeda') -> bool:
+    def is_system_compatible(self, ct_name: str = 'Luxtorpeda', tr_context: str = 'ctmod_luxtorpeda') -> bool:
         """
         Are the system requirements met?
         Return Type: bool
         """
 
-        if not deps:
+        if not self.deps:
             return True  # Skip check if we have no dependencies
 
         # Emit warning if we generated a missing dependencies message
         msg_tr_title = QCoreApplication.instance().translate(tr_context, 'Missing dependencies!')
-        msg, success = create_missing_dependencies_message(ct_name, deps, tr_context)
+        msg, success = create_missing_dependencies_message(ct_name, self.deps, tr_context)
         if not success:
             self.message_box_message.emit(msg_tr_title, msg, QMessageBox.Warning)
 

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -102,7 +102,7 @@ class CtInstaller(QObject):
                 values['size'] = asset['size']
         return values
 
-    def is_system_compatible(self, ct_name: str = 'Luxtorpeda', tr_context: str = 'ctmod_luxtorpeda') -> bool:
+    def is_system_compatible(self, ct_name: str = 'Luxtorpeda') -> bool:
         """
         Are the system requirements met?
         Return Type: bool
@@ -112,8 +112,8 @@ class CtInstaller(QObject):
             return True  # Skip check if we have no dependencies
 
         # Emit warning if we generated a missing dependencies message
-        msg_tr_title = QCoreApplication.instance().translate(tr_context, 'Missing dependencies!')
-        msg, success = create_missing_dependencies_message(ct_name, self.deps, tr_context)
+        msg_tr_title = self.tr('Missing dependencies!')
+        msg, success = create_missing_dependencies_message(ct_name, self.deps, 'util.py')
         if not success:
             self.message_box_message.emit(msg_tr_title, msg, QMessageBox.Warning)
 

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -113,7 +113,7 @@ class CtInstaller(QObject):
 
         # Emit warning if we generated a missing dependencies message
         msg_tr_title = self.tr('Missing dependencies!')
-        msg, success = create_missing_dependencies_message(ct_name, self.deps, 'util.py')
+        msg, success = create_missing_dependencies_message(ct_name, self.deps)
         if not success:
             self.message_box_message.emit(msg_tr_title, msg, QMessageBox.Warning)
 

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -30,9 +30,7 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
-
-        # Allows override for Boxtron/Roberta
-        self.extract_dir_name = 'luxtorpeda'
+        self.extract_dir_name = 'luxtorpeda'  # Allows override for Boxtron/Roberta
 
         self.rs = requests.Session()
         rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
@@ -114,7 +112,7 @@ class CtInstaller(QObject):
         msg_tr_title = QCoreApplication.instance().translate(tr_context, 'Missing dependencies!')
         msg, success = create_missing_dependencies_message(ct_name, deps, tr_context)
         if not success:
-            self._emit_missing_dependencies(msg_tr_title, msg)
+            self.message_box_message.emit(msg_tr_title, msg, QMessageBox.Warning)
 
         return True  # install Boxtron anyway
 
@@ -148,13 +146,6 @@ class CtInstaller(QObject):
         self.__set_download_progress_percent(100)
 
         return True
-
-    def _emit_missing_dependencies(self, msg_title, msg):
-        """
-        Emit a missing dependencies warning message for child class
-        """
-
-        self.message_box_message.emit(msg_title, msg, QMessageBox.Warning)
 
     def get_info_url(self, version):
         """

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -831,7 +831,7 @@ def get_launcher_from_installdir(install_dir: str) -> Launcher:
         return Launcher.UNKNOWN
 
 
-def create_missing_dependencies_message(ct_name: str, dependencies: List):
+def create_missing_dependencies_message(ct_name: str, dependencies: List) -> Tuple[str, bool]:
 
     """
     Generate a string message noting which dependencies are missing for a ctmod_name, with tr_context to translate relevant strings.

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -831,7 +831,7 @@ def get_launcher_from_installdir(install_dir: str) -> Launcher:
         return Launcher.UNKNOWN
 
 
-def create_missing_dependencies_message(ct_name: str, dependencies: List, tr_context: str):
+def create_missing_dependencies_message(ct_name: str, dependencies: List):
 
     """
     Generate a string message noting which dependencies are missing for a ctmod_name, with tr_context to translate relevant strings.
@@ -840,15 +840,15 @@ def create_missing_dependencies_message(ct_name: str, dependencies: List, tr_con
     Return Type: str, bool
     """
 
-    tr_missing = QCoreApplication.instance().translate(tr_context, 'missing')
-    tr_found = QCoreApplication.instance().translate(tr_context, 'found')
+    tr_missing = QCoreApplication.instance().translate('util.py', 'missing')
+    tr_found = QCoreApplication.instance().translate('util.py', 'found')
 
     deps_found = [ host_which(dep) for dep in dependencies ]
 
     if all(deps_found):
         return '', True
-    msg = QCoreApplication.instance().translate(tr_context, 'You need {DEPS} for {CT_NAME}.'.format(DEPS=', '.join(dependencies), CT_NAME=ct_name)) + '\n\n'
+    msg = QCoreApplication.instance().translate('util.py', 'You need {DEPS} for {CT_NAME}.'.format(DEPS=', '.join(dependencies), CT_NAME=ct_name)) + '\n\n'
     msg += '\n'.join(f'{dep_name}: {tr_missing if not deps_found[i] else tr_found}' for i, dep_name in enumerate(dependencies))
-    msg += '\n\n' + QCoreApplication.instance().translate(tr_context, 'Will continue installing {CT_NAME} anyway.'.format(CT_NAME=ct_name))
+    msg += '\n\n' + QCoreApplication.instance().translate('util.py', 'Will continue installing {CT_NAME} anyway.'.format(CT_NAME=ct_name))
 
     return msg, False

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -843,10 +843,12 @@ def create_missing_dependencies_message(ct_name: str, dependencies: List, tr_con
     tr_missing = QCoreApplication.instance().translate(tr_context, 'missing')
     tr_found = QCoreApplication.instance().translate(tr_context, 'found')
 
-    if all(host_which(dep) for dep in dependencies):
+    deps_found = [ host_which(dep) for dep in dependencies ]
+
+    if all(deps_found):
         return '', True
     msg = QCoreApplication.instance().translate(tr_context, 'You need {DEPS} for {CT_NAME}.'.format(DEPS=', '.join(dependencies), CT_NAME=ct_name)) + '\n\n'
-    msg += '\n'.join(f'{dep_name}: {tr_missing if host_which(dep_name) else tr_found}' for dep_name in dependencies)
+    msg += '\n'.join(f'{dep_name}: {tr_missing if not deps_found[i] else tr_found}' for i, dep_name in enumerate(dependencies))
     msg += '\n\n' + QCoreApplication.instance().translate(tr_context, 'Will continue installing {CT_NAME} anyway.'.format(CT_NAME=ct_name))
 
     return msg, False

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -829,3 +829,24 @@ def get_launcher_from_installdir(install_dir: str) -> Launcher:
         return Launcher.BOTTLES
     else:
         return Launcher.UNKNOWN
+
+
+def create_missing_dependencies_message(ct_name: str, dependencies: List, tr_context: str):
+
+    """
+    Generate a string message noting which dependencies are missing for a ctmod_name, with tr_context to translate relevant strings.
+    Return the string message and a boolean to note whether the dependencies were met or not.
+
+    Return Type: str, bool
+    """
+
+    tr_missing = QCoreApplication.instance().translate(tr_context, 'missing')
+    tr_found = QCoreApplication.instance().translate(tr_context, 'found')
+
+    if all(host_which(dep) for dep in dependencies):
+        return '', True
+    msg = QCoreApplication.instance().translate(tr_context, 'You need {DEPS} for {CT_NAME}.'.format(DEPS=', '.join(dependencies), CT_NAME=ct_name)) + '\n\n'
+    msg += '\n'.join(f'{dep_name}: {tr_missing if host_which(dep_name) else tr_found}' for dep_name in dependencies)
+    msg += '\n\n' + QCoreApplication.instance().translate(tr_context, 'Will continue installing {CT_NAME} anyway.'.format(CT_NAME=ct_name))
+
+    return msg, False


### PR DESCRIPTION
## Overview
This PR updates the Boxtron ctmod to use a subclass of the Luxtorpeda ctmod, stripping it out almost entirely and having a couple of tweaked values. A new helper method was added to facilitate generating the dependencies warning message, and Luxtorpeda's `is_system_compatible` method was tweaked a little bit so that it could be called by subclasses. This saves subclasses having to implement this themselves and has as little repeated code as possible.

I chose Luxtorpeda as the primary ctmod as it was the most "generic". It didn't have any dependencies and did a lot of what Boxtron did, but without the dependencies check. In my mind this made it the ideal candidate to be the superclass, it has the fewest moving parts.

Luxtorpeda, Roberta, and Boxtron are all sister projects (with Luxtorpeda iirc being the "overarching" one that can use these two, and others). So from that hierarchy, I think using Luxtorpeda as the base makes sense.

## Background
When looking into porting more ctmods over to use the GitHub/GitLab download functions, I thought to start with some "low risk" ctmods, so I was deciding between Boxtron, Roberta, and Luxtorpeda. But when looking at them, I noticed they shared a lot of the same code. The only difference really was that Boxtron and Roberta did dependency checks. There were a couple of other smaller differences, such as the extract directory name being hardcoded, but these were easily fixed by making them variables.

At first I stripped out the Boxtron ctmod, made it subclass the Luxtorpeda ctmod, set its `extract_dir_name`, and then reimplemented `is_system_compatible` so that it would check for the Boxtron dependencies instead of simply `return True` which the Luxtorpeda implementation does.

Then, I decided to clean up the logic a little bit, and generate the string using `str.join` and a list of dependencies. And of course, then I fell down the rabbit hole and decided to make it a re-usable function that generates the missing dependencies string from the list of dependencies (and a ctmod name to display, and the translation context). You could make a bingo game out of it at this point :smile: 

Once this was made generic, I tweaked Luxtorpeda's `is_system_compatible` function to take some optional arguments, so that subclasses could override these and generate the dependencies message relevant to them. `is_system_compatible` now takes the ctmod name (purely visual for displaying what ctmod needs these dependencies in the error dialog), the dependencies list (default to empty), and the translation context (defaults to `ctmod_luxtorpeda`).

`is_system_compatible` will skip running if the dependencies argument is falsey (i.e. empty), meaning by default it won't run at all for Luxtorpeda, because the optional dependencies parameter is falsey. Boxtron overrides `is_system_compatible` with no arguments, and instead calls super with its own ctmod name, dependencies list, and tr_context provided.

This might seem excessive, but it means we can re-use this for, say, Roberta, which should be straightforward to re-implement the same way Boxtron is in this PR.

## Changes
So the overall changes are:
- Luxtorpeda:
    - Use a variable name to define the extract dir name, so subclasses can override it
    - Tweak `is_system_compatible` to take some optional parameters, allowing subclasses to use it to generate a relevant missing dependencies message
- Boxtron:
    - Re-implement entire ctmod to be a subclass of Luxtorpeda ctmod
    - Override extract dir name to `boxtron`
    - Set dependencies list
    - Re-implement Luxtorpeda ctmod's `is_system_compatible` method to use `ct_name = 'Boxtron', deps = self.deps, tr_context = 'boxtron'` so that the relevant missing dependencies dialog can be generated for Boxtron
    - One Dependency's *display name* slightly changed from `inotify-tools` to `inotifywait`, as the dependencies list reflects the `host_which` name. We *could* make a dictionary with a binary name and display name, if we really want to preserve this though!
- Util:
    - New `create_missing_dependencies_message` function which generates a missing dependencies string using a list of dependency names and a translation context 

## Testing
I tested downloading Luxtorpeda and Boxtron on `main` and on this branch, and the functionality does not appear to be impacted. `host_which` still performs exactly as it should

## Concerns
My old friend `QCoreApplication.instance().translate()` is sure to come back and bite me here. I know there is some weirdness around how this works, and it might get grumpy about using `tr_context` as a variable. In that case, maybe giving it `'{TR_CONTEXT}'.format(TR_CONTEXT=tr_context)` would make it happy. It works in my tests *but* I'm not using the i18n stuff, so please bonk me if I broke something here :-)

We also call `host_which` a few times more than we probably need to. For example we call it in `all(host_which(dep) for dep in dependencies)`, which for Boxtron is 3 calls. Then we call it in `'\n'.join` with our iterator. It might be possible to store the `host_which` status for dependencies in a list, and maybe use `enumerate` in our `.join` call to check the index of the current iteration over the index of the dependency found list. Maybe something like this (untested):

```python
deps_found = [ host_which(dep) for dep in dependencies ]
if all(deps_found):
    return
msg += '\n'.join(f'{dep_name}: {tr_missing if deps_found[i] else tr_found}' for i, dep_name in enumerate(dependencies))
```

It might help performance a little if we use this for a ctmod which could have a lot of dependencies maybe. Though there'd probably need to be a *lot* of dependencies for any noticeable performance impact :-)

## Future Work
The changes in this PR could be applied to Roberta as well, and if this approach is accepted, I can implement this as well.

This PR does not move Luxtorpeda over to using the GitHub/GitLab methods mentioned, because that change can be made independent of this work. If this approach is accepted, we can move Roberta over to using this ctmod.

The code in this ctmod is probably sharable with some other """simpler""" ctmods for lack of a better term, such as Steam-Play-None. However, since that project is independent of Luxtorpeda, it would be better to move its repeated code into a util function if possible. Or, probably more useful, it could be moved into a base ctmod class, once we reach that stage :-)

<hr>

Thanks!