### PR TITLE
FIX: awacy_icon denied problem

### DIFF
--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -404,7 +404,7 @@ class PupguiGameListDialog(QObject):
             awacy_icon = 'awacy_broken.png'
         elif game.awacy_status == AWACYStatus.DENIED:
             awacy_status = self.tr('Linux support was explicitly denied')
-            awacy_status = 'awacy_denied.png'
+            awacy_icon = 'awacy_denied.png'
         else:
             awacy_status = self.tr('Anti-Cheat status unknown')
             awacy_icon = 'awacy_unknown.png'


### PR DESCRIPTION
# Overview

Fixing the problem when opening the game list, that contains a game with status denied.

## ScreenShot

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/33804215/78672b0b-fbbc-43da-a500-67c93b3a0444)
