### PR TITLE
CtInfo: Display 'No games' text in place of empty games list

### DIFF
--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -77,6 +77,8 @@ class PupguiCtInfoDialog(QObject):
             self.ui.listGames.setHorizontalHeaderLabels(['', ''])
             self.ui.listGames.setEnabled(False)
 
+        self.update_game_list_ui()
+
     def update_game_list_steam(self, cached=True):
         if self.install_loc.get('launcher') == 'steam' and 'vdf_dir' in self.install_loc:
             self.games = get_steam_game_list(self.install_loc.get('vdf_dir'), self.ctool.get_internal_name(), cached=cached)
@@ -118,6 +120,11 @@ class PupguiCtInfoDialog(QObject):
         self.ui.listGames.setRowCount(row_count)
         self.ui.listGames.setHorizontalHeaderLabels(header_labels)
         self.ui.txtNumGamesUsingTool.setText(str(row_count))        
+
+    def update_game_list_ui(self):
+        self.ui.listGames.setVisible(len(self.games) > 0)
+        self.ui.lblGamesList.setVisible(len(self.games) <= 0)
+        self.ui.btnBatchUpdate.setEnabled(len(self.games) > 0)
 
     def list_games_cell_double_clicked(self, row):
         if self.install_loc.get('launcher') == 'steam':

--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -131,6 +131,50 @@
     </layout>
    </item>
    <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblGamesList">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>26</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>No games</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTableWidget" name="listGames">
      <property name="focusPolicy">
       <enum>Qt::ClickFocus</enum>
@@ -173,21 +217,37 @@
     </widget>
    </item>
    <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QPushButton" name="btnBatchUpdate">
        <property name="text">
         <string>Batch update</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="searchBox">
-       <property name="toolTip">
-        <string>e.g. Half-Life 3</string>
-       </property>
-       <property name="placeholderText">
-        <string>Search for a game...</string>
        </property>
       </widget>
      </item>
@@ -203,6 +263,16 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="searchBox">
+       <property name="toolTip">
+        <string>e.g. Half-Life 3</string>
+       </property>
+       <property name="placeholderText">
+        <string>Search for a game...</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QPushButton" name="btnClose">

--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -175,6 +175,19 @@
     </widget>
    </item>
    <item>
+    <spacer name="verticalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <widget class="QTableWidget" name="listGames">
      <property name="focusPolicy">
       <enum>Qt::ClickFocus</enum>

--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -163,7 +163,7 @@
      </property>
      <property name="font">
       <font>
-       <pointsize>26</pointsize>
+       <pointsize>18</pointsize>
       </font>
      </property>
      <property name="text">


### PR DESCRIPTION
Opened based on discussion in #314.

## Overview
This PR makes a change to the CtInfo dialog when no games are found. Instead of displaying an empty games list, it hides this list, disables the "Batch update" button, and displays some text that says "No games".

If a game is set to use this ctmod after the dialog is opened, pressing the "refresh" button will correctly update the dialog to hide the text, toggle the batch update button, and show the games list. Vice versa also applies, if a compat tool is then unset for a game and becomes unused, refreshing will once again hide the game list, show the "No games" text, and disable "Batch Update".

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/53163f09-d120-4b8e-8f77-237c354727d6)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/91d2f428-3996-4a6b-bfe0-0743413ce353)

For ctmods without "Batch Update", there is no change to this button, see the example of Luxtorpeda below:

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/25442b2a-fc11-4ba9-8aef-a10de8ba6e17)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/2bf07f81-a4d0-44a0-a965-3e48cf10fd78)

## Implementation
### UI Design
#### Inspiration
I chose the design of this UI element largely based on a similar UI found on KDE's Dolphin file manager (also based on Qt, though with KDE-specific frameworks and libraries under the hood, and even custom Qt patches). When there are no files in a directory, it displays "Folder is empty" as below:

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/cfc86493-922e-478e-b94c-38878a047146)

In Dolphin's case, it displays this inside of the table view, however I chose not to do this for a couple of reasons. First off, I wasn't sure how easily we could implement a centered label overtop a table. We would also have to disable some columns, note how Dolphin only displays the "Name" column, so we would have to have more conditional logic to manage the table.

I do really like how Dolphin displays it centered in the dark frame, but I'm not sure if we could easily implement this. If it's really desired, though, we could go for it. We could potentially add an empty frame and layout to center this label inside of, and then show/hide that, to achieve the same effect that KDE have, but without the column names along the top. Perhaps this is overkill though :sweat_smile: 

#### Font Sizing & Color
I achieved this text effect in the CtInfo dialog by adding a label, with the default Noto Sans font, using Size 18, and the grey effect was achieved by marking the label as "Disabled". This should hopefully the color consistent across themes and is a cleaner way of doing this imo compared to specifying a color :-)

I also put some effort into centering the label as much as possible, achieved using spacers. I believe I used them correctly but please let me know if I need to adjust something here.

I experimented with a couple of different font sizes before landing on Size 18 as my preferred option. I felt larger was too big, and smaller was too small. Originally, I tested with Size 26, but decided that was way too big. We only want a subtle indicator that there are no games, not something that "yells", if that makes sense. I'll give some examples below.

<details>

<summary>Put in spoilers so as not to take up this PR with too many images</summary>

Sizing increments were chosen based on the ones list in Qt Designer. Size 18 was just my preference but if you want Size 16 or Size 20, or a different size altogether, feel free to comment :-) It's just my opinion that Size 18 strikes the right proportional balance of using up enough of the space in the dialog without looking like there is too much empty space.

### Size 20 (Slightly Too Big imo)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/0a591126-fabf-4524-9605-aed55bdd3676)

### Size 18 (This PR)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/e2b8f191-d29c-489e-8336-3780dd25d6fd)

### Size 16 (Slightly Too Small imo)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/aa5d021b-3245-4da0-a48f-3b4e588588e8)

</details>

### Show/Hide Logic
We handle this show/hide/enable/disable logic using a new method in the CtInfo dialog called `update_game_list_ui`, which we call when updating the games list. This manages toggling these widgets using conditional checks based on the length of `self.games`. This method is called on dialog open, and also when the refresh button is pressed, which is why I put it in `PupguiCtInfoDialog#update_game_list`, so that the call is only coded in one place.

## Remaining Work
When writing this PR I noticed the logic for the search search isn't quite right. If we open the dialog with no games, the search button is hidden. But it doesn't show/hide on refresh if the games list becomes populated/empty.
- If we open the ctinfo with no games, search icon is hidden
- If we open the ctinfo with games, search icon is shown
- If we open the ctinfo with no games, then refresh and have games, search icon does not re-appear
- If we open the ctinfo with games, then refresh and have no games, search icon does not disappear

I should be able to tackle this in this PR, probably in `update_game_list_ui`, and I'll look into it after opening this PR.

## Future Work
The label in this PR could be changed to display a message when a tool is marked as global, once #314 is merged. Since there is little reason to display the games list when no games are used and also when it is the default tool where the tool is not *explicitly* used, it would make sense to re-use the functionality in this PR to display a label giving a visual indicator on the CtInfo dialog that a tool is marked as global.

If #314 is merged first and you would like me to tackle the global ctmod message in this PR though, I can do that no problem :-)

<hr>

I'm no UI expert so all feedback is appreciated here.

Thanks! :-)