### PR TITLE
Tool List: Mark Tool as Global

### DIFF
--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -106,13 +106,13 @@ class BasicCompatTool:
     install_dir = ''
     install_folder = ''
     ct_type = CTType.UNKNOWN
+    is_global = False
 
     def __init__(self, displayname, install_dir, install_folder, ct_type = CTType.UNKNOWN) -> None:
         self.displayname = displayname
         self.install_dir = install_dir
         self.install_folder = install_folder
         self.ct_type = ct_type
-        self.is_global = False
 
     def set_version(self, ver : str) -> None:
         self.version = ver

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -112,21 +112,26 @@ class BasicCompatTool:
         self.install_dir = install_dir
         self.install_folder = install_folder
         self.ct_type = ct_type
+        self.is_global = False
 
     def set_version(self, ver : str) -> None:
         self.version = ver
 
-    def set_global(self, global_tr='global'):
+    def set_global(self, is_global: bool = True):
+        self.is_global = is_global
 
-        self.displayname += f' ({global_tr})'
-
-    def get_displayname(self, unused_tr='unused') -> str:
+    def get_displayname(self, unused_tr='unused', global_tr='global') -> str:
         """ Returns the display name, e.g. GE-Proton7-17 or luxtorpeda v57 """
         displayname = self.displayname
         if self.version != '':
             displayname += f' {self.version}'
-        if self.no_games == 0:
+
+        # Don't mark global tools as unused
+        if self.is_global:
+            displayname += f' ({global_tr})'
+        elif self.no_games == 0:
             displayname += f' ({unused_tr})'
+
         return displayname
 
     def get_internal_name(self) -> str:

--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -116,6 +116,10 @@ class BasicCompatTool:
     def set_version(self, ver : str) -> None:
         self.version = ver
 
+    def set_global(self, global_tr='global'):
+
+        self.displayname += f' ({global_tr})'
+
     def get_displayname(self, unused_tr='unused') -> str:
         """ Returns the display name, e.g. GE-Proton7-17 or luxtorpeda v57 """
         displayname = self.displayname

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -23,7 +23,7 @@ from pupgui2.pupgui2ctinfodialog import PupguiCtInfoDialog
 from pupgui2.pupgui2customiddialog import PupguiCustomInstallDirectoryDialog
 from pupgui2.pupgui2gamelistdialog import PupguiGameListDialog
 from pupgui2.pupgui2installdialog import PupguiInstallDialog
-from pupgui2.steamutil import get_steam_acruntime_list, get_steam_app_list, get_steam_ct_game_map
+from pupgui2.steamutil import get_steam_acruntime_list, get_steam_app_list, get_steam_ct_game_map, get_steam_global_ctool_name
 from pupgui2.heroicutil import is_heroic_launcher, get_heroic_game_list
 from pupgui2.util import apply_dark_theme, create_compatibilitytools_folder, get_installed_ctools, remove_ctool
 from pupgui2.util import install_directory, available_install_directories, get_install_location_from_directory_name
@@ -228,10 +228,14 @@ class MainWindow(QObject):
         # Launcher specific (Steam): Number of games using the compatibility tool
         elif install_loc.get('launcher') == 'steam' and 'vdf_dir' in install_loc:
             get_steam_app_list(install_loc.get('vdf_dir'), cached=False)  # update app list cache
+            global_ctool_name: str = get_steam_global_ctool_name(install_loc.get('vdf_dir'))
             self.compat_tool_index_map += get_steam_acruntime_list(install_loc.get('vdf_dir'), cached=True)
             map = get_steam_ct_game_map(install_loc.get('vdf_dir'), self.compat_tool_index_map, cached=True)
             for ct in self.compat_tool_index_map:
                 ct.no_games = len(map.get(ct, []))
+                ct_name = ct.get_internal_name()
+                if ct_name == global_ctool_name:
+                    ct.set_global(global_tr=self.tr('global'))  # Set (global) text
         # Launcher specific (Heroic): Set number of installed games using compat tool
         elif is_heroic_launcher(install_loc.get('launcher')):
             heroic_dir = os.path.join(os.path.expanduser(install_loc.get('install_dir')), '../..')

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -235,7 +235,7 @@ class MainWindow(QObject):
                 ct.no_games = len(map.get(ct, []))
                 ct_name = ct.get_internal_name()
                 if ct_name == global_ctool_name:
-                    ct.set_global(global_tr=self.tr('global'))  # Set (global) text
+                    ct.set_global()  # Set (global) text
         # Launcher specific (Heroic): Set number of installed games using compat tool
         elif is_heroic_launcher(install_loc.get('launcher')):
             heroic_dir = os.path.join(os.path.expanduser(install_loc.get('install_dir')), '../..')
@@ -250,7 +250,7 @@ class MainWindow(QObject):
             self.get_installed_versions('vkd3d', vkd3d_dir)
 
         for ct in self.compat_tool_index_map:
