### PR TITLE
pupgui2: Disable Remove Button for Global Compatibility Tool

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -412,6 +412,9 @@ class MainWindow(QObject):
             if ct.ct_type in [CTType.STEAM_CT, CTType.STEAM_RT]:
                 self.ui.btnRemoveSelected.setEnabled(False)
                 break
+            if ct.is_global:
+                self.ui.btnRemoveSelected.setEnabled(False)
+                break
 
     def btn_show_ct_info_clicked(self):
         install_loc = get_install_location_from_directory_name(install_directory())


### PR DESCRIPTION
Another piece for #254.

This PR disables `btnRemoveSelected` when the currently selected compatibility tool `is_global`. We already have a loop where we disable based on the compatibility tool type, so this just adds an extra condition :-)

Currently this PR does not:
- Allow removing in Advanced Mode, though that would be trivial to add
- Show a warning dialog of any sort

The approach I took is based on partial discussion in #314: Disable the Remove button for the global tool by default. I figure there's no need to allow remove and then show a warning, we can simply show a warning in advanced mode and users can optionally proceed. We don't want users to risk anything without this enabled, and hopefully it's clear that the global tool shouldn't be removed. The user would have to explicitly set this anyway, so they should also be able to unset it.

Only showing one dialog and only doing it in Advanced Mode probably also makes implementation easier, since we don't have to juggle dialog elements like we do for the SteamTinkerLaunch dialogs :-)

I should be able to add the dialog in this PR as well, but if you'd prefer it go in a separate PR that's fine too.

Thanks!