### PR TITLE
AppImage build: Upgrade to Ubuntu 22.04 and Python 3.10

### DIFF
--- a/.github/workflows/appimage-ci.yml
+++ b/.github/workflows/appimage-ci.yml
@@ -7,25 +7,21 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v1
     
     - name: Install required dependencies
-      run: sudo apt install -y gtk-update-icon-cache python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace fuse
+      run: sudo apt install -y binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync
     
     - name: Download AppImageBuilder etc.
       run: |
-        mkdir -p ~/.local/bin
-        wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O ~/.local/bin/appimagetool
-        chmod +x ~/.local/bin/appimagetool
         pip3 install appimage-builder
     
     - name: Build AppImage
       run: |
         sed -i "s/BUILD_INFO = .*/BUILD_INFO = 'Official AppImage by DavidoTek'/" pupgui2/constants.py
-        sed -i "s/PySide6.*/PySide6==6.2.4/" requirements.txt
         appimage-builder
 
     - name: Upload AppImage

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 *.AppImage.zsync
 AppDir/
 appimage-builder-cache/
+appimage-build/

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,18 +1,18 @@
 version: 1
 script:
   - rm -rf AppDir  | true
-  - mkdir -p AppDir/usr/lib/python3.8/site-packages
-  - cp pupgui2 AppDir/usr/lib/python3.8/site-packages -r
+  - mkdir -p AppDir/usr/lib/python3.10/site-packages
+  - cp pupgui2 AppDir/usr/lib/python3.10/site-packages -r
   - cp share AppDir/usr -r
   - python3 -m pip install --ignore-installed --prefix=/usr --no-cache-dir --root=AppDir -r ./requirements.txt
-  - rm -rf AppDir/usr/lib/python3.8/site-packages/PySide6/Qt/qml/
-  - rm -rf AppDir/usr/lib/python3.8/site-packages/PySide6/examples/
-  - rm -rf AppDir/usr/lib/python3.8/site-packages/PySide6/Qt/resources/
-  - rm -rf AppDir/usr/lib/python3.8/site-packages/PySide6/Qt/translations/qtwebengine_locales/
-  - rm -f AppDir/usr/lib/python3.8/site-packages/PySide6/{assistant,designer,linguist,lrelease,lupdate}
-  - rm -f AppDir/usr/lib/python3.8/site-packages/PySide6/{Qt3D*,QtBluetooth*,QtCharts*,QtConcurrent*,QtDataVisualization*,QtDBus*,QtDesigner*,QtHelp*,QtMultimedia*,QtNetwork*,QtOpenGL*,QtPositioning*,QtPrintSupport*,QtQml*,QtQuick*,QtRemoteObjects*,QtScxml*,QtSensors*,QtSerialPort*,QtSql*,QtStateMachine*,QtSvg*,QtTest*,QtWeb*,QtXml*}
+  - rm -rf AppDir/usr/lib/python3.10/site-packages/PySide6/Qt/qml/
+  - rm -rf AppDir/usr/lib/python3.10/site-packages/PySide6/examples/
+  - rm -rf AppDir/usr/lib/python3.10/site-packages/PySide6/Qt/resources/
+  - rm -rf AppDir/usr/lib/python3.10/site-packages/PySide6/Qt/translations/qtwebengine_locales/
+  - rm -f AppDir/usr/lib/python3.10/site-packages/PySide6/{assistant,designer,linguist,lrelease,lupdate}
+  - rm -f AppDir/usr/lib/python3.10/site-packages/PySide6/{Qt3D*,QtBluetooth*,QtCharts*,QtConcurrent*,QtDataVisualization*,QtDBus*,QtDesigner*,QtHelp*,QtMultimedia*,QtNetwork*,QtOpenGL*,QtPositioning*,QtPrintSupport*,QtQml*,QtQuick*,QtRemoteObjects*,QtScxml*,QtSensors*,QtSerialPort*,QtSql*,QtStateMachine*,QtSvg*,QtTest*,QtWeb*,QtXml*}
   - shopt -s extglob
-  - rm -rf AppDir/usr/lib/python3.8/site-packages/PySide6/Qt/lib/!(libQt6OpenGL*|libQt6XcbQpa*|libQt6Wayland*|libQt6Egl*|libicudata*|libicuuc*|libicui18n*|libQt6DBus*|libQt6Network*|libQt6Qml*|libQt6Core*|libQt6Gui*|libQt6Widgets*|libQt6Svg*|libQt6UiTools*)
+  - rm -rf AppDir/usr/lib/python3.10/site-packages/PySide6/Qt/lib/!(libQt6OpenGL*|libQt6XcbQpa*|libQt6Wayland*|libQt6Egl*|libicudata*|libicuuc*|libicui18n*|libQt6DBus*|libQt6Network*|libQt6Qml*|libQt6Core*|libQt6Gui*|libQt6Widgets*|libQt6Svg*|libQt6UiTools*)
 
 
 AppDir:
@@ -29,14 +29,13 @@ AppDir:
   apt:
     arch: amd64
     sources:
-      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse'
-        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32'
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920d1991bc93c'
 
     include:
       - python3
       - python3-pkg-resources
       - libopengl0
-      - libssl1.1
       - libk5crypto3
       - libkrb5-3
       - libgssapi-krb5-2
@@ -45,7 +44,7 @@ AppDir:
   runtime:
     env:
       PYTHONHOME: '${APPDIR}/usr'
-      PYTHONPATH: '${APPDIR}/usr/lib/python3.8/site-packages'
+      PYTHONPATH: '${APPDIR}/usr/lib/python3.10/site-packages'
 
 
 AppImage:


### PR DESCRIPTION
Upgrade AppImage dependencies as Ubuntu 20.04 and Python 3.8 slowly reach *end of life* status:

- Ubuntu 20.04 (Focal) -> Ubuntu 22.04 (Jammy)
    - glibc 2.31 -> glibc 2.35
- Python 3.8 -> Python 3.10
- PySide 6.2.4 -> latest (no upper limit for now)

This may increase the system requirements for using the AppImage.

---

- EOL Python 3.8: October 2024
- EOL Python 3.10: October 2026
- EOL Ubuntu 20.04: April 2025
- EOL Ubuntu 22.04: April 2027

References:
https://devguide.python.org/versions/
https://ubuntu.com/about/release-cycle (see standard support)