### PR TITLE
Batch Update: Use UI file & UX Improvements

### DIFF
--- a/pupgui2/pupgui2ctbatchupdatedialog.py
+++ b/pupgui2/pupgui2ctbatchupdatedialog.py
@@ -9,38 +9,53 @@ class PupguiCtBatchUpdateDialog(QDialog):
 
     batch_update_complete = Signal(bool)
 
-    def __init__(self, parent=None, games=[], steam_config_folder=''):
+    def __init__(self, parent=None, current_ctool_name: str='', games=[], steam_config_folder=''):
         super(PupguiCtBatchUpdateDialog, self).__init__(parent)
         self.games = games
         self.steam_config_folder = steam_config_folder
 
         self.ctools = sort_compatibility_tool_names(list_installed_ctools(install_directory()), reverse=True)
 
-        self.setup_ui()
+        self.setup_ui(current_ctool_name)
 
-    def setup_ui(self):
+    def setup_ui(self, current_ctool_name: str):
         self.setWindowTitle(self.tr('Batch update'))
         self.setModal(True)
 
         formLayout = QFormLayout()
         self.comboNewCtool = QComboBox()
         self.btnBatchUpdate = QPushButton(self.tr('Batch update'))
+        self.btnClose = QPushButton(self.tr('Close'))
         formLayout.addRow(QLabel(self.tr('New version:')), self.comboNewCtool)
         formLayout.addWidget(self.btnBatchUpdate)
+        formLayout.addWidget(self.btnClose)
         self.setLayout(formLayout)
 
-        for ctool in self.ctools:
-            if 'Proton' in ctool:
-                self.comboNewCtool.addItem(ctool)
-        self.btnBatchUpdate.clicked.connect(self.btn_batch_update_clicked)
+        combobox_ctools = [ctool for ctool in self.ctools if 'Proton' in ctool and current_ctool_name not in ctool]
+        self.comboNewCtool.addItems(combobox_ctools)
 
-        if is_steam_running():
-            lblSteamRunningWarning = QLabel(self.tr('Close the Steam client beforehand.'))
-            lblSteamRunningWarning.setStyleSheet('QLabel { color: orange; }')
-            formLayout.addRow(lblSteamRunningWarning)
+        self.comboNewCtool.setEnabled(len(combobox_ctools) > 0)
+        self.btnBatchUpdate.setEnabled(len(combobox_ctools) > 0)
+
+        self.btnBatchUpdate.clicked.connect(self.btn_batch_update_clicked)
+        self.btnClose.clicked.connect(lambda: self.close())
+
+        if len(combobox_ctools) <= 0:
+            self.add_warning_message('No supported compatibility tools found.', formLayout)
+        elif is_steam_running():
+            self.add_warning_message('Close the Steam Client beforehand.', formLayout)
 
         self.show()
     
+    def add_warning_message(self, msg: str, layout: QFormLayout, stylesheet: str = 'QLabel { color: orange; }'):
+        """
+        Add a QLabel warning message with a default Orange stylesheet to display a warning message in a FormLayout.
+        """
+
+        lblWarning = QLabel(self.tr('{MSG}'.format(MSG=msg)))
+        lblWarning.setStyleSheet(stylesheet)
+        layout.addRow(lblWarning)
+
     def btn_batch_update_clicked(self):
         self.update_games_to_ctool(self.comboNewCtool.currentText())
         self.batch_update_complete.emit(True)

--- a/pupgui2/pupgui2ctbatchupdatedialog.py
+++ b/pupgui2/pupgui2ctbatchupdatedialog.py
@@ -33,19 +33,22 @@ class PupguiCtBatchUpdateDialog(QObject):
         # compatibility tool may have been available but then was removed (maybe manually?) -- Is potentially just more robust
         combobox_ctools = [ctool for ctool in self.ctools if 'Proton' in ctool and current_ctool_name not in ctool]
         self.ui.comboNewCtool.addItems(combobox_ctools)
+        self.ui.oldVersionText.setText(f' {current_ctool_name}')
 
+        # Batch update only disabled when no ctools installed
+        # Not disabled when Steam Client is running because it can be closed while this dialog is open 
         self.ui.comboNewCtool.setEnabled(len(combobox_ctools) > 0)
         self.ui.btnBatchUpdate.setEnabled(len(combobox_ctools) > 0)
         
         self.ui.btnBatchUpdate.clicked.connect(self.btn_batch_update_clicked)
         self.ui.btnClose.clicked.connect(lambda: self.ui.close())
 
