### PR TITLE
Shortcut Editor: Various UIX Tweaks

### DIFF
--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -97,6 +97,11 @@ class PupguiShortcutDialog(QObject):
         txt_path.setToolTip(shortcut.shortcut_startdir)
         txt_icon.setToolTip(shortcut.shortcut_icon)
 
+        txt_name.setPlaceholderText(shortcut.game_name)
+        txt_exe.setPlaceholderText(shortcut.shortcut_exe)
+        txt_path.setPlaceholderText(shortcut.shortcut_startdir)
+        txt_icon.setPlaceholderText(shortcut.shortcut_icon)
+
         txt_name.editingFinished.connect(lambda i=i: self.txt_changed(i, 0))
         txt_exe.editingFinished.connect(lambda i=i: self.txt_changed(i, 1))
         txt_path.editingFinished.connect(lambda i=i: self.txt_changed(i, 2))

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -55,6 +55,8 @@ class PupguiShortcutDialog(QObject):
         txt_path = QLineEdit(shortcut.shortcut_startdir)
         txt_icon = QLineEdit(shortcut.shortcut_icon)
 
+        txt_name.setCursorPosition(0)
+
         txt_name.editingFinished.connect(lambda i=i: self.txt_changed(i, 0))
         txt_exe.editingFinished.connect(lambda i=i: self.txt_changed(i, 1))
         txt_path.editingFinished.connect(lambda i=i: self.txt_changed(i, 2))

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -11,6 +11,25 @@ from pupgui2.steamutil import get_steam_shortcuts_list, write_steam_shortcuts_li
 from pupgui2.util import host_path_exists
 
 
+class ShortcutDialogLineEdit(QLineEdit):
+
+    def __init__(self, parent=None, default_cursor_position: int = -1, *args, **kwargs,):
+        super(ShortcutDialogLineEdit, self).__init__(parent, *args, **kwargs)
+
+        self.default_cursor_position = default_cursor_position
+        if self.default_cursor_position >= 0:
+            self.setCursorPosition(self.default_cursor_position)
+
+    def focusOutEvent(self, arg__1):
+        super().focusOutEvent(arg__1)  # Super handles focusing events etc
+        updated_cursor_pos = len(self.text()) if self.default_cursor_position == -1 else self.default_cursor_position
+        self.setCursorPosition(updated_cursor_pos)  # Move cursor back to default position (ex: start for Game Name field)
+        self.deselect()
+
+    def mousePressEvent(self, arg__1):
+        self.selectAll()
+
+
 class PupguiShortcutDialog(QObject):
 
     def __init__(self, steam_config_folder: str, game_property_changed: Signal, parent=None):
@@ -50,12 +69,10 @@ class PupguiShortcutDialog(QObject):
         self.ui.btnRemove.clicked.connect(self.btn_remove_clicked)
 
     def prepare_table_row(self, i: int, shortcut: SteamApp):
-        txt_name = QLineEdit(shortcut.game_name)
-        txt_exe = QLineEdit(shortcut.shortcut_exe)
-        txt_path = QLineEdit(shortcut.shortcut_startdir)
-        txt_icon = QLineEdit(shortcut.shortcut_icon)
-
-        txt_name.setCursorPosition(0)
+        txt_name = ShortcutDialogLineEdit(shortcut.game_name, default_cursor_position=0)
+        txt_exe = ShortcutDialogLineEdit(shortcut.shortcut_exe)
+        txt_path = ShortcutDialogLineEdit(shortcut.shortcut_startdir)
+        txt_icon = ShortcutDialogLineEdit(shortcut.shortcut_icon)
 
         txt_name.editingFinished.connect(lambda i=i: self.txt_changed(i, 0))
         txt_exe.editingFinished.connect(lambda i=i: self.txt_changed(i, 1))

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -92,6 +92,11 @@ class PupguiShortcutDialog(QObject):
         txt_path = ShortcutDialogLineEdit(shortcut.shortcut_startdir)
         txt_icon = ShortcutDialogLineEdit(shortcut.shortcut_icon)
 
+        txt_name.setToolTip(shortcut.game_name)
+        txt_exe.setToolTip(shortcut.shortcut_exe)
+        txt_path.setToolTip(shortcut.shortcut_startdir)
+        txt_icon.setToolTip(shortcut.shortcut_icon)
+
         txt_name.editingFinished.connect(lambda i=i: self.txt_changed(i, 0))
         txt_exe.editingFinished.connect(lambda i=i: self.txt_changed(i, 1))
         txt_path.editingFinished.connect(lambda i=i: self.txt_changed(i, 2))

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -1,7 +1,7 @@
 import pkgutil
 from collections import Counter
 
