### PR TITLE
pupgui2: remove references to compat tools on Flathub

### DIFF
--- a/i18n/pupgui2_de.ts
+++ b/i18n/pupgui2_de.ts
@@ -116,8 +116,8 @@ Abbrechen und beenden?</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Info: GE-Proton / Boxtron ist direkt auf Flathub verfügbar!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Info: Boxtron ist direkt auf Flathub verfügbar!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_de.ts
+++ b/i18n/pupgui2_de.ts
@@ -115,11 +115,6 @@ Abbrechen und beenden?</translation>
         <translation>Installationsort zu {install_dir} geändert.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Info: Boxtron ist direkt auf Flathub verfügbar!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Tool von Flathub laden</translation>

--- a/i18n/pupgui2_es.ts
+++ b/i18n/pupgui2_es.ts
@@ -115,11 +115,6 @@ Cancel and exit anyway?</source>
         <translation>Cambiado el directorio de instalación a {install_dir}.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Información: ¡Puede obtener Boxtron directamente de Flathub!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Instalar herramienta desde Flathub</translation>

--- a/i18n/pupgui2_es.ts
+++ b/i18n/pupgui2_es.ts
@@ -116,8 +116,8 @@ Cancel and exit anyway?</source>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Información: ¡Puede obtener GE-Proton / Boxtron directamente de Flathub!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Información: ¡Puede obtener Boxtron directamente de Flathub!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_fi.ts
+++ b/i18n/pupgui2_fi.ts
@@ -116,8 +116,8 @@ Keskeytetäänkö ja poistutaan silti?</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Tiedote: voit noutaa GE-Proton:n / Boxtron:in suoraan Flathub.ista!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Tiedote: voit noutaa Boxtron:in suoraan Flathub.ista!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_fi.ts
+++ b/i18n/pupgui2_fi.ts
@@ -115,11 +115,6 @@ Keskeytetäänkö ja poistutaan silti?</translation>
         <translation>Asennuskansio vaihdettiin kohteeseen {install_dir}.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Tiedote: voit noutaa Boxtron:in suoraan Flathub.ista!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Asenna työkalu Flathub:ista</translation>

--- a/i18n/pupgui2_fr.ts
+++ b/i18n/pupgui2_fr.ts
@@ -116,8 +116,8 @@ Annuler et quitter&#x202f;?</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Info&#x202f;: Vous pouvez récupérer GE-Proton / Boxtron directement depuis Flathub&#x202f;!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Info&#x202f;: Vous pouvez récupérer Boxtron directement depuis Flathub&#x202f;!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_fr.ts
+++ b/i18n/pupgui2_fr.ts
@@ -115,11 +115,6 @@ Annuler et quitter&#x202f;?</translation>
         <translation>Emplacement d&apos;installation remplacé par {install_dir}.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Info&#x202f;: Vous pouvez récupérer Boxtron directement depuis Flathub&#x202f;!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Installer l&apos;outil via Flathub</translation>

--- a/i18n/pupgui2_it.ts
+++ b/i18n/pupgui2_it.ts
@@ -113,8 +113,8 @@ Annullare e uscire comunque?</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Info: Puoi ottenere GE-Proton / Boxtron direttamente da Flathub!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Info: Puoi ottenere Boxtron direttamente da Flathub!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_it.ts
+++ b/i18n/pupgui2_it.ts
@@ -112,11 +112,6 @@ Annullare e uscire comunque?</translation>
         <translation>Percorso d&apos;installazione cambiato in {install_dir}.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Info: Puoi ottenere Boxtron direttamente da Flathub!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Installa tool da Flathub</translation>

--- a/i18n/pupgui2_nb_NO.ts
+++ b/i18n/pupgui2_nb_NO.ts
@@ -111,11 +111,6 @@ Cancel and exit anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Installer verktøy fra Flathub</translation>

--- a/i18n/pupgui2_nb_NO.ts
+++ b/i18n/pupgui2_nb_NO.ts
@@ -112,7 +112,7 @@ Cancel and exit anyway?</source>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/pupgui2_nl.ts
+++ b/i18n/pupgui2_nl.ts
@@ -113,8 +113,8 @@ Weet je zeker dat je wilt annuleren en afsluiten?</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Informatie: je kunt GE-Proton/Boxtron direct van Flathub downloaden!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Informatie: je kunt Boxtron direct van Flathub downloaden!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_nl.ts
+++ b/i18n/pupgui2_nl.ts
@@ -112,11 +112,6 @@ Weet je zeker dat je wilt annuleren en afsluiten?</translation>
         <translation>De installatiemap is ingesteld op {install_dir}.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Informatie: je kunt Boxtron direct van Flathub downloaden!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation type="unfinished"></translation>

