### PR TITLE
util: Check if Steam configuration files exist before marking as available

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -26,7 +26,7 @@ HOME_DIR = os.path.expanduser('~')
 # support different Steam root directories
 # valid install dir should have config.vdf and libraryfolders.vdf, to ensure it is not an unused folder with correct directory structure
 _POSSIBLE_STEAM_ROOTS = ['~/.local/share/Steam', '~/.steam/root', '~/.steam/steam', '~/.steam/debian-installation']
-_STEAM_ROOT = _POSSIBLE_STEAM_ROOTS[0]
+_STEAM_ROOT = _POSSIBLE_STEAM_ROOTS[0]  # Default to '~/.local/share/Steam', but this is not guaranteed to exist
 for steam_root in _POSSIBLE_STEAM_ROOTS:
     ct_dir = os.path.join(os.path.expanduser(steam_root), 'config')
     config_vdf = os.path.join(ct_dir, 'config.vdf')

--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -24,23 +24,26 @@ TEMP_DIR = os.path.join(os.getenv('XDG_CACHE_HOME'), 'tmp', 'pupgui2.a70200/') i
 HOME_DIR = os.path.expanduser('~')
 
 # support different Steam root directories, building paths relative to HOME_DIR (i.e. /home/gaben/.local/share/Steam)
+# Use os.path.realpath to expand all _STEAM_ROOT paths
 _POSSIBLE_STEAM_ROOTS = [
-    os.path.join(HOME_DIR, _STEAM_ROOT) for _STEAM_ROOT in ['.local/share/Steam', '.steam/root', '.steam/steam', '.steam/debian-installation']
+    os.path.realpath(os.path.join(HOME_DIR, _STEAM_ROOT)) for _STEAM_ROOT in ['.local/share/Steam', '.steam/root', '.steam/steam', '.steam/debian-installation']
 ]
+
+# Remove duplicate paths while preserving order, as os.path.realpath may expand some symlinks to the real Steam root
+_POSSIBLE_STEAM_ROOTS = list(dict.fromkeys(_POSSIBLE_STEAM_ROOTS))
 
 # Steam can be installled in any of the locations at '_POSSIBLE_STEAM_ROOTS' - usually only one, and the others (if they exist) are typically symlinks,
 # i.e. '~/.steam/root' is usually a symlink to '~/.local/share/Steam'
-# Use os.path.realpath to expand all _STEAM_ROOT paths and only add unique _STEAM_ROOT paths
 # These paths may still not be valid installations however, as they could be leftother paths from an old Steam installation without the data files we need ('config.vdf' and 'libraryfolders.vdf')
 # We catch this later on in util#is_valid_launcher_installation though
 POSSIBLE_INSTALL_LOCATIONS = [
         {
-            'install_dir': f'{os.path.realpath(_STEAM_ROOT)}/compatibilitytools.d/',
+            'install_dir': f'{os.path.join(_STEAM_ROOT, "compatibility_tools.d")}',
             'display_name': 'Steam',
             'launcher': 'steam',
             'type': 'native',
             'icon': 'steam',
-            'vdf_dir': f'{os.path.realpath(_STEAM_ROOT)}/config'
+            'vdf_dir': f'{os.path.join(_STEAM_ROOT, "config")}'
         } for _STEAM_ROOT in _POSSIBLE_STEAM_ROOTS if os.path.exists(os.path.realpath(_STEAM_ROOT))
 ]
 

