### PR TITLE
About Dialog: Refactor

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -8,6 +8,7 @@ from PySide6.QtGui import QColor, QPalette
 APP_NAME = 'ProtonUp-Qt'
 APP_VERSION = '2.8.2'
 APP_ID = 'net.davidotek.pupgui2'
+APP_THEMES = ( 'light', 'dark', 'system', None )
 APP_ICON_FILE = os.path.join(xdg_config_home, 'pupgui/appicon256.png')
 APP_GHAPI_URL = 'https://api.github.com/repos/Davidotek/ProtonUp-qt/releases'
 DAVIDOTEK_KOFI_URL = 'https://ko-fi.com/davidotek'

--- a/pupgui2/pupgui2aboutdialog.py
+++ b/pupgui2/pupgui2aboutdialog.py
@@ -20,6 +20,7 @@ class PupguiAboutDialog(QObject):
     def __init__(self, parent=None):
         super(PupguiAboutDialog, self).__init__(parent)
         self.parent = parent
+        self.is_update_available = lambda current, newest: tuple(map(int, current.split('.'))) < tuple(map(int, newest.split('.')))
 
         self.load_ui()
         self.setup_ui()
@@ -85,7 +86,7 @@ class PupguiAboutDialog(QObject):
         v_newest = newest_release.get('tag_name', '')
         v_current = f'v{APP_VERSION}'
 