-            self.ui.listInstalledVersions.addItem(ct.get_displayname(unused_tr=self.tr('unused')))
+            self.ui.listInstalledVersions.addItem(ct.get_displayname(unused_tr=self.tr('unused'), global_tr=self.tr('global')))
             if ct.no_games == 0:
                 unused_ctools += 1
 

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -195,6 +195,14 @@ def get_steam_ctool_list(steam_config_folder: str, only_proton=False, cached=Fal
     return ctools
 
 
+def get_steam_global_ctool_name(steam_config_folder: str) -> str:
+
+    config_vdf_file = os.path.join(os.path.expanduser(steam_config_folder), 'config.vdf')
+    d = get_steam_vdf_compat_tool_mapping(vdf.load(open(config_vdf_file)))
+
+    return d.get('0').get('name', '')
+
+
 def get_steam_acruntime_list(steam_config_folder: str, cached=False) -> List[BasicCompatTool]:
     """
     Returns a list of installed Steam Proton anticheat(EAC/BattlEye) Runtimes.

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -205,7 +205,7 @@ def get_steam_global_ctool_name(steam_config_folder: str) -> str:
     config_vdf_file = os.path.join(os.path.expanduser(steam_config_folder), 'config.vdf')
     d = get_steam_vdf_compat_tool_mapping(vdf.load(open(config_vdf_file)))
 
-    return d.get('0').get('name', '')
+    return d.get('0', {}).get('name', '')
 
 
 def get_steam_acruntime_list(steam_config_folder: str, cached=False) -> List[BasicCompatTool]:

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -197,6 +197,11 @@ def get_steam_ctool_list(steam_config_folder: str, only_proton=False, cached=Fal
 
 def get_steam_global_ctool_name(steam_config_folder: str) -> str:
 
+    """
+    Return the internal name of the global Steam compatibility tool selected in the Steam Play settings from the Steam Client.
+    Return Type: str
+    """
+
     config_vdf_file = os.path.join(os.path.expanduser(steam_config_folder), 'config.vdf')
     d = get_steam_vdf_compat_tool_mapping(vdf.load(open(config_vdf_file)))
 


### PR DESCRIPTION
Addresses at least part of #254.

## Overview
This PR adds `(global)` beside installed compatibility tools which are set as the global tool in the Steam client's Steam Play settings. When no compatibility tool is forced, but when Steam detects that a game/app is a Windows-only application, this is the default tool that will be used to run that app from the Steam Client. This can be any compatibility tool, including things like GE-Proton. In such a case, even though the compatibility tool is technically not *explicitly* used, it is still the default and so used by all Windows games which do not have an alternative compatibility tool forced in the Properties dialog.

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/43e8ec48-f3d9-4514-9117-2843e031a326)

## Implementation
This PR accomplishes marking the tool as global, in summary, by doing the following:
- Adding a property `is_global` to `SteamApp`. This is then toggled manually in `pupgui2.py` when fetching the compat tool mapping list
- We update this property using a new `steamutil` function which returns the name of the `0` entry in config.vdf's `CompatToolMapping.` It looks in `config.vdf`, gets `CompatToolMapping`, and returns the name field for the `0` entry. This should always exist when Steam Play is enabled (required to even use Proton flavours and even show the "Compatibility" section of the Properties dialog), but if it's not, we have fallbacks in place to return an empty string.
- In `pupgui2.py`, when we're fetching all of the compatibility tools, if the name of a tool matches the global tool name, we mark it as default
- In `get_displayname`, which is called to return a string to set as the tool name in the games list, this function checks if the compat tool `is_global` and if it is, it sets `(global)`. We use an if/elif so that a tool is not marked as `global` *and* `unused`.

## Future Work
There are some future things we could do for this functionality, and this PR serves as a baseline for implementing them since it allows us to track which tool is the global one:
- Use badges instead of text, as it may still not be clear which tool is the global one
- Move the global compatibility tool to the top of the list, to make it visually clearer
- Show a warning dialog when trying to remove the global compatibility tool, like we do when trying to remove a used compatibility tool
    - I'm not sure how Steam handles a missing global compatibility tool and if it tries to fall back, but if you force something like GE-Proton8-22 for a single game in the Properties dialogue for that game, and then remove it, Steam will get confused and will not display the "Play" button, and there will be text beside it saying "Available for [Windows icon, and maybe a macOS icon]".
    - This is because the tracked compatibility tool in `config.vdf` under `CompatToolMapping` is still the previous tool, which would be `GE-Proton8-22` in this case. Checking and unchecking the use of a compatibility tool, or removing this entry altogether from `config.vdf`, will resolve the issue.
    - When removing the entry in `config.vdf`, Steam will fall back to the global compatibility tool and uncheck the checkbox (Steam knows to check/uncheck the checkbox based on whether that app's AppID has an entry under `config.vdf`'s `CompatToolMapping`). But I have no idea what happens if you remove the *global* compatibility tool if that makes sense. Since the fallback for all other apps *is* the global (`0`) compatibility tool, what happens when that one is missing? Maybe it just turns that setting off?
    - And so to go full circle, I Have no idea what happens if the global compatibility tool itself is missing, but marked in the `config.vdf` still. Unless Steam has a fallback this will not get updated, which may mean all tools show the same message as when a per-app forced compatibility tool is missing, and a user would have to manually update it
    - All this to say, at the very least a warning is probably necessary when removing the global tool, if not outright disabling the remove button (maybe we could only enable it in Advanced Mode?).
- Add an option to mark a given tool as the global compatibility tool. Steam would need to be closed for this action. This was also discussed in #254, but there was not a solid consensus on where to put it. Implementation shouldn't be that tricky since, at its core, it should just be setting the `0` compat tool's `name` in `CompatToolMapping` to the given tool's internal name.
- Potentially more I'm not thinking of :smile: 

<hr>

I actually wrote most of this back in June when I left my comment on #254, but I guess I abandonded it for some reason. Maybe I wanted to try and accomplish a lot more, like some of the things mentioned in Additional Work, but for now I figured this works and is better than not showing anything. I rebased it on main and polished it up a little before making this PR and made a couple of tiny adjustments, and now it's ready for review :-) 

Thanks!