--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -38,13 +38,13 @@ _POSSIBLE_STEAM_ROOTS = list(dict.fromkeys(_POSSIBLE_STEAM_ROOTS))
 # We catch this later on in util#is_valid_launcher_installation though
 POSSIBLE_INSTALL_LOCATIONS = [
         {
-            'install_dir': f'{os.path.join(_STEAM_ROOT, "compatibility_tools.d")}',
+            'install_dir': f'{_STEAM_ROOT}/compatibilitytools.d/',
             'display_name': 'Steam',
             'launcher': 'steam',
             'type': 'native',
             'icon': 'steam',
-            'vdf_dir': f'{os.path.join(_STEAM_ROOT, "config")}'
-        } for _STEAM_ROOT in _POSSIBLE_STEAM_ROOTS if os.path.exists(os.path.realpath(_STEAM_ROOT))
+            'vdf_dir': f'{_STEAM_ROOT}/config'
+        } for _STEAM_ROOT in _POSSIBLE_STEAM_ROOTS if os.path.exists(_STEAM_ROOT)
 ]
 
 # Possible install locations for all other launchers, ensuring Steam paths are at the top of the list

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -801,7 +801,6 @@ def is_valid_steam_install(steam_path) -> bool:
     Return Type: bool
     """
 
-    # Identical to the check we do in constants.py to determine the Steam root
     ct_dir = os.path.join(os.path.expanduser(steam_path), 'config')
 
     config_vdf = os.path.join(ct_dir, 'config.vdf')

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -792,3 +792,21 @@ def determine_most_recent_steam_user(steam_users: List[SteamUser]) -> SteamUser:
 
     print('Warning: No Steam users found. Returning None')
     return None
+
+
+def is_valid_steam_install(steam_path) -> bool:
+
+    """
+    Return whether required Steam data files actually exist to determine if 'steam_path' is a valid Steam installation.
+    Return Type: bool
+    """
+
+    # Identical to the check we do in constants.py to determine the Steam root
+    ct_dir = os.path.join(os.path.expanduser(steam_path), 'config')
+
+    config_vdf = os.path.join(ct_dir, 'config.vdf')
+    libraryfolders_vdf = os.path.join(ct_dir, 'libraryfolders.vdf')
+
+    is_valid_steam_install = os.path.exists(config_vdf) and os.path.exists(libraryfolders_vdf)
+
+    return is_valid_steam_install

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -223,8 +223,7 @@ def available_install_directories() -> List[str]:
     available_dirs = []
     for loc in POSSIBLE_INSTALL_LOCATIONS:
         install_dir = os.path.expanduser(loc['install_dir'])
-        # POSSIBLE_INSTALL_LOCATIONS may contain duplicate paths, so only add unique paths to available_dirs
-        # This avoids adding symlinked Steam paths
+        # only add unique paths to available_dirs
         if is_valid_launcher_installation(loc) and not install_dir in available_dirs:
             available_dirs.append(install_dir)
     install_dir = config_custom_install_location().get('install_dir')

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -223,10 +223,12 @@ def available_install_directories() -> List[str]:
     available_dirs = []
     for loc in POSSIBLE_INSTALL_LOCATIONS:
         install_dir = os.path.expanduser(loc['install_dir'])
-        if is_valid_launcher_installation(loc):
+        # POSSIBLE_INSTALL_LOCATIONS may contain duplicate paths, so only add unique paths to available_dirs
+        # This avoids adding symlinked Steam paths
+        if is_valid_launcher_installation(loc) and not install_dir in available_dirs:
             available_dirs.append(install_dir)
     install_dir = config_custom_install_location().get('install_dir')
-    if install_dir and os.path.exists(install_dir):
+    if install_dir and os.path.exists(install_dir) and not install_dir in available_dirs:
         available_dirs.append(install_dir)
     return available_dirs
 

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -23,7 +23,7 @@ from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS, CONFIG_FILE, PALETTE_D
 from pupgui2.constants import AWACY_GAME_LIST_URL, LOCAL_AWACY_GAME_LIST
 from pupgui2.constants import GITHUB_API, GITLAB_API, GITLAB_API_RATELIMIT_TEXT
 from pupgui2.datastructures import BasicCompatTool, CTType, Launcher, SteamApp, LutrisGame, HeroicGame
-from pupgui2.steamutil import remove_steamtinkerlaunch
+from pupgui2.steamutil import remove_steamtinkerlaunch, is_valid_steam_install
 
 
 def create_msgbox(
@@ -196,6 +196,25 @@ def create_compatibilitytools_folder() -> None:
                 print(f'Error trying to create compatibility tools folder {str(install_dir)}: {str(e)}')
 
 
+def is_valid_launcher_installation(loc) -> bool:
+
+    """
+    Check whether a launcher installation is actually valid based on per-launcher criteria
+    Return Type: bool
+    """
+
+    install_dir = os.path.expanduser(loc['install_dir'])
+
+    # Right now we only check to make sure regular Steam (not Flatpak or Snap) has config.vdf and libraryfolders.vdf
+    # because Steam can leave behind its directory structure when uninstalled, but not these files.
+    #
+    # In future we could expand this to other Steam flavours and other launchers.
+    if loc['display_name'] == 'Steam':  # This seems to get called many times, why?
+        return is_valid_steam_install(os.path.realpath(os.path.join(install_dir, '..')))
+    
+    return os.path.exists(install_dir)  # Default to path check for all other launchers
+
+
 def available_install_directories() -> List[str]:
     """
     List available install directories
