### PR TITLE
Shortcut Editor: Add 'Find' and 'Save' keyboard shortcuts

### DIFF
--- a/pupgui2/pupgui2shortcutdialog.py
+++ b/pupgui2/pupgui2shortcutdialog.py
@@ -4,6 +4,7 @@ from collections import Counter
 from PySide6.QtCore import Qt, QObject, Signal, QDataStream, QByteArray
 from PySide6.QtWidgets import QLineEdit
 from PySide6.QtUiTools import QUiLoader
+from PySide6.QtGui import QKeySequence, QShortcut
 
 from pupgui2.datastructures import SteamApp
 from pupgui2.steamutil import calc_shortcut_app_id, get_steam_user_list, determine_most_recent_steam_user
@@ -87,6 +88,10 @@ class PupguiShortcutDialog(QObject):
         self.ui.btnAdd.clicked.connect(self.btn_add_clicked)
         self.ui.btnRemove.clicked.connect(self.btn_remove_clicked)
         self.ui.searchBox.textChanged.connect(self.search_shortcuts)
+
+        # Keyboard Shortcuts
+        QShortcut(QKeySequence.Save, self.ui).activated.connect(self.btn_save_clicked)
+        QShortcut(QKeySequence.Find, self.ui).activated.connect(lambda: self.ui.searchBox.setFocus())
 
     def prepare_table_row(self, i: int, shortcut: SteamApp):
         txt_name = ShortcutDialogLineEdit(shortcut.game_name, default_cursor_position=0)


### PR DESCRIPTION
## Overview
When using the Shortcut Editor (which is my new favourite thing :smile:) I instinctively pressed "Ctrl+F" to focus the search bar. I figured it would be a useful bit of functionality, so I decided to add it!

While adding it, I also thought a save shortcut would be handy, so I added that too.

There is some precedent for keyboard shortcuts in ProtonUp-Qt, as we already have some on the Main Menu, so I think it's okay to add them to the Shortcut Editor too :slightly_smiling_face: 

## Implementation
These shortcuts are bound using  `QKeySequence.Find` and `QKeySequence.Save`, which are Qt's built-in per-platform "constants" (I guess?) for these actions. Since we're only targetting Linux with ProtonUp-Qt, it isn't a huge deal, but I think it's nicer to be explicit with a shortcut key combination called "Save" rather than the *very, very slightly* more ambiguous "Ctrl+S". This is also what we already use for the keyboard shortcuts on the Main Menu.

To wire up the shortcuts:
- The "Find" shortcut has a lambda attached to it that just sets the focus to the `searchBox` widget.
- The "Save" shortcut just connects to the existing `btn_save_clicked` method.

If this change is desired, there is room for other shortcuts too, such as `Ctrl+N` for creating a new shortcut row. Open to all discussion :smile: 

## Future Work
We could probably document these shortcuts on the brand-new wiki to give a bit more visibility on this change. We could have a page for keyboard shortcuts, with a per-screen table of available shortcuts. I'd be happy to take a stab at the markup and attach it to a discussion as I can't directly edit the wiki.

<hr>

Thanks!