--- a/i18n/pupgui2_pl.ts
+++ b/i18n/pupgui2_pl.ts
@@ -115,11 +115,6 @@ Anulować i wyjść mimo to?</translation>
         <translation>Zmieniono katalog instalacji na {install_dir}.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Info: Możesz pobrać Boxtron bezpośrednio z Flathuba!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Zainstaluj z Flathub</translation>

--- a/i18n/pupgui2_pl.ts
+++ b/i18n/pupgui2_pl.ts
@@ -116,8 +116,8 @@ Anulować i wyjść mimo to?</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Info: Możesz pobrać GE-Proton / Boxtron bezpośrednio z Flathuba!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Info: Możesz pobrać Boxtron bezpośrednio z Flathuba!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_pt.ts
+++ b/i18n/pupgui2_pt.ts
@@ -115,11 +115,6 @@ Cancelar e sair mesmo assim?</translation>
         <translation>Mudou o diretório de instalação para {install_dir}.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Nota: Pode obter Boxtron diretamente do Flathub!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Instalar ferramenta do Flathub</translation>

--- a/i18n/pupgui2_pt.ts
+++ b/i18n/pupgui2_pt.ts
@@ -116,8 +116,8 @@ Cancelar e sair mesmo assim?</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Nota: Pode obter GE-Proton / Boxtron diretamente do Flathub!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Nota: Pode obter Boxtron diretamente do Flathub!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_pt_BR.ts
+++ b/i18n/pupgui2_pt_BR.ts
@@ -115,11 +115,6 @@ Cancelar e sair mesmo assim?</translation>
         <translation>Mudou o diretório de instalação para {install_dir}.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Nota: Você pode obter Boxtron diretamente do Flathub!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Instalar ferramenta do Flathub</translation>

--- a/i18n/pupgui2_pt_BR.ts
+++ b/i18n/pupgui2_pt_BR.ts
@@ -116,8 +116,8 @@ Cancelar e sair mesmo assim?</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Nota: Você pode obter GE-Proton / Boxtron diretamente do Flathub!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Nota: Você pode obter Boxtron diretamente do Flathub!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_ru.ts
+++ b/i18n/pupgui2_ru.ts
@@ -117,8 +117,8 @@ Cancel and exit anyway?</source>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Информация: Вы можете получить GE-Proton / Boxtron непосредственно с Flathub!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Информация: Вы можете получить Boxtron непосредственно с Flathub!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_ru.ts
+++ b/i18n/pupgui2_ru.ts
@@ -116,11 +116,6 @@ Cancel and exit anyway?</source>
         <translation>Изменён каталог установки на {install_dir}.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Информация: Вы можете получить Boxtron непосредственно с Flathub!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Установка инструмента с Flathub</translation>

--- a/i18n/pupgui2_sv.ts
+++ b/i18n/pupgui2_sv.ts
@@ -116,8 +116,8 @@ Avbryt och avsluta ändå?</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Info: Du kan hämta GE-Proton / Boxtron direkt från Flathub!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Info: Du kan hämta Boxtron direkt från Flathub!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_sv.ts
+++ b/i18n/pupgui2_sv.ts
@@ -115,11 +115,6 @@ Avbryt och avsluta ändå?</translation>
         <translation>Ändrade installationskatalog till {install_dir}.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Info: Du kan hämta Boxtron direkt från Flathub!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Installera verktyg från Flathub</translation>

--- a/i18n/pupgui2_tr.ts
+++ b/i18n/pupgui2_tr.ts
@@ -115,11 +115,6 @@ Cancel and exit anyway?</source>
         <translation>Kurulum dizini {install_dir} olarak değiştirildi.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Bilgi: Boxtron&apos;u doğrudan Flathub&apos;dan indirebilirsiniz!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Aracı Flathub&apos;dan yükle</translation>

