### PR TITLE
CtInfo: Hide Game List When Tool is Global

### DIFF
--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -119,8 +119,8 @@ class PupguiCtInfoDialog(QObject):
         self.ui.txtNumGamesUsingTool.setText(str(row_count))        
 
     def update_game_list_ui(self):
-        self.ui.listGames.setVisible(len(self.games) > 0 and not self.ctool.is_global)
-        self.ui.lblGamesList.setVisible(len(self.games) <= 0 or self.ctool.is_global)
+        # switch between showing the QTableWidget (listGames) or the QLabel (lblGamesList)
+        self.ui.stackTableOrText.setCurrentIndex(0 if len(self.games) > 0 and not self.ctool.is_global else 1)
         self.ui.btnBatchUpdate.setEnabled(len(self.games) > 0 and not self.ctool.is_global)
         self.ui.btnSearch.setEnabled(len(self.games) > 0 and not self.ctool.is_global)
 

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -119,10 +119,16 @@ class PupguiCtInfoDialog(QObject):
         self.ui.txtNumGamesUsingTool.setText(str(row_count))        
 
     def update_game_list_ui(self):
-        self.ui.listGames.setVisible(len(self.games) > 0)
-        self.ui.lblGamesList.setVisible(len(self.games) <= 0)
-        self.ui.btnBatchUpdate.setEnabled(len(self.games) > 0)
-        self.ui.btnSearch.setEnabled(len(self.games) > 0)
+        self.ui.listGames.setVisible(len(self.games) > 0 and not self.ctool.is_global)
+        self.ui.lblGamesList.setVisible(len(self.games) <= 0 or self.ctool.is_global)
+        self.ui.btnBatchUpdate.setEnabled(len(self.games) > 0 and not self.ctool.is_global)
+        self.ui.btnSearch.setEnabled(len(self.games) > 0 and not self.ctool.is_global)
+
+        if self.ctool.is_global:
+            self.ui.lblGamesList.setText(self.tr('Tool is Global'))
+
+        if len(self.games) < 0 or self.ctool.is_global:
+            self.ui.btnClose.setFocus()
 
     def list_games_cell_double_clicked(self, row):
         if self.install_loc.get('launcher') == 'steam':

--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -20,42 +20,42 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
-     <item row="1" column="0">
+     <item row="0" column="0">
       <widget class="QLabel" name="lblToolName">
        <property name="text">
         <string>Compatibility tool:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="0" column="1">
       <widget class="QLabel" name="txtToolName">
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="1" column="0">
       <widget class="QLabel" name="lblLauncherName">
        <property name="text">
         <string>Game Launcher:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="1" column="1">
       <widget class="QLabel" name="txtLauncherName">
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="lblInstallDirectory">
        <property name="text">
         <string>Install directory:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="2" column="1">
       <widget class="QLabel" name="txtInstallDirectory">
        <property name="text">
         <string/>

--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -131,44 +131,13 @@
     </layout>
    </item>
    <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-    <widget class="QLabel" name="lblGamesList">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
+    <widget class="QTableWidget" name="listGames">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="font">
-      <font>
-       <pointsize>18</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>No games</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QTableWidget" name="listGames">
      <property name="focusPolicy">
       <enum>Qt::ClickFocus</enum>
      </property>
@@ -207,6 +176,43 @@
      </attribute>
      <column/>
      <column/>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblGamesList">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>18</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>No games</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
     </widget>
    </item>
    <item>

--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -131,35 +131,28 @@
     </layout>
    </item>
    <item>
-    <spacer name="verticalSpacer_2">
+    <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>0</height>
       </size>
      </property>
     </spacer>
    </item>
-   <item>
-    <spacer name="verticalSpacer_4">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
+   <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
     <widget class="QLabel" name="lblGamesList">
      <property name="enabled">
       <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="font">
       <font>
@@ -173,19 +166,6 @@
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_5">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <widget class="QTableWidget" name="listGames">
@@ -230,27 +210,14 @@
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
+       <height>0</height>
       </size>
      </property>
     </spacer>

--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -131,102 +131,121 @@
     </layout>
    </item>
    <item>
-    <widget class="QTableWidget" name="listGames">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::ClickFocus</enum>
-     </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <property name="rowCount">
+    <widget class="QStackedWidget" name="stackTableOrText">
+     <property name="currentIndex">
       <number>0</number>
      </property>
-     <property name="columnCount">
-      <number>2</number>
-     </property>
-     <attribute name="horizontalHeaderVisible">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="horizontalHeaderCascadingSectionResizes">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="verticalHeaderShowSortIndicator" stdset="0">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="verticalHeaderStretchLastSection">
-      <bool>false</bool>
-     </attribute>
-     <column/>
-     <column/>
+     <widget class="QWidget" name="page">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTableWidget" name="listGames">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::ClickFocus</enum>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <property name="rowCount">
+          <number>0</number>
+         </property>
+         <property name="columnCount">
+          <number>2</number>
+         </property>
+         <attribute name="horizontalHeaderVisible">
+          <bool>true</bool>
+         </attribute>
+         <attribute name="horizontalHeaderCascadingSectionResizes">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="verticalHeaderShowSortIndicator" stdset="0">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="verticalHeaderStretchLastSection">
+          <bool>false</bool>
+         </attribute>
+         <column/>
+         <column/>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_2">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="lblGamesList">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>18</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>No games</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QLabel" name="lblGamesList">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>18</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>No games</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">


