### PR TITLE
Boxtron: Fix typo 'doxbox' -> 'dosbox'

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_boxtron.py
+++ b/pupgui2/resources/ctmods/ctmod_boxtron.py
@@ -21,7 +21,7 @@ class CtInstaller(LuxtorpedaInstaller):
     def __init__(self, main_window = None):
         super().__init__(main_window)
         self.extract_dir_name = 'boxtron'
-        self.deps = [ 'doxbox', 'inotifywait', 'timidity' ]
+        self.deps = [ 'dosbox', 'inotifywait', 'timidity' ]
 
     def is_system_compatible(self) -> bool:
         """


### PR DESCRIPTION
Fixes a typo found in https://github.com/DavidoTek/ProtonUp-Qt/issues/27#issuecomment-1910343839.

[This was my doing](https://github.com/DavidoTek/ProtonUp-Qt/pull/311/files#diff-3ea3745ae52687773ab601bf354442a59c64c0d248b2097be254e664dc28d0afR24) :sweat: I'll learn to spell properly one of these days, I promise! Even though I spelt it wrong *again* when writing the commit message... 