### PR TITLE
misc: Avoid shadowing 'map' name

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -229,9 +229,9 @@ class MainWindow(QObject):
             get_steam_app_list(install_loc.get('vdf_dir'), cached=False)  # update app list cache
             global_ctool_name: str = get_steam_global_ctool_name(install_loc.get('vdf_dir'))
             self.compat_tool_index_map += get_steam_acruntime_list(install_loc.get('vdf_dir'), cached=True)
-            map = get_steam_ct_game_map(install_loc.get('vdf_dir'), self.compat_tool_index_map, cached=True)
+            ct_game_map = get_steam_ct_game_map(install_loc.get('vdf_dir'), self.compat_tool_index_map, cached=True)
             for ct in self.compat_tool_index_map:
-                ct.no_games = len(map.get(ct, []))
+                ct.no_games = len(ct_game_map.get(ct, []))
                 ct_name = ct.get_internal_name()
                 if ct_name == global_ctool_name:
                     ct.set_global()  # Set (global) text

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -165,7 +165,7 @@ def get_steam_ct_game_map(steam_config_folder: str, compat_tools: List[BasicComp
     Informal Example: { GE-Proton7-43: [GTA V, Cyberpunk 2077], SteamTinkerLaunch: [Vecter, Terraria] }
     Return Type: Dict[BasicCompatTool, List[SteamApp]]
     """
-    map = {}
+    ct_game_map = {}
 
     apps = get_steam_app_list(steam_config_folder, cached=cached)
 
@@ -173,9 +173,9 @@ def get_steam_ct_game_map(steam_config_folder: str, compat_tools: List[BasicComp
 
     for app in apps:
         if app.app_type == 'game' and app.compat_tool in ct_name_object_map:
-            map.setdefault(ct_name_object_map.get(app.compat_tool), []).append(app)
+            ct_game_map.setdefault(ct_name_object_map.get(app.compat_tool), []).append(app)
 
-    return map
+    return ct_game_map
 
 
 def get_steam_ctool_list(steam_config_folder: str, only_proton=False, cached=False) -> List[SteamApp]:


### PR DESCRIPTION
`map` is a keyword, so this PR replaces a couple usages of `map` as a variable name to avoid that, and hopefully uses clearer variable names for this as well :-)