### PR TITLE
CtInfo, Games List: Use random game name from list in tooltip

### DIFF
--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -151,7 +151,7 @@ class PupguiCtInfoDialog(QObject):
         # Generate random tooltip here, updating so if a game is removed on refresh, we won't list a game no longer listed
         # If game is not found, fall back to tooltip defined in UI file
         if tooltip_game_name := get_random_game_name(self.games):
-            self.ui.searchBox.setToolTip('e.g. {GAME_NAME}'.format(GAME_NAME=tooltip_game_name))
+            self.ui.searchBox.setToolTip(self.tr('e.g. {GAME_NAME}').format(GAME_NAME=tooltip_game_name))
 
         self.ui.searchBox.setVisible(not self.ui.searchBox.isVisible())
         self.ui.btnBatchUpdate.setVisible(self.is_batch_update_available and not self.ui.searchBox.isVisible())

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -131,11 +131,6 @@ class PupguiCtInfoDialog(QObject):
         if len(self.games) < 0 or self.ctool.is_global:
             self.ui.btnClose.setFocus()
 
-        # Generate random tooltip here, updating so if a game is removed on refresh, we won't list a game no longer listed
-        # If game is not found, fall back to tooltip defined in UI file
-        if tooltip_game_name := get_random_game_name(self.games):
-            self.ui.searchBox.setToolTip('e.g. {GAME_NAME}'.format(GAME_NAME=tooltip_game_name))
-
     def list_games_cell_double_clicked(self, row):
         if self.install_loc.get('launcher') == 'steam':
             steam_game_id = str(self.ui.listGames.item(row, 0).text())
@@ -152,6 +147,11 @@ class PupguiCtInfoDialog(QObject):
     def btn_search_clicked(self):
         if not self.ui.btnSearch.isEnabled():
             return
+
+        # Generate random tooltip here, updating so if a game is removed on refresh, we won't list a game no longer listed
+        # If game is not found, fall back to tooltip defined in UI file
+        if tooltip_game_name := get_random_game_name(self.games):
+            self.ui.searchBox.setToolTip('e.g. {GAME_NAME}'.format(GAME_NAME=tooltip_game_name))
 
         self.ui.searchBox.setVisible(not self.ui.searchBox.isVisible())
         self.ui.btnBatchUpdate.setVisible(self.is_batch_update_available and not self.ui.searchBox.isVisible())

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -1,6 +1,5 @@
 import pkgutil
 import os
-import random
 
 from pupgui2.constants import STEAM_APP_PAGE_URL
 from pupgui2.datastructures import BasicCompatTool, CTType, SteamApp, LutrisGame, HeroicGame

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -303,7 +303,7 @@ class PupguiGameListDialog(QObject):
     def update_tooltip(self):
         # If game is not found, fall back to tooltip defined in UI file
         if tooltip_game_name := get_random_game_name(self.games):
-            self.ui.searchBox.setToolTip('e.g. {GAME_NAME}'.format(GAME_NAME=tooltip_game_name))
+            self.ui.searchBox.setToolTip(self.tr('e.g. {GAME_NAME}').format(GAME_NAME=tooltip_game_name))
 
     def btn_search_clicked(self):
         self.ui.searchBox.setVisible(not self.ui.searchBox.isVisible())

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -77,7 +77,6 @@ class PupguiGameListDialog(QObject):
         if len(self.games) > 0:
             self.ui.btnSearch.setVisible(True)
             QShortcut(QKeySequence.Find, self.ui).activated.connect(self.btn_search_clicked)
-            self.update_tooltip()
 
     def setup_steam_list_ui(self):
         self.ui.tableGames.setHorizontalHeaderLabels([self.tr('Game'), self.tr('Compatibility Tool'), self.tr('Deck compatibility'), self.tr('Anticheat'), 'ProtonDB'])
@@ -313,6 +312,8 @@ class PupguiGameListDialog(QObject):
         self.ui.searchBox.setFocus()
 
         self.search_gamelist_games(self.ui.searchBox.text() if self.ui.searchBox.isVisible() else '')
