### PR TITLE
Luxtorpeda: Use fetch_project_releases and fetch_project_release_data

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -551,8 +551,6 @@ def fetch_project_releases(releases_url: str, rs: requests.Session, count=100) -
     """
     releases_api_url: str = f'{releases_url}?per_page={str(count)}'
 
-    print(rs.headers)
-
     releases: dict = {}
     tag_key: str = ''
     if GITHUB_API in releases_url:


### PR DESCRIPTION
Supersedes #310.

Updates Luxtorpeda to use the new `fetch_project_releases` and `fetch_project_release_data` util functions from #302. This reduces repeated code and will help "proof out" how these functions can be used in other ctmods. More work may be required for some ctmods, but for Luxtorpeda, it was a drop-in replacement.

Boxtron gets this for free because it subclasses Luxtorpeda as of #311, and Roberta will inherit this PR's changes when #317 is merged. That's why I didn't touch that ctmod in this PR, changing Luxtorpeda will change all of them. [Luxtorpeda](https://github.com/luxtorpeda-dev/luxtorpeda/releases), [Roberta](https://github.com/dreamer/roberta/releases/), and [Boxtron](https://github.com/dreamer/boxtron/releases/) all use `.tar.xz` archives, so the `release_format` only has to be defined for Luxtorpeda. But, Roberta and Boxtron will be free to override this in the future if this ever changes.

There should be no user-facing changes to functionality here. Releases still come for Roberta, and all three ctmods still download and extract as expected. This just makes the ctmods (hopefully!) a little bit more maintainable for us developers :slightly_smiling_face: 

Thanks! :smile: 