### PR TITLE
Custom Install Directory: Use Inline `if` for Safer Default Launcher Selection

### DIFF
--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -50,7 +50,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
             display_name for display_name in self.install_locations_dict.values()
         ])
 
-        self.set_selected_launcher(self.install_locations_dict[self.launcher] or 'steam')  # Default combobox selection to "Steam" if unknown launcher for some reason
+        self.set_selected_launcher(self.install_locations_dict[self.launcher] if self.launcher in self.install_locations_dict else 'steam')  # Default combobox selection to "Steam" if unknown launcher for some reason
 
         self.ui.btnSave.clicked.connect(self.btn_save_clicked)
         self.ui.btnDefault.clicked.connect(self.btn_default_clicked)


### PR DESCRIPTION
Fix #370.

Almost forewent my usual PR format, but that would be no fun, right? :wink: 

## Overview
Changes the check in the Custom Install Dialog that selects the default launcher to use an inline `if`, which fixes a crash if `self.launcher` is not a key in `self.install_locations_dict`. This currently occurs when there are no available launchers installed. We get a `KeyError` if no launchers are found, because `self.launcher` is not a valid key in `self.install_locations_dict`.

## Problem
Apparently, in Python, `dictionary[key] or 'value'` will result in a `KeyError` if `key` is not defined. However in other cases, this does not happen. For example with an inline `if` I guess the conditional gets parsed first, like a "full" `if`, so you can do `dictionary[key] if key in dictionary else 'value'` safely, as Python won't process the `dictionary[key]` first. Makes sense having thought it through (you wouldn't want `print('hello') if condition else print ('goodbye')` to print `hello`, so `condition` has to be processed fiirst), but tripped me up a little.

## How to Replicate Error
You can test this fix by forcefully returning False at the beginning if `util#is_valid_launcher_installation`. This will result in ProtonUp-Qt not finding any launchers. On `main`, opening the Custom Install Directory dialog will give a crash. With this change, it should work correctly.

I did some testing and this prevents the crash, and the crash I was encountering matches the one described in #370 (`KeyError: ''` and noting line 53, where this fix is implemented). I am very confident this is the cause of the crash. What I am not sure of is how no Steam installation was found in #370. For some reason this seems to be coming up more in recent months for no clear reason...

## Future Work
There are some UIX issues I'd like to tackle in separate PRs that won't depend on the changes here. For example, adding a custom install directory will not immediately find all compatibility tools, you have to restart the launcher. If you force no launchers to be found and then add a valid path to a Steam installation's `compatibilitytools.d`, you have to restart ProtonUp-Qt for any tools to display.

<hr>

Small change, big PR description :sweat_smile: 

Thanks!