--- a/i18n/pupgui2_tr.ts
+++ b/i18n/pupgui2_tr.ts
@@ -116,8 +116,8 @@ Cancel and exit anyway?</source>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Bilgi: GE-Proton ve Boxtron&apos;u doğrudan Flathub&apos;dan indirebilirsiniz!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Bilgi: Boxtron&apos;u doğrudan Flathub&apos;dan indirebilirsiniz!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_uk.ts
+++ b/i18n/pupgui2_uk.ts
@@ -115,11 +115,6 @@ Cancel and exit anyway?</source>
         <translation>Змінено каталог встановлення на {install_dir}.</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>Інформація: Ви можете отримати Boxtron безпосередньо з Flathub!</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>Встановити інструмент із Flathub</translation>

--- a/i18n/pupgui2_uk.ts
+++ b/i18n/pupgui2_uk.ts
@@ -116,8 +116,8 @@ Cancel and exit anyway?</source>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>Інформація: Ви можете отримати GE-Proton / Boxtron безпосередньо з Flathub!</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>Інформація: Ви можете отримати Boxtron безпосередньо з Flathub!</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_zh_TW.ts
+++ b/i18n/pupgui2_zh_TW.ts
@@ -116,8 +116,8 @@ Cancel and exit anyway?</source>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get GE-Proton / Boxtron directly from Flathub!</source>
-        <translation>資訊：您可以直接從 Flathub 取得 GE-Proton / Boxtron！</translation>
+        <source>Info: You can get Boxtron directly from Flathub!</source>
+        <translation>資訊：您可以直接從 Flathub 取得 Boxtron！</translation>
     </message>
     <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>

--- a/i18n/pupgui2_zh_TW.ts
+++ b/i18n/pupgui2_zh_TW.ts
@@ -115,11 +115,6 @@ Cancel and exit anyway?</source>
         <translation>將安裝資料夾改為 {install_dir}。</translation>
     </message>
     <message>
-        <location filename="../pupgui2/pupgui2.py" line="388"/>
-        <source>Info: You can get Boxtron directly from Flathub!</source>
-        <translation>資訊：您可以直接從 Flathub 取得 Boxtron！</translation>
-    </message>
-    <message>
         <location filename="../pupgui2/pupgui2.py" line="428"/>
         <source>Install tool from Flathub</source>
         <translation>從 Flathub 安裝工具</translation>

--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -78,7 +78,6 @@ PROTONDB_API_URL = 'https://www.protondb.com/api/v1/reports/summaries/{game_id}.
 PROTONDB_APP_PAGE_URL = 'https://protondb.com/app/'
 
 STEAM_BOXTRON_FLATPAK_APPSTREAM = 'appstream://com.valvesoftware.Steam.CompatibilityTool.Boxtron'
-STEAM_PROTONGE_FLATPAK_APPSTREAM = 'appstream://com.valvesoftware.Steam.CompatibilityTool.Proton-GE'
 STEAM_STL_FLATPAK_APPSTREAM = 'appstream://com.valvesoftware.Steam.Utility.steamtinkerlaunch'
 
 STEAM_STL_INSTALL_PATH = os.path.join(HOME_DIR, 'stl')

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -383,10 +383,9 @@ class MainWindow(QObject):
 
     def show_launcher_specific_information(self):
         install_loc = get_install_location_from_directory_name(install_directory())
-        if 'steam' in install_loc.get('launcher', '') and 'Flatpak' in install_loc.get('display_name', ''):
-            self.ui.btnSteamFlatpakCtools.setVisible(True)
-        else:
-            self.ui.btnSteamFlatpakCtools.setVisible(False)
+        self.ui.btnSteamFlatpakCtools.setVisible(
+            'steam' in install_loc.get('launcher', '') and 'Flatpak' in install_loc.get('display_name', '')
+            )
     
     def list_installed_versions_item_double_clicked(self, item):
         """ Show info about compatibility tool when double clicked in list """

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -12,7 +12,7 @@ from PySide6.QtWidgets import QApplication, QDialog, QMessageBox, QLabel, QPushB
 from PySide6.QtUiTools import QUiLoader
 
 from pupgui2.constants import APP_NAME, APP_VERSION, BUILD_INFO, TEMP_DIR, STEAM_STL_INSTALL_PATH
