### PR TITLE
Shortcut Editor: Implement Search Functionality

### DIFF
--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -48,6 +48,7 @@ class PupguiShortcutDialog(QObject):
         self.ui.btnClose.clicked.connect(self.btn_close_clicked)
         self.ui.btnAdd.clicked.connect(self.btn_add_clicked)
         self.ui.btnRemove.clicked.connect(self.btn_remove_clicked)
+        self.ui.searchBox.textChanged.connect(self.search_shortcuts)
 
     def prepare_table_row(self, i: int, shortcut: SteamApp):
         txt_name = QLineEdit(shortcut.game_name)
@@ -167,3 +168,11 @@ class PupguiShortcutDialog(QObject):
                 if sid not in self.discarded_shortcuts:
                     self.discarded_shortcuts.append(sid)
                 self.ui.tableShortcuts.cellWidget(i, 0).setStyleSheet('QLineEdit { color: red; }')
+
+    def search_shortcuts(self, text):
+        """ Search based on the shortcut name text (App Name on Row 0) in the QLineEdit widget on each row """
+        for row in range(self.ui.tableShortcuts.rowCount()):
+            if type(row_widget := self.ui.tableShortcuts.cellWidget(row, 0)) is not QLineEdit:
+                continue
+            should_hide: bool = not text.lower() in row_widget.text().lower()
+            self.ui.tableShortcuts.setRowHidden(row, should_hide)

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -172,7 +172,11 @@ class PupguiShortcutDialog(QObject):
     def search_shortcuts(self, text):
         """ Search based on the shortcut name text (App Name on Row 0) in the QLineEdit widget on each row """
         for row in range(self.ui.tableShortcuts.rowCount()):
-            if type(row_widget := self.ui.tableShortcuts.cellWidget(row, 0)) is not QLineEdit:
+            if type(row_widget_name := self.ui.tableShortcuts.cellWidget(row, 0)) is not QLineEdit:
                 continue
-            should_hide: bool = not text.lower() in row_widget.text().lower()
+            if type(row_widget_exe := self.ui.tableShortcuts.cellWidget(row, 1)) is not QLineEdit:
+                row_widget_exe = None
+            search_text_in_name = text.lower() in row_widget_name.text().lower()
+            search_text_in_exe = text.lower() in row_widget_exe.text().lower() if row_widget_exe else False
+            should_hide: bool = not (search_text_in_name or search_text_in_exe)
             self.ui.tableShortcuts.setRowHidden(row, should_hide)

--- a/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
@@ -71,7 +71,7 @@
      <item>
       <widget class="QLineEdit" name="searchBox">
        <property name="toolTip">
-        <string/>
+        <string>e.g. ProtonUp-Qt</string>
        </property>
        <property name="placeholderText">
         <string>Search for a game...</string>

--- a/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
@@ -69,17 +69,14 @@
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+      <widget class="QLineEdit" name="searchBox">
+       <property name="toolTip">
+        <string/>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
+       <property name="placeholderText">
+        <string>Search for a game...</string>
        </property>
-      </spacer>
+      </widget>
      </item>
      <item>
       <widget class="QPushButton" name="btnSave">


### PR DESCRIPTION
## Overview
This PR adds a QLineEdit to function as a search bar to the Shortcuts Editor dialog, matching what we have for the CtInfo dialog and the Games List dialog. I have some other planned PRs for the Shortcuts dialog (spoiler :wink:) , so while I was working in here I realised search was missing and figured it would be straightforward enough to add.

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/82366830-6ac3-46e0-8c16-0d6e69d972c4)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/5ffc7bc0-4294-4f3c-8000-597286d992fb)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/1d252523-fac4-4450-95b7-45da3145881a)

## Implementation
Unlike the CtInfo and Games List tables, which use static labels, the Shortcuts Editor uses QLineEdits. So in order to search, we have to get the widget in the cell and then get the text from that widget, instead of just getting the TableItem at that cell and getting the text.

I believe you can populate tables with TableItems in Qt and have the option to double-click to edit them, but the Shortcuts Dialog uses QLineEdits and personally I think this is more flexible anyway.

## Design
### Always Shown Search Bar
This search bar is shown unconditionally. While this doesn't match the behaviour of the CtInfo and Games List, on those dialogs we have a search button (and Ctrl+F shortcut) because the search bar may conflict with existing widgets. On the CtInfo dialog, the Search Bar is toggled because it may overlap with the "Batch Update" button, and on the Games List, it conflicts with the Steam Running warning message. The search bar kind of has to be a toggle on those dialogs, but we have no such limitation on the Shortcuts Editor dialog, so we can unconditionally show the search bar. It would also be a bit more cluttered to introduce a search button either on the same bottom row of Add/Remove/Save/Close, above the games list with a new row, or a new row above/below the Add/Remove/Save/Close options.

Another spoiler, I'm investigating the feasibility / usefulness of adding a button to refresh the shortcuts list, so having a dedicated search button would create even more clutter on the bottom row (on top of not being as necessary as it is on the CtInfo/Games List).

I will also admit, I think it just looks nice to fill that space :sweat_smile: 

### No Tooltip
There is no tooltip for the search bar, unlike for the CtInfo and Games List dialog search bars which show "e.g. Half-Life 3" and "e.g. Team Fortress 2" respectively. Initially I had planned to add a tooltip for the Shortcuts dialog (of course with something equally as witty as Half-Life 3) but I had an idea to instead refactor the tooltip logic a bit. Instead of having a fixed tooltip, these search box tooltips could show a tooltip with a random game from the current game list. So instead of always saying "e.g. Half-Life 3", on each load of the dialog it would pick a random game name and generate the tooltip.

Instead of adding a tooltip here only to strip it out in another PR, I figured I'd leave it out. Then, if that PR is declined, we could add a tooltip here separately.

<hr>

If you want to make a release with the Shortcuts Dialog as-is then we can leave this PR for review until after the next release. It may make more sense to get an initial iteration out first and then work on enhancements afterwards. Even though this isn't out in a release yet, out of habit I use ProtonUp-Qt from my fork on `main` with `python3 -m pupgui2`, so I've been using the shortcut editor a little bit even so :-)

Thanks!