### PR TITLE
Wine-tkg: Clarify Wine version used for Wine-tkg variants

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_winetkg_valve_otherdistro.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_valve_otherdistro.py
@@ -7,9 +7,9 @@ from PySide6.QtCore import QCoreApplication
 from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstaller  # Use ProtonTKg Ctmod as base
 
 
-CT_NAME = 'Wine Tkg (Valve Wine)'
+CT_NAME = 'Wine Tkg (Valve Wine Bleeding Edge)'
 CT_LAUNCHERS = ['lutris', 'heroicwine']
-CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_winetkg_valve_otherdistro', '''Custom Wine build for running Windows games, built with the Wine-tkg build system.''')}
+CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_winetkg_valve_otherdistro', '''Custom Wine build for running Windows games, built with the Wine-tkg build system based on <b>Valve Wine bleeding_edge</b>.''')}
 
 
 class CtInstaller(TKGCtInstaller):

--- a/pupgui2/resources/ctmods/ctmod_winetkg_winemaster.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_winemaster.py
@@ -7,9 +7,9 @@ from PySide6.QtCore import QCoreApplication
 from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstaller  # Use ProtonTKg Ctmod as base
 
 
-CT_NAME = 'Wine Tkg (Vanilla Wine)'
+CT_NAME = 'Wine Tkg (Wine Master)'
 CT_LAUNCHERS = ['lutris', 'heroicwine', 'advmode']
-CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_winetkg_vanilla_ubuntu', '''Custom Wine build for running Windows games, built with the Wine-tkg build system.''')}
+CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_winetkg_vanilla_ubuntu', '''Custom Wine build for running Windows games, built with the Wine-tkg build system (Ubuntu CI) based on <b>Wine Master</b>.''')}
 
 
 class CtInstaller(TKGCtInstaller):


### PR DESCRIPTION
This PR changes the description of the Valve Wine and Vanilla Wine -tkg builds to note which branch they use for clarity.
- Valve Wine uses Valve's `bleeding_edge` branch, which is what their `experimental_X.X` branches are based on (ValveSoftware/wine branches: https://github.com/ValveSoftware/wine/branches). It also changes the name of the Vanilla Wine ctmod file for consistency with this change.
    - The wine-tkg-git workflow calls this `wine-valvexbe` where "xbe" is e**X**perimental **B**leeding **E**dge.
- Vanilla Wine uses Wine Master built on an Ubuntu CI
    - Verified the branch used with this line in `customisation.cfg`: https://github.com/Frogging-Family/wine-tkg-git/blob/edf80e3ecdcf69555f2359433003dd635b3b5798/wine-tkg-git/customization.cfg#L55
    - Verified that this is not changed in the workflow file: https://github.com/Frogging-Family/wine-tkg-git/blob/edf80e3ecdcf69555f2359433003dd635b3b5798/.github/workflows/wine-ubuntu.yml#L21-L23
    - Verified that it does in fact use an Ubuntu CI: https://github.com/Frogging-Family/wine-tkg-git/blob/edf80e3ecdcf69555f2359433003dd635b3b5798/.github/workflows/wine-ubuntu.yml#L10

I think we had some discussion about which CI to use and how to name these at the time, but I think using these names is a bit clearer. Noting the CI used for Wine Master might seem a little strange though, but I think it's an important distinction as the Ubuntu CI has different dependencies and thus builds Wine differently. The main distinction as far as I know currently being the Ubuntu CI is not built with Wine 9.0's Wayland support enabled. However, the Arch CIs are built with Wayland support.
- Relevant line from the most recent Ubuntu CI run at time of writing: https://github.com/Frogging-Family/wine-tkg-git/actions/runs/7702698870/job/20991531020#step:3:3404
- Relevant section from the most recent Arch CI build at time of writing: https://github.com/Frogging-Family/wine-tkg-git/actions/runs/7702279360/job/20990224301#step:4:11146 - There is more Wayland build logging further down, and the Ubuntu CI does not get this far before bailing out
- If search for `wayland` in the two logs, you will see the Ubuntu CI only has 31 results, whereas the Arch CI has 72 results.

<hr>

I learned this the hard way the other night when I couldn't figure out why I couldn't get any Wine 9.0 builds to properly enable the Wayland driver (Arch's Wine package is not built with `--with-wayland` for fear of introducing the Wayland dependencies unnecessarily for an experimental in-development feature that is off by default).

Even if/when the Ubuntu CI is updated, it might be good to note it in the description of this tool. I think we skipped putting this in the name before for concerns of confusing users thinking that the Ubuntu CI might only be for Ubuntu, but I think putting it in brackets should be fine.

The ctmod names were also updated to better reflect their branches. In hindsight, "Valve Wine" doesn't carry the implication that it's the latest `bleeding_edge`, and it's not clear that this is the latest Valve Wine patch. It's equivalent to selecting Proton Experimental in your library -> Properties -> Betas, and selecting the "bleeding_edge" beta (although this means every game using Proton Experimental will use the bleeding_edge branch, which is normally undesirable). We could update the description further to note this in some way.

<hr>

This PR was motivated by my own misunderstandings, and I thought that it might be good to further clarify what the Wine-tkg builds are using.

With this PR, I essentially want to find a way to make it clearer to users what the Wine-tkg builds are using, because this can be important in some cases. I don't know if I've done it in the best way in this PR, so all feedback on phrasing welcome :slightly_smiling_face: 

Thanks!