-from pupgui2.constants import STEAM_PROTONGE_FLATPAK_APPSTREAM, STEAM_BOXTRON_FLATPAK_APPSTREAM, STEAM_STL_FLATPAK_APPSTREAM
+from pupgui2.constants import STEAM_BOXTRON_FLATPAK_APPSTREAM, STEAM_STL_FLATPAK_APPSTREAM
 from pupgui2 import ctloader
 from pupgui2.datastructures import CTType, MsgBoxType, MsgBoxResult
 from pupgui2.gamepadinputworker import GamepadInputWorker
@@ -423,22 +423,19 @@ class MainWindow(QObject):
             cti_dialog.batch_update_complete.connect(self.update_ui)
 
     def btn_steam_flatpak_ctools_clicked(self):
-        """ Open dialog to open the appstore(appstream) to install Proton-GE/Boxtron from Flathub"""
+        """ Open dialog to open the appstore(appstream) to installBoxtron from Flathub"""
         iftdialog = QDialog(parent=self.ui)
         iftdialog.setWindowTitle(self.tr('Install tool from Flathub'))
         iftdialog.setFixedSize(250, 100)
         iftdialog.setModal(True)
         lbl_description = QLabel(self.tr('Click to open your app store'))
-        btn_dl_protonge = QPushButton('Proton-GE')
         btn_dl_boxtron = QPushButton('Boxtron')
         btn_dl_stl = QPushButton('Steam Tinker Launch')
         layout1 = QVBoxLayout()
         layout1.addWidget(lbl_description)
-        layout1.addWidget(btn_dl_protonge)
         layout1.addWidget(btn_dl_boxtron)
         layout1.addWidget(btn_dl_stl)
         iftdialog.setLayout(layout1)
-        btn_dl_protonge.clicked.connect(lambda: os.system(f'xdg-open {STEAM_PROTONGE_FLATPAK_APPSTREAM}'))
         btn_dl_boxtron.clicked.connect(lambda: os.system(f'xdg-open {STEAM_BOXTRON_FLATPAK_APPSTREAM}'))
         btn_dl_stl.clicked.connect(lambda: os.system(f'xdg-open {STEAM_STL_FLATPAK_APPSTREAM}'))
         iftdialog.show()

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -383,9 +383,7 @@ class MainWindow(QObject):
 
     def show_launcher_specific_information(self):
         install_loc = get_install_location_from_directory_name(install_directory())
-        # For Steam Flatpak only: Show that Boxtron is available directly from Flathub.
         if 'steam' in install_loc.get('launcher', '') and 'Flatpak' in install_loc.get('display_name', ''):
-            self.ui.statusBar().showMessage(self.tr('Info: You can get Boxtron directly from Flathub!'))
             self.ui.btnSteamFlatpakCtools.setVisible(True)
         else:
             self.ui.btnSteamFlatpakCtools.setVisible(False)

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -423,7 +423,7 @@ class MainWindow(QObject):
             cti_dialog.batch_update_complete.connect(self.update_ui)
 
     def btn_steam_flatpak_ctools_clicked(self):
-        """ Open dialog to open the appstore(appstream) to installBoxtron from Flathub"""
+        """ Open dialog to open the appstore(appstream) to install Boxtron from Flathub"""
         iftdialog = QDialog(parent=self.ui)
         iftdialog.setWindowTitle(self.tr('Install tool from Flathub'))
         iftdialog.setFixedSize(250, 100)

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -383,9 +383,9 @@ class MainWindow(QObject):
 
     def show_launcher_specific_information(self):
         install_loc = get_install_location_from_directory_name(install_directory())
-        # For Steam Flatpak only: Show that GE-Proton and Boxtron are available directly from Flathub.
+        # For Steam Flatpak only: Show that Boxtron is available directly from Flathub.
         if 'steam' in install_loc.get('launcher', '') and 'Flatpak' in install_loc.get('display_name', ''):
-            self.ui.statusBar().showMessage(self.tr('Info: You can get GE-Proton / Boxtron directly from Flathub!'))
+            self.ui.statusBar().showMessage(self.tr('Info: You can get Boxtron directly from Flathub!'))
             self.ui.btnSteamFlatpakCtools.setVisible(True)
         else:
             self.ui.btnSteamFlatpakCtools.setVisible(False)


### PR DESCRIPTION
https://github.com/flathub/com.valvesoftware.Steam.CompatibilityTool.Proton-GE was marked as archived on January 8th and EOL on Flathub. This PR removes the mention of being able to download it from there. 