@@ -204,7 +223,7 @@ def available_install_directories() -> List[str]:
     available_dirs = []
     for loc in POSSIBLE_INSTALL_LOCATIONS:
         install_dir = os.path.expanduser(loc['install_dir'])
-        if os.path.exists(install_dir):
+        if is_valid_launcher_installation(loc):
             available_dirs.append(install_dir)
     install_dir = config_custom_install_location().get('install_dir')
     if install_dir and os.path.exists(install_dir):


### PR DESCRIPTION
Should fix #353.

All mentions to just "Steam" in this issue refer to Steam installed i.e. via package manager, not Steam Flatpak or Steam Snap :-) The problem could still apply to them I think, but I don't have them on-hand to test.

## Overview
This PR changes the check in `util#available_install_directories` to be a bit stricter when checking for Steam installs. It now makes sure that the configuration files we need exist before marking a Steam installation as valid.

## Problem
The core of the problem is that we can mark an invalid Steam installation as available because we only check if the directories that we need exist, not if the actual files we need exist. We need `libraryfolders.vdf` and `config.vdf` to perform various actions, but in `util#available_install_directories`, we only check `os.path.exists`. This causes the crash in #353, because all the directories exist, but the files do not.

The existing check loops through all the paths in `POSSIBLE_INSTALL_LOCATIONS`, which is a list of dictionaries with the installation paths for *compatibility tools* being under the `install_dir` key (this distinction is important later). However it only checks if `install_dir` _exists_. In the case of Steam installations, this means it only checks if, say, `~/.local/share/Steam/compatibiltytools.d` exists. But that is not sufficient for Steam at least. This is because this path can exist even if Steam itself - and more importantly, the data files we need such as `config.vdf` - do not. So because the path to `compatibilitytools.d` can exist, we might mark this Steam installation as valid by adding it to `available_dirs`. But then if we try to use this Steam directory, we'll be unable to read the files we need such as `config.vdf` because the other data files are missing.

We already encountered this problem in a different form a while back, which we solved in #231. However that issue was about selecting the *correct* Steam installation path, assuming that at least one of them existed. It's a similar idea as the problem was with selecting a Steam installation path that existed without the data files we needed, but this time we need to solve for a case when the path exists, but *no* Steam installation exists!

In `constants.py` we do a check when selecting our `_STEAM_ROOT` path to make sure we only pick one that has `config.vdf` and `libraryfolders.vdf`. However we will always default to `_POSSIBLE_STEAM_ROOTS[0]`, which at time of writing, is `~/.local/share/Steam`. This means even if our check for these VDF files fails in `constants.py`, we'll always default to using `~/.local/share/Steam`. And in the case of #353, this path exists but is *not* valid. In other words, all the directories exist, but we don't have the VDF files we're looking for. Then, in `POSSIBLE_INSTALL_LOCATIONS`, we set our Steam path to `f'{_STEAM_ROOT}/compatibilitytools.d/'`. So when we get to `util#available_install_directories`, we only check if this path exists, and if it does, we just mark it as available.