-from PySide6.QtCore import QObject, Signal, QDataStream, QByteArray
+from PySide6.QtCore import Qt, QObject, Signal, QDataStream, QByteArray
 from PySide6.QtWidgets import QLineEdit
 from PySide6.QtUiTools import QUiLoader
 
@@ -19,15 +19,23 @@ class ShortcutDialogLineEdit(QLineEdit):
         self.default_cursor_position = default_cursor_position
         if self.default_cursor_position >= 0:
             self.setCursorPosition(self.default_cursor_position)
+        
+        self.focus_reason = None
 
     def focusOutEvent(self, arg__1):
         super().focusOutEvent(arg__1)  # Super handles focusing events etc
         updated_cursor_pos = len(self.text()) if self.default_cursor_position == -1 else self.default_cursor_position
         self.setCursorPosition(updated_cursor_pos)  # Move cursor back to default position (ex: start for Game Name field)
-        self.deselect()
+
+    def focusInEvent(self, arg__1):
+        super().focusInEvent(arg__1)
+        self.focus_reason = arg__1.reason()
+        # self.setCursorPosition(len(self.text()))
 
     def mousePressEvent(self, arg__1):
-        self.selectAll()
+        super().mousePressEvent(arg__1)
+        if self.focus_reason == Qt.MouseFocusReason:
+            print('Hewlo')
 
 
 class PupguiShortcutDialog(QObject):

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -159,6 +159,8 @@ class PupguiShortcutDialog(QObject):
         elif col == 3:
             self.shortcuts[index].shortcut_icon = text
 
+        self.ui.tableShortcuts.cellWidget(index, col).setToolTip(text)
+
     def btn_save_clicked(self):
         # remove all shortcuts that have no name or executable
         filtered_shortcuts = list(filter(lambda s: s.game_name != '' and s.shortcut_exe != '', self.shortcuts))

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -80,6 +80,7 @@ class PupguiShortcutDialog(QObject):
 
     def setup_ui(self):
         self.ui.tableShortcuts.setHorizontalHeaderLabels([self.tr('App Name'), self.tr('Executable'), self.tr('Start Directory'), self.tr('Icon')])
+        self.ui.tableShortcuts.setColumnWidth(0, 350)
 
         self.ui.btnSave.clicked.connect(self.btn_save_clicked)
         self.ui.btnClose.clicked.connect(self.btn_close_clicked)

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -164,7 +164,7 @@ class PupguiShortcutDialog(QObject):
         elif col == 3:
             self.shortcuts[index].shortcut_icon = text
 
-        self.ui.tableShortcuts.cellWidget(index, col).setToolTip(text)
+        self.ui.tableShortcuts.cellWidget(index, col).setToolTip(text or self.ui.tableShortcuts.cellWidget(index, col).placeholderText())
 
     def btn_save_clicked(self):
         # remove all shortcuts that have no name or executable

--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -20,22 +20,32 @@ class ShortcutDialogLineEdit(QLineEdit):
         if self.default_cursor_position >= 0:
             self.setCursorPosition(self.default_cursor_position)
         
-        self.focus_reason = None
+        self.was_focused = False
 
     def focusOutEvent(self, arg__1):
         super().focusOutEvent(arg__1)  # Super handles focusing events etc
+        self.was_focused = False
+
         updated_cursor_pos = len(self.text()) if self.default_cursor_position == -1 else self.default_cursor_position
         self.setCursorPosition(updated_cursor_pos)  # Move cursor back to default position (ex: start for Game Name field)
 
     def focusInEvent(self, arg__1):
         super().focusInEvent(arg__1)
-        self.focus_reason = arg__1.reason()
-        # self.setCursorPosition(len(self.text()))
+
+        # Only call focusWithTextSelection for tab focus, because mousePressEvent will capture select on mousee click focus
+        # mousePressEvent is fired after focusInEvent, and the click event in mousePressEvent clears the selection if we call focusWithTextSelection here
+        # We can call focusWithTextSelection here and set self.was_focused because you can only focus onto the same widget with a tab once, pressing tab again moves the focus away
+        if arg__1.reason() in [ Qt.FocusReason.TabFocusReason, Qt.FocusReason.OtherFocusReason ]:
+            self.focusWithTextSelection()
 
     def mousePressEvent(self, arg__1):
         super().mousePressEvent(arg__1)
-        if self.focus_reason == Qt.MouseFocusReason:
-            print('Hewlo')
+        self.focusWithTextSelection()
+
+    def focusWithTextSelection(self):
+        if not self.was_focused:
+            self.selectAll()
+            self.was_focused = True
 
 
 class PupguiShortcutDialog(QObject):

