### PR TITLE
Add GUI exception handler

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -21,6 +21,7 @@ from pupgui2.gamepadinputworker import GamepadInputWorker
 from pupgui2.pupgui2aboutdialog import PupguiAboutDialog
 from pupgui2.pupgui2ctinfodialog import PupguiCtInfoDialog
 from pupgui2.pupgui2customiddialog import PupguiCustomInstallDirectoryDialog
+from pupgui2.pupgui2exceptionhandler import PupguiExceptionHandler
 from pupgui2.pupgui2gamelistdialog import PupguiGameListDialog
 from pupgui2.pupgui2installdialog import PupguiInstallDialog
 from pupgui2.steamutil import get_steam_acruntime_list, get_steam_app_list, get_steam_ct_game_map
@@ -527,6 +528,8 @@ def main():
     app.setApplicationVersion(APP_VERSION)
     app.setWindowIcon(QIcon.fromTheme('net.davidotek.pupgui2'))
     app.setDesktopFileName('net.davidotek.pupgui2')
+
+    PupguiExceptionHandler(app)
 
     lang = QLocale.languageToCode(QLocale().language())
     lname = QLocale().name()

--- a/pupgui2/pupgui2exceptionhandler.py
+++ b/pupgui2/pupgui2exceptionhandler.py
@@ -1,0 +1,29 @@
+import sys
+import logging
+import traceback
+
+from types import TracebackType
+
+from PySide6.QtCore import QObject, Signal, Slot
+from PySide6.QtWidgets import QMessageBox, QApplication
+
+
+class PupguiExceptionHandler(QObject):
+    exception = Signal(type, BaseException, TracebackType)
+
+    def __init__(self, parent):
+        self.logger = logging.getLogger(type(self).__name__)
+        super(PupguiExceptionHandler, self).__init__(parent)
+        sys.excepthook = self._excepthook
+        self.exception.connect(self._on_exception)
+
+    def _excepthook(self, exc_type: type[BaseException], exc_value: BaseException, exc_tb: TracebackType):
+        self.exception.emit(exc_type, exc_value, exc_tb)
+
+    @Slot(type, BaseException, TracebackType)
+    def _on_exception(self, exc_type: type[BaseException], exc_value: BaseException, exc_tb: TracebackType):
+        message = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+
+        self.logger.fatal(message)
+        QMessageBox.critical(None, exc_type.__name__, message)
+        QApplication.quit()


### PR DESCRIPTION
Fix https://github.com/DavidoTek/ProtonUp-Qt/issues/247

Adds a GUI exception handler, similar to the [implementation in the Rare game launcher](https://github.com/Dummerle/Rare/blob/76df1236e9d6a8ec122b293858c90330e6bb2fe3/rare/widgets/rare_app.py#L19-L41).