### PR TITLE
pupgui2: Put Global Tool at top of list

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -237,6 +237,7 @@ class MainWindow(QObject):
                 ct_name = ct.get_internal_name()
                 if ct_name == global_ctool_name:
                     ct.set_global()  # Set (global) text
+                    self.compat_tool_index_map.insert(0, self.compat_tool_index_map.pop(self.compat_tool_index_map.index(ct)))  # Move global ctool to top of list
         # Launcher specific (Heroic): Set number of installed games using compat tool
         elif is_heroic_launcher(install_loc.get('launcher')):
             heroic_dir = os.path.join(os.path.expanduser(install_loc.get('install_dir')), '../..')


### PR DESCRIPTION
Another part for #254, and hopefully a quick win.

This PR puts the global compatibility tool at the top of the tools list. We do this in the same condition here we mark the tool as global. I found a one-liner on StackOverflow that shows how to do this. Since we're looping through the `compat_tool_index_map` list already, we have a reference to the `ct` object. So we `pop` it from the list and since `pop` returns the element, we can pass this to `insert` and put it at index `0`. Maybe not the *most* readable one-liner but I think it's fine :-)

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/eb6efbc8-9b56-4aa0-9f8f-5e47d2cf89ba)

This doesn't impact interacting with the tool the ctinfo dialog still opens as expected (we can make the change to hide the Games List after #319):

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/ce1acd55-9eed-4f23-ae0d-bf5297d0fce2)

*(The games list is displaying this way because I edited my `config.vdf` temporarily, with Steam closed, to make this Proton version the global one. It isn't actually my global compatibility tool. This screenshot is just to illustrate that there should be no impact to moving the ctool to the top of the list :slightly_smiling_face: )*

This does mean we can still remove the tool as well, but that change can be made in a separate PR.

<hr>

Thanks!