### PR DESCRIPTION
UX tweak related to #254.
Follow up from #319.

## Overview
This PR hides the games list for the global compatibility tool. Currently this only applies to the Steam global compatibility tool. This is because this tool is the default for any game not using a custom compatibility tool, so it doesn't really make sense to show a games list, and any games list we show would be incomplete, and there's no need to show the list when a given tool is the global one.

I also made a minor change to set the focus to be the "Close" button when the games list is blank or when the tool is global.

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/ec4cda0d-a2f9-406e-9423-70e611b59b29)

*(The number of games using the compatibility tool is `5` because I modified my `config.vdf` to set this tool as global instead of actually setting it as global from Steam, to avoid messing up any game configurations, since I don't actually want GE-Proton8-25 to be my global compatibility tool. Normally, this would probably be `0`, so hope that clears up the discrepancy.)*

Since the only defaults Valve set are Valve Proton versions (which are not displayed in ProtonUp-Qt), if ProtonUp-Qt is displaying a given tool as the global one, that means the user went out of their way to specifically set this tool as global in the Steam Settings, so they should be aware anyway that this tool is the global one and what that means :-)

This PR also makes a couple of layout changes, fixing some spacers and reducing the overall perceived padding introduced to the games list in #319. I have included a comparison screenshot of `main` to illustrate the UI difference.

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/4bf43586-de61-43b5-9878-092e88329296)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/18b47914-5874-414b-af41-4af202d8e457)

## Background
When a tool is marked as global for Steam, it basically means any Windows game (or Steam app!) will use that tool by default unless a custom compatibility tool is forced from the Steam Properties menu for a specific game ("Force the use of a custom Steam Play compatibility tool"), or if Valve have specified a specific compatibility tool for that game instead.

The global compatibility tool, as far as I know, cannot be selected from the custom Steam Play Compatibility Tool dropdown on the Game Properties menu (unless you're forcing a native game to use Proton), though it could be set manually from `config.vdf`. However there is no reason to do this since it will be used by default if no custom compatibility tool is forced.

As a result of this behaviour, all installed games which are not using a custom compatibility tool, will be using the global compatibility tool. Therefore it is a little misleading to show a games list, as it would either be incomplete, or we would have to end up creating logic to list all the Windows games not using a compatibility tool, and there is no real need to do this since we have the Games List for that purpose. We'd have to do some kind of filtering on the `from_os` value for a SteamApp if we store that, and it could end up getting complicated.

## Implementation
The biggest part of the diff here is the UI file edited using Qt Designer. The actual code changes were pretty small. Essentially just:
- Hiding the games list of the current ctool is global.
- Hiding the batch update button if the current ctool is global.
- Disabling the search button if the current ctool is global.
- Showing the `lblGamesList` (by default says "No games", introduced in #319) if the current ctool is global.
- Changing the `lblGamesList` text to say "Tool is Global" instead of the default "No Games" text if the current ctool is global.
    - This means even though the global ctool should normally have 0 games, we prioritize displaying the "Tool is Global" message, which makes a bit more sense since it isn't quite right to say "No games". It also means we can re-use the `lblGamesList`.

We re-use the `setVisible` and `setEnabled` calls from `update_game_list_ui`, and just update their logic to have an extra check for `self.ctool.is_global`, so we just piggyback off of these existing checks. This means the UIX from #319 when we have 0 games directly and identically applies to when we have a global compatibility tool. 

I chose to add an additional check for `self.ctool.is_global` to these checks to be more explicit. In most cases, the global ctool should have zero games, but in cases where `config.vdf` is manually updated, or potentially some other weird corner cases, having this explicit check means we don't have to rely on "expected" behaviour, we can use our boolean for when we *know* a tool should be the global one, and work with that.

## Future Work
### Games List Sizing Regression
A sizing regression was introduced in #319, and has been slightly mitigated in this PR but is still problematic.

When resizing the CtInfo dialog, because of the spacers that position the `lblGamesList` element, the games list does not vertically fill the CtInfo dialog. The vertical spacers

We could name and hide the spacers like we do for other UI elements, but it feels a bit messy. We also can't use layouts to solve this problem, as putting the spacers, games list, and label in one layout just creates the same problem. Putting just the spacers and the label in a layout may solve the problem, but layouts cannot be hidden in Qt as far as I understand ([Qt forums link](https://forum.qt.io/topic/61472/how-to-hide-the-horizontallayout), likely also applies to PySide6 as there is no `setVisible` for layouts since that is a property of `QWidget`s). So we would have to first make a parent `QWidget` which -> contains `VBoxLayout` which -> contains a `Spacer` + `QLabel` + `Spacer`.

This seems a bit unclean though, perhaps there is a better way to organize this layout. 

### Other Launchers
Right now we only mark a tool as global for Steam, but this change is not Steam-specific in case there is a time in future when we want to do this for other launchers. The game list UI changes here are not tied solely to Steam, but currently, they only impact Steam.

<hr>

Just some follow-up UI tweaks to take another step towards fully implementing what was discussed for #254. Even if that issue is closed there were a couple of other bits of functionality discussed and with this PR we should be another step closer!