### PR TITLE
Update ctinfo after batch update

### DIFF
--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -74,7 +74,6 @@ class PupguiCtInfoDialog(QObject):
             self.ui.listGames.setEnabled(False)
 
         self.update_game_list_ui()
-        self.batch_update_complete.emit(True)
 
     def update_game_list_steam(self, cached=True):
         if self.install_loc.get('launcher') == 'steam' and 'vdf_dir' in self.install_loc:
@@ -136,7 +135,7 @@ class PupguiCtInfoDialog(QObject):
     def btn_batch_update_clicked(self):
         steam_config_folder = self.install_loc.get('vdf_dir')
         ctbu_dialog = PupguiCtBatchUpdateDialog(parent=self.ui, current_ctool_name=self.ctool.displayname, games=self.games, steam_config_folder=steam_config_folder)
-        ctbu_dialog.batch_update_complete.connect(lambda: self.update_game_list(cached=False))
+        ctbu_dialog.batch_update_complete.connect(self.btn_refresh_games_clicked)
 
     def btn_refresh_games_clicked(self):
         self.update_game_list(cached=False)

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -137,7 +137,7 @@ class PupguiCtInfoDialog(QObject):
     def btn_batch_update_clicked(self):
         steam_config_folder = self.install_loc.get('vdf_dir')
         ctbu_dialog = PupguiCtBatchUpdateDialog(parent=self.ui, current_ctool_name=self.ctool.displayname, games=self.games, steam_config_folder=steam_config_folder)
-        ctbu_dialog.batch_update_complete.connect(self.update_game_list_steam)
+        ctbu_dialog.batch_update_complete.connect(lambda: self.update_game_list(cached=False))
 
     def btn_refresh_games_clicked(self):
         self.update_game_list(cached=False)

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -74,6 +74,7 @@ class PupguiCtInfoDialog(QObject):
             self.ui.listGames.setEnabled(False)
 
         self.update_game_list_ui()
+        self.batch_update_complete.emit(True)
 
     def update_game_list_steam(self, cached=True):
         if self.install_loc.get('launcher') == 'steam' and 'vdf_dir' in self.install_loc:

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -74,6 +74,7 @@ class PupguiCtInfoDialog(QObject):
             self.ui.listGames.setEnabled(False)
 
         self.update_game_list_ui()
+        self.batch_update_complete.emit(True)
 
     def update_game_list_steam(self, cached=True):
         if self.install_loc.get('launcher') == 'steam' and 'vdf_dir' in self.install_loc:
@@ -89,8 +90,6 @@ class PupguiCtInfoDialog(QObject):
 
             self.ui.listGames.setItem(i, 0, dataitem_appid)
             self.ui.listGames.setItem(i, 1, QTableWidgetItem(game.game_name))
-
-        self.batch_update_complete.emit(True)
 
     def update_game_list_lutris(self):
         self.games = [game for game in get_lutris_game_list(self.install_loc) if game.runner == 'wine' and game.get_game_config().get('wine', {}).get('version') == self.ctool.displayname]


### PR DESCRIPTION
## Overview
This PR fixes the CtInfo dialog's game list not updating after a batch update. If you perform a batch update, the game list still shows the old values. The used/unused and game count indicators will update correctly on the main menu, and re-opening or refreshing the CtInfo dialog will update the values. But they are not immediately updated after a batch update.

When we do a batch update to move the games in use by one compatibility tool to another, aside from actually doing this, there are some other steps:
- In the Batch Update dialog class, we emit a signal to say that the batch update is complete
- In the CtInfo dialog, we connect to this signal and call `update_game_list_steam`
- In `update_game_list_steam`, at the end, we call emit a signal to notify that the batch update is complete. This is received by the main window and updates athe compatibility tool usage information (i.e. immediately update to reflect if a tool is unused after a batch update)

## Problem
Currently though, the call to `update_game_list_steam` is incorrect, for two reasons:
1. The main reason, we're still using a cached game list. So calling the method doesn't really do anything.
2. If we ever enabled batch update for other launchers, it wouldn't update their game lists, since it would always try to call `update_game_list_steam`.
    a. By extension, we were only calling `batch_update_complete.emit` inside of `update_games_list_steam`, when it should've been called in `update_game_list` so that the signal is correctly emitted if we ever implement batch update for other launchers.

## Solution
The fix for this is to first, call `btn_refresh_games_clicked`, which is the method connected on click of the CtInfo dialog and calls `update_game_list` with `cached=False`. Then to fix the last issue, `batch_update_complete.emit` was moved to the bottom of `update_game_list`. I wasn't sure if it should go in `update_game_list` or `update_game_list_ui`, but I figured keeping it more "top-level" in update_game_list is fine. It does technically have the job of performing a Qt-related action, and updating the UI on the *main menu*, so if you'd prefer it elsewhere that's fine. :slightly_smiling_face: 

This does mean there is a bit of delay after pressing the "Batch Update" button, as it will "hang" a bit before the dialog actually closes while the CtInfo dialog updates. Once this is updated, the Batch Update dialog will close and the user will be returned to the updated 

## Concerns
Two minor concerns here:

We're calling `batch_update_complete.emit(True)` unconditionally. We were doing this before already, but only with Steam, but now we're doing it for every launcher when we open a CtInfo dialog. I have not noticed any performance impact to this. We could possibly add `batch_update_complete=False` as a default parameter to `update_game_list`, and then we could change the emit call to `self.batch_update_complete.emit(batch_update_complete)`. Then for the Batch Update dialog's signal, we can to change to connecting like this: `ctbu_dialog.batch_update_complete.connect(lambda: self.update_game_list(cached=False, batch_update_complete=True)`.

My other concern is, after a Batch Update, the CtInfo dialog is always going to be empty since we're moving every game. There may not be much reason to keep the dialog open. Maybe we should close the CtInfo dialog after a batch update? We'd have to make sure we still call `self.batch_update_complete.emit(True)` in CtInfo so that the main menu information updates, but that should be fine to do. It would invalidate this PR but it may be better UX - or unexpected, depending on your point of view :sweat_smile: 

<hr>

Thanks! :-)