-        if len(combobox_ctools) <= 0:
+        if len(combobox_ctools) <= 0:  # No ctools to migrate to installed
             self.add_warning_message('No supported compatibility tools found.', self.ui.formLayout, stylesheet='QLabel { color: red; }')
-        elif is_steam_running():
-            self.add_warning_message('Close the Steam Client beforehand.', self.ui.formLayout)
-        else:
-            self.ui.formLayout.addWidget(QLabel())
+        elif is_steam_running():  # Steam is running so any writes to config.vdf will get overwritten on Steam Client exit
+            self.add_warning_message('Warning: Close the Steam Client beforehand.', self.ui.formLayout)
+        else:  # Spacer label
+            self.ui.formLayout.addRow(QLabel())
 
     def add_warning_message(self, msg: str, layout, stylesheet: str = 'QLabel { color: orange; }'):
         """

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -6,7 +6,7 @@ from pupgui2.datastructures import BasicCompatTool, CTType
 from pupgui2.lutrisutil import get_lutris_game_list
 from pupgui2.pupgui2ctbatchupdatedialog import PupguiCtBatchUpdateDialog
 from pupgui2.steamutil import get_steam_game_list
-from pupgui2.util import open_webbrowser_thread
+from pupgui2.util import open_webbrowser_thread, sort_compatibility_tool_names, list_installed_ctools, install_directory
 from pupgui2.heroicutil import get_heroic_game_list, is_heroic_launcher
 
 from PySide6.QtCore import QObject, Signal, QDataStream, QByteArray
@@ -126,7 +126,7 @@ class PupguiCtInfoDialog(QObject):
 
     def btn_batch_update_clicked(self):
         steam_config_folder = self.install_loc.get('vdf_dir')
-        ctbu_dialog = PupguiCtBatchUpdateDialog(parent=self.ui, games=self.games, steam_config_folder=steam_config_folder)
+        ctbu_dialog = PupguiCtBatchUpdateDialog(parent=self.ui, current_ctool_name=self.ctool.displayname, games=self.games, steam_config_folder=steam_config_folder)
         ctbu_dialog.batch_update_complete.connect(self.update_game_list_steam)
 
     def btn_refresh_games_clicked(self):

--- a/pupgui2/resources/ui/pupgui2_ctbatchupdatedialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctbatchupdatedialog.ui
@@ -7,23 +7,23 @@
     <x>0</x>
     <y>0</y>
     <width>350</width>
-    <height>140</height>
+    <height>160</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>350</width>
-    <height>140</height>
+    <height>160</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>350</width>
-    <height>140</height>
+    <height>160</height>
    </size>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Batch Update</string>
   </property>
   <property name="modal">
    <bool>true</bool>
@@ -41,7 +41,7 @@
     <item>
      <widget class="QLabel" name="txtDescription">
       <property name="text">
-       <string>Migrate all games using the current compatibility tool to using the one specified below.</string>
+       <string>Migrate all games from the current compatibility tool to the one specified below.</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>
@@ -50,20 +50,34 @@
     </item>
     <item>
      <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="lblNewVersion">
         <property name="text">
          <string>New Version:</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QComboBox" name="comboNewCtool">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lblOldVersion">
+        <property name="text">
+         <string>Old Version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="oldVersionText">
+        <property name="text">
+         <string/>
         </property>
        </widget>
       </item>

--- a/pupgui2/resources/ui/pupgui2_ctbatchupdatedialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctbatchupdatedialog.ui
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PuiguiCustomInstallDirectoryDialog</class>
+ <widget class="QDialog" name="PuiguiCustomInstallDirectoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>350</width>
+    <height>140</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>350</width>
+    <height>140</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>350</width>
+    <height>140</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>331</width>
+     <height>182</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="txtDescription">
+      <property name="text">
+       <string>Migrate all games using the current compatibility tool to using the one specified below.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="lblNewVersion">
+        <property name="text">
+         <string>New Version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="comboNewCtool">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnBatchUpdate">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Batch Update</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnClose">
+        <property name="text">
+         <string>Close</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
I know I already have a meaty enough PR open for a UI change (#319), and that soon I'll be taking a look at another CtInfo dialog change for anti-cheat runtimes (#186) so no hurry to review this. I wanted to get it up and document the changes here while it was all fresh in my head.

## Overview
This PR moves the Batch Update dialog to use a Qt UI file and makes a couple of UX tweaks. It's a similar vein to what I did for Custom Install Directory in #225.
- Add a short label describing what Batch Update does (feedback very welcome on phrasing).
- Remove the current Proton version from the dropdown list, i.e. if we're using GE-Proton8-25 and want to batch update, don't display GE-Proton8-25, as it doesn't make sense to batch update from the current tool, *to* the current tool.
- Disable the dropdown if no compatibility tools to migrate to are found. For example if only GE-Proton8-25 is installed, we can't migrate to any other versions, so disable the dropdown.
- Disable the "Batch Update" button on the dialog itself if no compatibility tools to migrate to are found.
    - This is not disabled for the "Close the Steam Client beforehand" warning message because the user can do that on most systems without closing ProtonUp-Qt. Even though if Steam is open, the batch update will be overwritten, the Steam Client can be closed while this dialog is open on the Linux Desktop, and it should prompt users to close the Steam Client. We don't prevent users from making changes in the Games List when Steam is running, so I don't think we *have* to prevent them in Batch Update :-)
    - This is not disabled on the ctinfo dialog as we'd have to fetch the installed compatibility tool info here which seems a little excessive just to disable a button, and also it may not be obvious without a tooltip why this is disabled (and there's no space anywhere for a label on this dialog really). Instead, we let the user open the dialog, and show warnings as below.
    - This *may* also create some slightly tricky logic paths / conflicts with #319.
    - This is also not disabled on ctinfo dialog as the above implementation would probably be necessary, and consider the following scenario: User has only one GE-Proton version and no other supported batch update tools -> sets new GE-Proton tool to download -> Opens ctinfo -> Realizes tool is downloading, decides to wait -> Tool downloads, and if the button is disabled they would have to re-open the dialog, or if not disabled but we pass a prefetched tool list to Batch Update, they open Batch Update screen -> it's missing info about the new tool, so they get the "No compatibility tool" message. Fetching information in the Batch Update dialog means we always have the latest tool information, unless they open Batch Update while a tool download is in progress.
        - In that scenario, if we fetched from ctinfo, since it remains open, a user would have to close the Batch Info *and* ctinfo dialog, whereas if the info is fetched in Batch Update, the user only has to close and re-open one dialog.
    - We would have a similar problem if we passed information about all installed compat tools from the Main Window to ctinfo and then to Batch Update, as the installed tool info would still be out-of-date in the above scenario since the information gotten from Main Window and sent to ctinfo would still not have that tool that is currently downloading.
    - We would run into similar problems when tools are removed.
- Show a red warning label when no compatibility tool to migrate to is installed, to complement the disabled dropdown and disabled update button. This should help make it clear why the option is disabled.
- Add a label to display the "old version", aka the current compatibility tool version that we're migrating *from*. When running in GameScope this is hopefully an extra bit of UX when the user can't look at the dialog behind very easily, it should provide a little bit of visual feedback to confirm what they're currently using and what they're moving to.
    - We have this already because we have to pass the internal name of the current tool from ctinfo to the batch update dialog, in order to create the filtered list of installed versions excluding the current one, to allow the disabled dropdown.
- Add dedicated "Close" button to be consistent with the rest of the UI and to allow easily closing the dialog in instances where the titlebar may not be visible (i.e. GameScope).
- Adjust the dialog size slightly to accommodate these changes.
- Probably other extremely minor UI sizing/layout tweaks I'm forgetting :sweat_smile: 

I think these changes make the Batch Update dialog a little bit more user-friendly. I have provided some sample screenshots below that I hope will show the improvements.

## Implementation
### Fetching the Compatibility Tool List
As noted above, we fetch the list of installed compatibility tools in the Batch Update dialog. But to allow the dropdown to be disabled if no other supported tools are installed, we have to know the current ctool name. We can get this from the displayname of the ctinfo dialog, since Batch Update is called from that dialog we already have that compatibility tool context.

I also changed how we build the dropdown elements, using a list and calling `addItems`. The filtering is done in a list comprehension instead of in the for loop.

All these changes should have a negligible performance impact.

### Warning Labels
I created a helper method to generate warning labels. This creates a QLabel and adds it to a FormLayout, which the Batch Update dialog uses. We give this as an argument to `add_warning_message` but we could hardcode it to just use `self.ui.formLayout`. Finally we also pass a stylesheet, because the Steam Running warning uses orange text since it's a warning that won't prevent the user from performing the batch update, but the missing compatibility tools message uses red text since we *do* prevent the user from performing the batch update. Taking an optional stylesheet made this simpler. Finally we of course give this method the text to use.

These labels are centered solely because I thought it looked nicer. I also used a full stop on both labels because it's there for the Steam Running warning on `main`, but it could be taken out if it's not necessary. On the Games List we use an exclamation mark, maybe we could do that here too :slightly_smiling_face: 

These labels are generated and added programmatically in an if/elif/else block, because it doesn't make sense imo to show both at once. The "no compatibility tool" message takes priority because it doesn't matter if Steam is running or not, Batch Update cannot be performed. The user would have to close the dialog anyway to install the new tool or to update the list of compatibility tools if a new one was added while the dialog was open. That's why only one is shown at a time, and why the No Compatibility Tools message takes precedence. I hope I explained that well enough.

Doing things in this way also made managing the layout easier. The label row is "structurally important" to the UI, which I'm not very pleased about, but it was better than fitting it into the bottom left and making the dialog wider just to accommodate that label. Putting the labels here would be less natural than it is for the Games List which puts the Steam Running label here. It might also be tricky, as we would have to programmatically set the label text, as having both labels at once would still lead to "structurally important" label placement.

On the subject of structurally important labels, that's why we have the "spacer label" in the `else` block. It allows for that bit of spacing between the form layout and the Batch Update and Close buttons, which imo it looks better to have the space there than under the buttons.

## Comparison
### Main Branch
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/557d4872-a67f-45d9-adf6-9bf9e1428dd0)

### This PR
#### No Supported Compatibility Tools
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/5851a7ca-b447-415a-8cfb-c686d2ab8ab3)

#### Steam Client Running
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/0d0785ff-a4ce-451f-8435-b23119474bdf)

#### Happy Migration Path
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/1da7aedf-234e-44b7-a449-0367b80c418a)

## Considerations
I have a couple of thoughts on the current state of this PR. While everything is functional there are some points that might merit discussion :slightly_smiling_face: 
- Batch Update is not disabled if no games are installed because we're handling that differently in #319.
- Not sure if "Batch Update" should be right-aligned with the "Close" button or if we should put it on the left. I put it on the right to match the general "Confirm/Cancel" layout, to visually differentiate it from the "Batch Update" button on the ctinfo dialog behind it (see screenshot below), and to match what we do in other dialogs (i.e. Custom Install Directory).
- Related to the above, should the text still say "Batch Update" or should we change it to something more 'standard' such as  "Ok" or "Confirm". Likewise, perhaps "Close" should say "Cancel" like how the Games List dialog says when a modification is made?
- If there are tools to batch update to, should we default to a compatibility tool at all, or set the default entry to something like `-- Select --`? Then, we can disable the Batch Update button if no tool is selected. But for UX we would only add this if 
    - This is not consistent with other dropdowns such as install tool, but it is consistent with having the "`-`" option in the Games List when selecting a compatibility tool. The Custom Install Directory dialog defaults a dropdown value but that's fine because it can't be added without a directory, which is blank by default, so its UX is different to the install dialog and Games List.
- I am unsure if the "Old Version" label in Batch Update should be the 1st or 2nd row. On one hand, "logically" the ordering makes sense, but since the user interacts with the dropdown and not the "old version" label, it may make more sense to have this on the 1st row...
- All feedback on label phrasing is welcome! I'm not super attached to any of the wording so anything you think is an improvement can be changed.
- _Super duper mega_ semantic: Should we camel case the "Batch update" button in ctinfo? :sweat_smile: 

Here is the screenshot to illustrate how the "Batch Update" button on the ctinfo dialog and Batch Update dialog are more visually distinct by having the Batch Update's button on the right:

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/62f0295f-8d95-4838-881d-a0476a45c192)

<hr>

I think that covers it. I hope these are good improvements, in my opinion it makes the UI a bit cleaner and feel a bit more consistent with the rest of ProtonUp-Qt, and gives some practical advantages such as being able to close the dialog with a dedicated button. But I made the PR so of course I'm a little biased :wink: 

Please let me know if you have any other feedback on these changes or any further changes that should be made while I'm poking around this part of the code.

Thanks! :-)