### PR TITLE
vkd3d: Use fetch_project_releases and fetch_project_release_data

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
+++ b/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
@@ -8,7 +8,7 @@ import requests
 
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
-from pupgui2.util import ghapi_rlcheck, extract_tar
+from pupgui2.util import extract_tar
 from pupgui2.util import build_headers_with_authorization, fetch_project_release_data, fetch_project_releases
 
 

--- a/pupgui2/resources/ctmods/ctmod_northstarproton.py
+++ b/pupgui2/resources/ctmods/ctmod_northstarproton.py
@@ -7,7 +7,7 @@ import requests
 
 from PySide6.QtCore import QObject, Signal, Property, QCoreApplication
 
-from pupgui2.util import ghapi_rlcheck, extract_tar
+from pupgui2.util import extract_tar
 from pupgui2.util import build_headers_with_authorization, fetch_project_release_data, fetch_project_releases
 
 

--- a/pupgui2/resources/ctmods/ctmod_vkd3dlutris.py
+++ b/pupgui2/resources/ctmods/ctmod_vkd3dlutris.py
@@ -18,3 +18,4 @@ class CtInstaller(VKD3DInstaller):
 
     def __init__(self, main_window = None):
         super().__init__(main_window)
+        self.release_format = 'tar.xz'

--- a/pupgui2/resources/ctmods/ctmod_vkd3dproton.py
+++ b/pupgui2/resources/ctmods/ctmod_vkd3dproton.py
@@ -8,8 +8,8 @@ import requests
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.datastructures import Launcher
-from pupgui2.util import ghapi_rlcheck, extract_tar, extract_tar_zst, get_launcher_from_installdir
-from pupgui2.util import build_headers_with_authorization
+from pupgui2.util import extract_tar, extract_tar_zst, get_launcher_from_installdir
+from pupgui2.util import build_headers_with_authorization, fetch_project_release_data, fetch_project_releases
 
 
 CT_NAME = 'vkd3d-proton'
@@ -28,6 +28,7 @@ class CtInstaller(QObject):
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
+        self.release_format = 'tar.zst'
 
         self.rs = requests.Session()
         rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
@@ -84,17 +85,8 @@ class CtInstaller(QObject):
         Content(s):
             'version', 'date', 'download', 'size', 'checksum'
         """
-        url = self.CT_URL + (f'/tags/{tag}' if tag else '/latest')
-        data = self.rs.get(url).json()
-        if 'tag_name' not in data:
-            return None
 
-        values = {'version': data['tag_name'], 'date': data['published_at'].split('T')[0]}
-        for asset in data['assets']:
-            if asset['name'].endswith('.tar.zst') or asset['name'].endswith('.tar.xz'):
-                values['download'] = asset['browser_download_url']
-                values['size'] = asset['size']
-        return values
+        return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag)
 
     def is_system_compatible(self):
         """
@@ -108,7 +100,8 @@ class CtInstaller(QObject):
         List available releases
         Return Type: str[]
         """
-        return [release['tag_name'] for release in ghapi_rlcheck(self.rs.get(f'{self.CT_URL}?per_page={str(count)}').json()) if 'tag_name' in release]
+
+        return fetch_project_releases(self.CT_URL, self.rs, count=count)
 
     def get_tool(self, version, install_dir, temp_dir):
         """


### PR DESCRIPTION
This PR applies the same changes in #318, #320, #321 to Valve's [vkd3d-proton](https://github.com/HansKristian-Work/vkd3d-proton/releases/) and the Lutris mirror [vkd3d](https://github.com/lutris/vkd3d/releases). The vkd3d-proton ctmod is the parent one and Lutris subclasses it, so we set the archive type for each of these.

There are also a couple of other changes made to remove the now-unused `ghapi_rlcheck` import from a couple of other ctmods (this is used internally in these functions instead).

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/2041c39b-7e3b-48bc-8cd0-d5a8ebb348b0)

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/0f1771ec-fbed-4df0-9682-d7bdc182dc56)

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/f4f94066-ad4d-4cb9-b617-ffe919d427a9)

Once again, there should be no user-facing impact here. The vkd3d-lutris version list may appear small but that's because it is small, it only goes back to v2.4, and it doesn't package all of the same versions as vkd3d-proton (v2.7, for example, is not on the list because there is no vkd3d-lutris v2.7, [releases page link](https://github.com/lutris/vkd3d/releases)). There should be no change in behaviour compared to the main branch.

<hr>

I wanted to note something here: vkd3d-proton packages its releases as `.tar.zst` while Lutris uses `.tar.xz`. In the vkd3d-proton ctmod. So when fetching releases we checked for both archive types in the one ctmod. One side effect of this was that if the format of the release changed, we could simply add on another filetype check. For example if Lutris switched to using `.tar.zst` as well.

With this change, however, we are locked into assuming one file type for each release. vkd3d and vkd3d-proton have used the same release format for all of their existence as far as I can see so I don't think this is _likely_ to change, but we can consider refactoring `fetch_project_release_data` to (optionally?) take a list of archive types to check for. That way if vkd3d-proton or vkd3d-lutris changed their release formats with the next version for some reason, it would be straightforward to check.

Although I should note that if any ctmod made a change to their packaging like this we would need to do a refactor (not just by adding another check when fetching assets but also for extraction), so maybe it's a non-issue to assume each project will use only one archive type :smile: 

<hr>

The number of total PRs was just too low, so I had no choice but to raise it :wink: Thanks!