### PR TITLE
Lutris: Add some util functions for conditional game list parsing

### DIFF
--- a/pupgui2/lutrisutil.py
+++ b/pupgui2/lutrisutil.py
@@ -47,3 +47,28 @@ def get_lutris_game_list(install_loc) -> List[LutrisGame]:
     except Exception as e:
         print('Error: Could not get lutris game list:', e)
     return lgs
+
+
+def is_lutris_game_using_runner(game: LutrisGame, runner: str) -> bool:
+
+    """ Determine if a LutrisGame is using a given runner. """
+
+    is_runner_name_valid = game.runner is not None and len(game.runner) > 0
+    is_using_runner = game.runner == runner
+
+    return is_runner_name_valid and is_using_runner
+
+
+def is_lutris_game_using_wine(game: LutrisGame, wine_version: str = '') -> bool:
+
+    """ Determine if a LutrisGame is using a given wine_version string. """
+
+    is_using_wine = is_lutris_game_using_runner(game, 'wine')
+
+    # Only check wine_version if it is passed
+    if len(wine_version) > 0:
+        is_using_wine_version = game.get_game_config().get('wine', {}).get('version', '') == wine_version
+    else:
+        is_using_wine_version = True
+
+    return is_using_wine and is_using_wine_version

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -3,7 +3,7 @@ import os
 
 from pupgui2.constants import STEAM_APP_PAGE_URL
 from pupgui2.datastructures import BasicCompatTool, CTType, SteamApp, LutrisGame, HeroicGame
-from pupgui2.lutrisutil import get_lutris_game_list
+from pupgui2.lutrisutil import get_lutris_game_list, is_lutris_game_using_wine
 from pupgui2.pupgui2ctbatchupdatedialog import PupguiCtBatchUpdateDialog
 from pupgui2.steamutil import get_steam_game_list
 from pupgui2.util import open_webbrowser_thread, get_random_game_name
@@ -93,7 +93,7 @@ class PupguiCtInfoDialog(QObject):
         self.batch_update_complete.emit(True)
 
     def update_game_list_lutris(self):
-        self.games = [game for game in get_lutris_game_list(self.install_loc) if game.runner == 'wine' and game.get_game_config().get('wine', {}).get('version') == self.ctool.displayname]
+        self.games = [game for game in get_lutris_game_list(self.install_loc) if is_lutris_game_using_wine(game, self.ctool.displayname)]
 
         self.setup_game_list(len(self.games), [self.tr('Slug'), self.tr('Name')])
 

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -11,7 +11,7 @@ from PySide6.QtUiTools import QUiLoader
 
 from pupgui2.constants import PROTONDB_COLORS, STEAM_APP_PAGE_URL, AWACY_WEB_URL, PROTONDB_APP_PAGE_URL, LUTRIS_WEB_URL
 from pupgui2.datastructures import AWACYStatus, SteamApp, SteamDeckCompatEnum, LutrisGame, HeroicGame
-from pupgui2.lutrisutil import get_lutris_game_list
+from pupgui2.lutrisutil import get_lutris_game_list, is_lutris_game_using_runner
 from pupgui2.pupgui2shortcutdialog import PupguiShortcutDialog
 from pupgui2.steamutil import steam_update_ctools, get_steam_game_list
 from pupgui2.steamutil import is_steam_running, get_steam_ctool_list
@@ -175,7 +175,7 @@ class PupguiGameListDialog(QObject):
         """ update the game list for the Lutris launcher """
         # Filter blank runners and Steam games, because we can't change any compat tool options for Steam games via Lutris
         # Steam games can be seen from the Steam games list, so no need to duplicate it here
-        self.games = list(filter(lambda lutris_game: (lutris_game.runner is not None and lutris_game.runner != 'steam' and len(lutris_game.runner) > 0), get_lutris_game_list(self.install_loc)))
+        self.games = [game for game in get_lutris_game_list(self.install_loc) if not is_lutris_game_using_runner(game, 'steam')]
 
         self.ui.tableGames.setRowCount(len(self.games))
 


### PR DESCRIPTION
Some readability improvements that may help extending these checks later for future work, hopefully not too premature! :smile: 

When I was digging into #363 I noticed that some of the conditional logic was a bit long and seemingly arbitrary. To help with readability I made some generic utility functions that should explain better than the checks we were doing before.

For #363 we may need to extend the conditional logic i.e. in `pupgui2ctinfodialog.py`, we may need to add a check for whether a given runtime is in use. This would get pretty long, but with this format, we could make `is_lutris_game_using_runtime('dxvk', game.dxvk_version)` (or something along these lines, idk how we would want to do this just yet, and not too important for this PR :-) ).

The first function added is to check what runner a `LutrisGame` is using, with `not None` and length sanity checks. We were already doing this for the Games List

(https://github.com/DavidoTek/ProtonUp-Qt/blob/6cf1def3bf1ee9775b2639ed41aad1ff96ae2afa/pupgui2/pupgui2gamelistdialog.py#L178)

But this function now means anytime we check the runner name, we perform these checks.

The 2nd function is more specific, and it checks if a `LutrisGame` is using Wine as its runner, with an optional parameter to check if it's using a specific Wine version. I figured there's no harm in making this function a bit more flexible as it was pretty straightforward to extend.

This could make our checks a lot cleaner should they be extended further. At least in my opinion, `if is_lutris_game_using_wine(game, self.ctool.displayname) or is_lutris_game_using_runtime(game, ...)` is a lot cleaner than extending our existing check.