-        if v_current != v_newest:
+        if self.is_update_available(v_current, v_newest):
             QMessageBox.information(
                 self.ui,
                 self.tr('Update available'),

--- a/pupgui2/pupgui2aboutdialog.py
+++ b/pupgui2/pupgui2aboutdialog.py
@@ -89,7 +89,7 @@ class PupguiAboutDialog(QObject):
             QMessageBox.information(
                 self.ui,
                 self.tr('Update available'),
-                self.tr('There is a newer version available.\nYou are running {v_current} but {v_newest} is available.').format(v_current=v_current,v_newest=v_newest)
+                self.tr('There is a newer version available.\nYou are running {APP_VERSION} but {newest_version} is available.').format(APP_VERSION=f'v{APP_VERSION}', newest_version=f'v{v_newest}')
             )
             open_webbrowser_thread(newest_release['html_url'])
         else:

--- a/pupgui2/pupgui2aboutdialog.py
+++ b/pupgui2/pupgui2aboutdialog.py
@@ -7,7 +7,7 @@ from PySide6.QtGui import QPixmap, QIcon
 from PySide6.QtWidgets import QApplication, QMessageBox
 from PySide6.QtUiTools import QUiLoader
 
-from pupgui2.constants import APP_NAME, APP_VERSION, APP_GHAPI_URL, ABOUT_TEXT, BUILD_INFO
+from pupgui2.constants import APP_NAME, APP_VERSION, APP_GHAPI_URL, ABOUT_TEXT, BUILD_INFO, APP_THEMES
 from pupgui2.constants import DAVIDOTEK_KOFI_URL, PROTONUPQT_GITHUB_URL
 from pupgui2.steamutil import install_steam_library_shortcut
 from pupgui2.util import config_theme, apply_dark_theme, config_advanced_mode
@@ -59,7 +59,7 @@ class PupguiAboutDialog(QObject):
         self.ui.btnGitHub.clicked.connect(lambda: open_webbrowser_thread(PROTONUPQT_GITHUB_URL))
 
         self.ui.comboColorTheme.addItems([self.tr('light'), self.tr('dark'), self.tr('system (restart required)')])
-        self.ui.comboColorTheme.setCurrentIndex(['light', 'dark', 'system', None].index(config_theme()))
+        self.ui.comboColorTheme.setCurrentIndex(APP_THEMES.index(config_theme()))
 
         self.ui.btnClose.clicked.connect(lambda: self.ui.close())
         self.ui.btnAboutQt.clicked.connect(lambda: QMessageBox.aboutQt(self.parent))
@@ -73,7 +73,7 @@ class PupguiAboutDialog(QObject):
         self.ui.btnCheckForUpdates.setVisible(os.getenv('APPIMAGE') is not None)
 
     def combo_color_theme_current_index_changed(self):
-        config_theme(['light', 'dark', 'system'][self.ui.comboColorTheme.currentIndex()])
+        config_theme(APP_THEMES[:-1][self.ui.comboColorTheme.currentIndex()])
         apply_dark_theme(QApplication.instance())
 
     def btn_check_for_updates_clicked(self):

--- a/pupgui2/pupgui2aboutdialog.py
+++ b/pupgui2/pupgui2aboutdialog.py
@@ -60,7 +60,7 @@ class PupguiAboutDialog(QObject):
         self.ui.btnGitHub.clicked.connect(lambda: open_webbrowser_thread(PROTONUPQT_GITHUB_URL))
 
         self.ui.comboColorTheme.addItems([self.tr('light'), self.tr('dark'), self.tr('system (restart required)')])
-        self.ui.comboColorTheme.setCurrentIndex(APP_THEMES.index(config_theme()))
+        self.ui.comboColorTheme.setCurrentIndex(APP_THEMES.index(config_theme()) if config_theme() in APP_THEMES else (len(APP_THEMES) - 1))
 
         self.ui.btnClose.clicked.connect(lambda: self.ui.close())
         self.ui.btnAboutQt.clicked.connect(lambda: QMessageBox.aboutQt(self.parent))

--- a/pupgui2/pupgui2aboutdialog.py
+++ b/pupgui2/pupgui2aboutdialog.py
@@ -83,10 +83,9 @@ class PupguiAboutDialog(QObject):
             return
 
         newest_release = releases[0]
-        v_newest = newest_release.get('tag_name', '')
-        v_current = f'v{APP_VERSION}'
+        v_newest = newest_release.get('tag_name', 'v0.0.0').replace('v', '')
 
-        if self.is_update_available(v_current, v_newest):
+        if self.is_update_available(APP_VERSION, v_newest):
             QMessageBox.information(
                 self.ui,
                 self.tr('Update available'),

--- a/pupgui2/pupgui2aboutdialog.py
+++ b/pupgui2/pupgui2aboutdialog.py
@@ -55,41 +55,27 @@ class PupguiAboutDialog(QObject):
             self.ui.btnDonate.setFlat(True)
         finally:
             self.ui.btnDonate.setText('')
-        self.ui.btnDonate.clicked.connect(self.btn_donate_clicked)
+        self.ui.btnDonate.clicked.connect(lambda: open_webbrowser_thread(DAVIDOTEK_KOFI_URL))
 
-        self.ui.btnGitHub.clicked.connect(self.btn_github_clicked)
+        self.ui.btnGitHub.clicked.connect(lambda: open_webbrowser_thread(PROTONUPQT_GITHUB_URL))
 
         self.ui.comboColorTheme.addItems([self.tr('light'), self.tr('dark'), self.tr('system (restart required)')])
         self.ui.comboColorTheme.setCurrentIndex(['light', 'dark', 'system', None].index(config_theme()))
 
-        self.ui.btnClose.clicked.connect(self.btn_close_clicked)
-        self.ui.btnAboutQt.clicked.connect(self.btn_aboutqt_clicked)
+        self.ui.btnClose.clicked.connect(lambda: self.ui.close())
+        self.ui.btnAboutQt.clicked.connect(lambda: QMessageBox.aboutQt(self.parent))
         self.ui.btnCheckForUpdates.clicked.connect(self.btn_check_for_updates_clicked)
         self.ui.comboColorTheme.currentIndexChanged.connect(self.combo_color_theme_current_index_changed)
 
         self.ui.checkAdvancedMode.setChecked(config_advanced_mode() == 'enabled')
-        self.ui.checkAdvancedMode.stateChanged.connect(self.check_advanced_mode_state_changed)
+        self.ui.checkAdvancedMode.stateChanged.connect(lambda: config_advanced_mode('enabled' if self.ui.checkAdvancedMode.isChecked() else 'disabled'))
 
         self.ui.btnAddSteamShortcut.clicked.connect(self.btn_add_steam_shortcut_clicked)
-
-        if os.getenv('APPIMAGE') is None:
-            self.ui.btnCheckForUpdates.setVisible(False)
+        self.ui.btnCheckForUpdates.setVisible(os.getenv('APPIMAGE') is not None)
 
     def combo_color_theme_current_index_changed(self):
         config_theme(['light', 'dark', 'system'][self.ui.comboColorTheme.currentIndex()])
         apply_dark_theme(QApplication.instance())
-
-    def btn_close_clicked(self):
-        self.ui.close()
-
-    def btn_aboutqt_clicked(self):
-        QMessageBox.aboutQt(self.parent)
-
-    def btn_donate_clicked(self):
-        open_webbrowser_thread(DAVIDOTEK_KOFI_URL)
-
-    def btn_github_clicked(self):
-        open_webbrowser_thread(PROTONUPQT_GITHUB_URL)
 
     def btn_check_for_updates_clicked(self):
         releases = requests.get(f'{APP_GHAPI_URL}?per_page=1').json()
@@ -105,9 +91,6 @@ class PupguiAboutDialog(QObject):
             open_webbrowser_thread(newest_release['html_url'])
         else:
             QMessageBox.information(self.ui, self.tr('Up to date'), self.tr('You are running the newest version!'))
-
-    def check_advanced_mode_state_changed(self, state : int):
-        config_advanced_mode('enabled' if self.ui.checkAdvancedMode.isChecked() else 'disabled')
 
     def tag_name_to_version(self, tag_name : str):
         """


### PR DESCRIPTION
This PR refactors the about dialog to be a little bit more concise. There is a significant change to the version check which we may need to discuss/revert, but I put it up like this as if it does work, it would be a lot simpler and more readable than what was there before :-)

The main idea behind this refactor is to make the code a bit more concise and easier to work in, as we may be changing this soon to accommodate other UI elements and related logic, or doing a significant change to turn it into a settings dialog. The idea is to just make this a little bit nicer to work in and """more consistent""" with the other UI classes, consistency as in using lambdas for `.clicked.connect` etc to replace class methods which are only used for this action.

## Overview
This PR refactors
- Move themes to be in the constants file, might be useful if we start adding more themes like the Steam theme (#309).
- Use lambdas instead of class methods for Qt event bindings.
- Heavily simplify the version check, comparing the strings instead of trying to calculate the version difference.

The first two changes, I think, are fairly inconsequential overall and just make things a bit cleaner. But the change to the version check is the major part here that I think may need discussion.

### Refactoring the Version Check
The existing version check is like this:

```python
(10000 * int(v_current[0]) + 100 * int(v_current[1]) + int(v_current[2])) < (10000 * int(v_newest[0]) + 100 * int(v_newest[1]) + int(v_newest[2])
```

This breaks apart each part of the version string for the current version and the version on GitHub taken from the API, and performs some calculation to compare them. I'm not sure what this exactly does or why exactly it's needed, but Python allows you to compare strings. To do that we would assume the version string format is the same, i.e. `X.Y.Z`, which is an assumption we already make in `tag_name_to_version`. In Python we can compare strings like `2.8.1 < 2.8.2`. I'm pretty sure this just compares the string as unicode(?), but for a version check, I think this is fine.

If we didn't want to compare on strings, we could remove the `.` from the strings and cast them to integers, something like `int(v_current.replace('.', '')) < int(v_newest.replace('.', ''))`.

The existing version check is probably much more "strict", but I'm not sure if it's strictly needed compared to this check. I tried to build an AppImage of my branch to test, but I struggled to use `appimage-builder`, so I was unable to test in-context. But the actual version comparison worked in some test scripts and in testing with just variables in a Python shell.

I'm not saying this way is better, it likely isn't "better" per-se, but it may be simpler overall and may work just as well for this purpose. At least, I don't yet see a reason why it wouldn't, but would be happy to be told otherwise and to revert it :-)

<hr>

These changes, currently, are fairly... insignificant for the moment I suppose? But my hope is that they make this part of the code easier to work with in future if and when there is a go-forward for working in here.

Thanks :-)