### PR TITLE
Kron4ek Wine: Use fetch_project_releases and fetch_project_release_data

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
+++ b/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
@@ -9,7 +9,7 @@ import requests
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.util import ghapi_rlcheck, extract_tar
-from pupgui2.util import build_headers_with_authorization
+from pupgui2.util import build_headers_with_authorization, fetch_project_release_data, fetch_project_releases
 
 
 CT_NAME = 'Kron4ek Wine-Builds Vanilla'
@@ -29,6 +29,7 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
+        self.release_format = 'tar.xz'
 
         self.rs = requests.Session()
         rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
@@ -85,17 +86,9 @@ class CtInstaller(QObject):
         Content(s):
             'version', 'date', 'download', 'size'
         """
-        url = self.CT_URL + (f'/tags/{tag}' if tag else '/latest')
-        data = self.rs.get(url).json()
-        if 'tag_name' not in data:
-            return None
 
-        values = {'version': data['tag_name'], 'date': data['published_at'].split('T')[0]}
-        for asset in data['assets']:
-            if asset['name'].endswith('tar.xz') and 'amd64' in asset['name'] and 'staging' not in asset['name']:
-                values['download'] = asset['browser_download_url']
-                values['size'] = asset['size']
-        return values
+        asset_condition = lambda asset: 'amd64' in asset.get('name', '') and 'staging' not in asset.get('name', '')
+        return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag, asset_condition=asset_condition)
 
     def is_system_compatible(self):
         """
@@ -115,7 +108,8 @@ class CtInstaller(QObject):
         List available releases
         Return Type: str[]
         """
-        return [release['tag_name'] for release in ghapi_rlcheck(self.rs.get(f'{self.CT_URL}?per_page={str(count)}').json()) if 'tag_name' in release]
+
+        return fetch_project_releases(self.CT_URL, self.rs, count=count)
 
     def get_tool(self, version, install_dir, temp_dir):
         """


### PR DESCRIPTION
Mostly the same as #318 but for Lutris' Kron4ek Wine-Builds Vanilla.

The difference here is that, like for DXVK, we have an asset condition that we pass. We only want to fetch 64bit, non-staging releases, so the existing conditional we had in `__fetch_github_data` to check the asset name was replaced with a lambda that we pass to `fetch_project_release_data`. This takes care of filtering the assets.

I tested with and without this conditional, and we end up with the `-x86` version, so this should confirm that the asset check works for us here :slightly_smiling_face: 

Once again, there should be no user-facing change and everything should still work as expected. The releases dropdown should have no change from `main`, and the correct archive should still download and extract correctly.

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/7fd1f74c-43ad-4411-ba5b-4947df094e82)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/02c455ff-69cf-4786-9152-86b1c2e5715f)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/f279dfe9-2f75-4b51-9d05-e4a7d49fb06f)

<hr>

I have put up a lot of PRs recently that tackle smaller refactors, sorry if it's a lot to manage without much visible gain... But there is no hurry, this PR and the similar ones are just small code refactors and do not contain any absolutely urgent critical fixes :-) Just code consistency.

I think the remaining ctmods may require slightly more work, so I won't be flooding with more PRs for a while :sweat_smile: 