### PR TITLE
Northstar Proton: Use fetch_project_releases and fetch_project_release_data

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_northstarproton.py
+++ b/pupgui2/resources/ctmods/ctmod_northstarproton.py
@@ -8,7 +8,7 @@ import requests
 from PySide6.QtCore import QObject, Signal, Property, QCoreApplication
 
 from pupgui2.util import ghapi_rlcheck, extract_tar
-from pupgui2.util import build_headers_with_authorization
+from pupgui2.util import build_headers_with_authorization, fetch_project_release_data, fetch_project_releases
 
 
 CT_NAME = 'Northstar Proton (Titanfall 2)'
@@ -28,6 +28,7 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
+        self.release_format = 'tar.gz'
 
         self.rs = requests.Session()
         rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
@@ -84,17 +85,8 @@ class CtInstaller(QObject):
         Content(s):
             'version', 'date', 'download', 'size'
         """
-        url = self.CT_URL + (f'/tags/{tag}' if tag else '/latest')
-        data = self.rs.get(url).json()
-        if 'tag_name' not in data:
-            return None
 
-        values = {'version': data['tag_name'], 'date': data['published_at'].split('T')[0]}
-        for asset in data['assets']:
-            if asset['name'].endswith('tar.gz'):
-                values['download'] = asset['browser_download_url']
-                values['size'] = asset['size']
-        return values
+        return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag)
 
     def is_system_compatible(self):
         """
@@ -108,7 +100,8 @@ class CtInstaller(QObject):
         List available releases
         Return Type: str[]
         """
-        return [release['tag_name'] for release in ghapi_rlcheck(self.rs.get(f'{self.CT_URL}?per_page={str(count)}').json()) if 'tag_name' in release]
+
+        return fetch_project_releases(self.CT_URL, self.rs, count=count)
 
     def get_tool(self, version, install_dir, temp_dir):
         """


### PR DESCRIPTION
Same as #318 but for Northstar Proton.

Should still download and extract correctly, once again with no user-facing changes. Just code maintenance mostly :-) With the hope of moving as many ctmods over to this as possible, gradually so as to reduce the risk of regression in a monster PR :slightly_smiling_face: 

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/c9d4e82e-9c61-4ac3-99e3-f5641d28ec47)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/0e8ed496-32d9-4d4e-a1f6-661a86b628c5)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/51af66c2-bcf3-4640-b09c-80450ad15ae2)