+
+        self.update_tooltip()
 
     def btn_shortcut_editor_clicked(self):
         self.ui.close()

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -1,6 +1,5 @@
 import os
 import pkgutil
-import random
 
 from typing import List, Callable, Tuple, Union
 from datetime import datetime

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -8,6 +8,7 @@ import webbrowser
 import requests
 import zipfile
 import tarfile
+import random
 
 import zstandard
 
@@ -21,7 +22,7 @@ from PySide6.QtWidgets import QApplication, QStyleFactory, QMessageBox, QCheckBo
 from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS, CONFIG_FILE, PALETTE_DARK, TEMP_DIR
 from pupgui2.constants import AWACY_GAME_LIST_URL, LOCAL_AWACY_GAME_LIST
 from pupgui2.constants import GITHUB_API, GITLAB_API, GITLAB_API_RATELIMIT_TEXT
-from pupgui2.datastructures import BasicCompatTool, CTType, Launcher
+from pupgui2.datastructures import BasicCompatTool, CTType, Launcher, SteamApp, LutrisGame, HeroicGame
 from pupgui2.steamutil import remove_steamtinkerlaunch
 
 
@@ -853,3 +854,21 @@ def create_missing_dependencies_message(ct_name: str, dependencies: List[str]) -
     )
 
     return tr_msg, False
+
+
+def get_random_game_name(games: List[Union[SteamApp, LutrisGame, HeroicGame]]) -> str:
+    """ Return a random game name from list of SteamApp, LutrisGame, or HeroicGame """
+
+    if len(games) <= 0:
+        return ''
+    
+    tooltip_game_name = ''
+    random_game = random.choice(games)
+    if type(random_game) is SteamApp:
+        tooltip_game_name = random_game.game_name
+    elif type(random_game) is LutrisGame:
+        tooltip_game_name = random_game.name
+    elif type(random_game) is HeroicGame:
+        tooltip_game_name = random_game.title
+    
+    return tooltip_game_name


### PR DESCRIPTION
## Overview
This PR allows for dynamically setting the search box tooltip for the CtInfo Dialog and Games List. On `main`, we hardcode these in the UI file to "Half-Life 3" and "Team Fortress 2" respectively, but now we attempt to take a random game from the list of games and use that game name in the tooltip. For example, if the games list has "GUILTY GEAR -STRIVE-", the tooltip has a chance of selecting that game and so would say "e.g. GUILTY GEAR -STRIVE-".

If the game list length is zero, or if we happen to select a game that somehow doesn't have a name, we will fall back to the default tooltip defined in the UI file. There could *maybe* be an edge case for Heroic/Lutris if someone only had one game using a tool and they manually made the game name blank, in such a case we would use our fallback. But that is astronomically unlikely to happen, and we don't show the search bar when the games list length is zero, so it's pretty unlikely that a user will ever see the fallback label. Still, since we can't `random.choice` on an empty list, we had to handle this case anyway :-)

Here are some screenshots:

### Steam CtInfo
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/22fb5a18-73fa-4fe3-b9c6-9c2d6b617a55)

### Heroic Games List
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/60b7351d-53b1-450e-ba3d-0bb5bdeb5cd7)

The tooltip updates on refresh too, so that if a game is added/removed in that time, we won't display names of games that aren't there.

This is implemented for Steam, Lutris, and Heroic. If we can't find a tooltip (i.e. the name is blank for some weird reason), we fall back to the tooltip define in the UI file.

Translation should not really matter here, since it will either use a translated tooltip in the UI file (if that's even applicable) or it will use the game name, which doesn't need a dedicated translation since it's simply pulling from the game name we already store.

I don't think this will add any considerable overhead, since we just pick a random element from the list of games that we already store. We aren't generating the games list again just to do this, we're re-using the list we already have.

<hr>

This just adds a bit of fun context to the search field that I thought would be cool to add :-)