### PR TITLE
CtInfo: Allow Label Text Selection

### DIFF
--- a/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
+++ b/pupgui2/resources/ui/pupgui2_ctinfodialog.ui
@@ -32,6 +32,9 @@
        <property name="text">
         <string/>
        </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+       </property>
       </widget>
      </item>
      <item row="1" column="0">
@@ -46,6 +49,9 @@
        <property name="text">
         <string/>
        </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+       </property>
       </widget>
      </item>
      <item row="2" column="0">
@@ -59,6 +65,9 @@
       <widget class="QLabel" name="txtInstallDirectory">
        <property name="text">
         <string/>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
A little quality-of-life change to allow selecting the text in the CtInfo dialog with the mouse. This can be useful for quickly getting an install directory path if a user (or a nerd :nerd_face:) wants to get there a little bit quicker. For consistency, all three label values can be selected (the ones on the right, not their parent labels on the left), as even though it's much less common a user would actually select these imo, it would be a bit unexpected if they couldn't.

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/7e90de55-bdea-4a50-a139-a197d826ac1c)

Selected text can also be dragged from ProtonUp-Qt into other applications, such as a terminal. This may be handy in cases like Steam Deck Game Mode, where if a user needs to visit their Steam installation files, they could more quickly get there.

In addition to, or instead of, we could add an icon button to the right of this label with a "copy to clipboard" type icon, to copy this path, which may be more touchscreen/gamescope friendly (as a small aside, this button would match the UI idea proposed in #336, but I'm getting ahead of myself). This may make the dialog wider than it needs to be though, and may add more clutter than anything else.

The keyboard selection flag was not enabled because it adds a cursor to the label, which looks strange. This however has the downside of not allowing selection changes with Shift+Arrow Keys. Though I think a triple-click to select all is probably the more common use-case for this :-) 