## Solution
The fix I came up with was to make a util function, `is_valid_launcher_installation`. This takes a dictionary from `POSSIBLE_INSTALL_LOCATIONS` and then based on the launcher's `display_name`, performs any launcher-specific checks to see if the installation is actually valid, and if no launcher specific checks are required we just fall back to the `os.path.exists` check. Right now we only check "regular" Steam to solve for the problem outlined above, but this could be expanded in future.

For Steam, I created a Steam utility function creatively named `is_valid_steam_install`. This takes the `install_path` and performs checks to make sure `config.vdf` and `libraryfolders.vdf` actually exist. This is the same check we perform in `constants.py`, actually pretty much entirely copied from there, just with the Steam path variable name changed.

In short, the previous flow was:
- For each location in `POSSIBLE_INSTALL_LOCATIONS`,
- If `install_path` exists
- Mark the launcher path as available (i.e. assume this launcher is installed solely based on whether the installation directories exist)

Now, the flow has become a bit more involved:
- For each location in `POSSIBLE_INSTALL_LOCATIONS`:
- Use `is_valid_launcher_installation` to determine if the installation path is valid.
    - In `is_valid_launcher_installation`,
    - If the current launcher is `'Steam'`, use `is_valid_steam_install` to determine if we have a valid Steam installation by passing it `install_path`.
        - In `is_valid_steam_install`.
        - Set our base path as `install_dir/..` (since for Steam, `install_dir` always points to `compatibilitytools.d`, so we go one directory up to get the base Steam path to check against).
        - Return True if we have (`config.vdf` and `libraryfolders.vdf`), otherwise return False.
    - For all other launchers, default to `os.path.exists(install_path)` as we have no other launcher-specific logic for now.
- Only add the current `install_path` to `available_dirs` if `is_valid_launcher_installation` is True.

## Concerns
I don't know if there's a better way to do this; could (or rather, should) `constants.py` re-use the `is_valid_steam_install` function from `steamutil.py`? I'm not sure if it's a good idea to import a function like this into the constant file, perhaps we'll just have to live with the duplication for now.

Other than that, this was just a solution I came up with some days ago at the coffee shop. I tried to make this flexible and extensible, in case we want to extend this to the other Steam flavours or other launchers. `is_valid_steam_install` should work for Steam Flatpak and Steam Snap, but I don't have those installed to test that out, which is why I left them out of this PR. And `is_valid_launcher_installation` should be easily extensible to other launchers as well, possibly with the use of other `lutrisutil` or `heroicutil` methods. Wrapping all of the launcher-specific checks in `is_valid_launcher_installation` helps keep the check in `available_install_directories` cleaner imo, and further wrapping the launcher-specific logic in helper methods would keep `is_valid_launcher_installation` clean too.

But perhaps this is unnecessary decomposition / over-engineering for this problem. I don't know if this is the best approach to take, so please let me know if you'd prefer a different approach! There is possibly opportunity to do stricter checks for the VDF files we need elsewhere in the code, so that we don't try to use them if they don't exist, but I don't necessarily think these approaches are mutually exclusive.

## Future Work
In my tests, this didn't break detection of my Steam installation, and if the `steam_path` given to `is_valid_steam_install` is invalid, then Steam will not be added to the dropdown. In this case it gracefully defaults to Lutris, but if all paths given to `is_valid_launcher_installation` are invalid, we still gracefully handle this by showing the main menu but with an empty combobox and blank list, but in future there is an opportunity for some slightly improved UX here I think (not that I think many users will run into this, I think it's unlikely a user will install or use ProtonUp-Qt with no available launchers installed).

Other launchers could be handled in follow-up PRs, I'm not sure if this issue affects them as much but it is not impossible I don't think. I think we're just a bit better at making sure these files exist for other launchers elsewhere, or rather, there is less dependence on these files (from my memory at least) than there is for Steam.

<hr>

Took me a while to finally get around to this after my comment on the linked issue, but this was the approach I had in mind back then. I hope I explained the problem as I understand it and the solution I came up with well enough. All feedback is welcome on this! There was a lack of coffee while I was working on this but hopefully it's not a total disaster :-)

Thanks!