--- a/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
@@ -10,6 +10,9 @@
     <height>350</height>
    </rect>
   </property>
+  <property name="focusPolicy">
+   <enum>Qt::ClickFocus</enum>
+  </property>
   <property name="windowTitle">
    <string>Steam Shortcut Editor</string>
   </property>
@@ -17,7 +20,7 @@
    <item>
     <widget class="QTableWidget" name="tableShortcuts">
      <property name="focusPolicy">
-      <enum>Qt::NoFocus</enum>
+      <enum>Qt::ClickFocus</enum>
      </property>
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>

--- a/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
+++ b/pupgui2/resources/ui/pupgui2_shortcutdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
+    <width>899</width>
     <height>350</height>
    </rect>
   </property>


### PR DESCRIPTION
## Overview
This PR makes a few UIX tweaks to the Shortcut Editor dialog:
- Increase size of Shortcut Editor dialog to match Games List, both show games and it makes sense to give them an equal size imo
- Increase width of App Name column, open to discussion on adjusting this and/or adjusting the widths of other columns to give the information more breathing room! On the other dialogs, the App Name is given the most sizing priority, which is why I gave it the biggest size here.
- Always put App Name LineEdit cursor at beginning, so the start of the game name is shown instead of the end.
- Select all text in LineEdit when initially focused with mouse, this allows quick editing and also moves the cursor to the end of the LineEdit, such as when clicking on the game name, allowing a quick way to see the beginning and end of the App Name.
    - Tab Focus behaviour is preserved.
- Allow unfocusing the LineEdits by clicking on the table background or the dialog background.
- When tabbing back out, the position of the App Name cursor is reset to the beginning.
- Add tooltips to LineEdits with their values, making it easier to see their full values.
- Add placeholder text to LineEdits with their original values, so if the value is cleared entirely, the original value can still be seen
    - If a LineEdit value is cleared entirely (i.e. `text` parameter in `txt_changed` is a falsey empty string), the tooltip text falls back to the placeholder text.

To help illustrate the changes, I made some usage comparison videos against `main` and this PR.

### `main` Branch
[pupgui2 shortcut editor - main.webm](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/6ca71929-fb00-45e2-bf90-8dac04601bb2)

### This PR
[pupgui2 shortcut editor - PR.webm](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/fabe8cb5-6bdf-438a-9d4c-026797d1ea92)

Despite the changes, this should still be compatible with #332.

## Implementation
To accomplish the focusing changes I wanted with any amount of flexibility, I created a custom subclass of `QLineEdit` that overrides various the focus events. We track when the line edit is initially focused and use this to know to only select the entire LineEdit text on the first focus click. This allows another click to de-select everything, and avoids everything being selected again on any other mouse click event.

One of the things that tripped me up here is the order these events are called, so I'll give some background on that. When you click on the QLineEdit, `focusInEvent` is called. However directly after that, `mousePressEvent` is called to process the click. If you try to select all the text in the line edit on `focusInEvent`, the click event processed directly after in `mousePressEvent` will override this. But we have to use `focusInEvent` to preserve the selection behaviour on Tabbing into the LineEdit cell. So we have to do two things:
1. Highlight all text in the LineEdit on the *first* mouse leftclick focus event
2. Highlight all text on the Tab focus event (this can only happen once, since to tab into the cell again, you have to tab out and then back in; you can't use tab to focus the same cell twice without first switching cells)

To accomplish this, we call the helper method I created on the widget called `focusWithTextSelection` to highlight the text in the LineEdit in `focusInEvent` if the focus reason is a tab focus event. This means we ignore mouse focus events, since we shouldn't call this helper method twice. Since we know `mousePressEvent` will handle the mouse click event directly afterwards on a mouse click focus event anyway, we let that method override handle that case. Finally, we use a boolean to track if the focus was already given, which allows us to only select all text on the *first* focus (meaning a 2nd click won't keep all the text highlighted) and also avoids a case where if we tab into the cell, clicking will move the cursor and de-select all of the text, instead of causing another call to `focusWithTextSelection`.

Calling `super` on these methods is pretty important, otherwise you end up with whacky focus/duplicated cursor issues!

## Motivation
Originally, I just wanted to move the cursor for AppName back to the beginning so that I could see the start of the App Name instead of the end. I eventually fell down a rabbit hole of making some other usability changes that I happened to notice along the way.

<hr>

Of course all of this is just my own personal tastes and based on my own expectations, so to you and others these behaviours may be unexpected. I'm open to all discussion on any feedback, or on the other hand, other UX changes you think would fit the scope of this PR.

Thanks!