### PR TITLE
Add winezgui support

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -58,7 +58,9 @@ POSSIBLE_INSTALL_LOCATIONS += [
     {'install_dir': '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/tools/wine/', 'display_name': 'Heroic Wine Flatpak', 'launcher': 'heroicwine', 'type': 'flatpak', 'icon': 'heroic'},
     {'install_dir': '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/tools/proton/', 'display_name': 'Heroic Proton Flatpak', 'launcher': 'heroicproton', 'type': 'flatpak', 'icon': 'heroic'},
     {'install_dir': '~/.local/share/bottles/runners/', 'display_name': 'Bottles', 'launcher': 'bottles', 'type': 'native', 'icon': 'com.usebottles.bottles'},
-    {'install_dir': '~/.var/app/com.usebottles.bottles/data/bottles/runners/', 'display_name': 'Bottles Flatpak', 'launcher': 'bottles', 'type': 'flatpak', 'icon': 'com.usebottles.bottles'}
+    {'install_dir': '~/.var/app/com.usebottles.bottles/data/bottles/runners/', 'display_name': 'Bottles Flatpak', 'launcher': 'bottles', 'type': 'flatpak', 'icon': 'com.usebottles.bottles'},
+    {'install_dir': '~/.local/share/winezgui/Runners/', 'display_name': 'WineZGUI', 'launcher': 'winezgui', 'type': 'native', 'icon': 'io.github.fastrizwaan.WineZGUI'},
+    {'install_dir': '~/.var/app/io.github.fastrizwaan.WineZGUI/data/winezgui/Runners/', 'display_name': 'WineZGUI Flatpak', 'launcher': 'winezgui', 'type': 'flatpak', 'icon': 'io.github.fastrizwaan.WineZGUI'}
 ]
 
 def PALETTE_DARK():

--- a/pupgui2/resources/ctmods/ctmod_00winege.py
+++ b/pupgui2/resources/ctmods/ctmod_00winege.py
@@ -14,7 +14,7 @@ from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'Wine-GE'
-CT_LAUNCHERS = ['lutris', 'heroicwine', 'bottles']
+CT_LAUNCHERS = ['lutris', 'heroicwine', 'bottles', 'winezgui']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_00winege', '''Compatibility tool "Wine" to run Windows games on Linux. Based on Valve Proton Experimental's bleeding-edge Wine, built for Lutris.<br/><br/><b>Use this when you don't know what to choose.</b>''')}
 
 

--- a/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
+++ b/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
@@ -13,7 +13,7 @@ from pupgui2.util import build_headers_with_authorization, fetch_project_release
 
 
 CT_NAME = 'Kron4ek Wine-Builds Vanilla'
-CT_LAUNCHERS = ['lutris']
+CT_LAUNCHERS = ['lutris', 'winezgui']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_kron4ekvanilla', '''Compatibility tool "Wine" to run Windows games on Linux. Official version from the WineHQ sources, compiled by Kron4ek.''')}
 
 

--- a/pupgui2/resources/ctmods/ctmod_lutriswine.py
+++ b/pupgui2/resources/ctmods/ctmod_lutriswine.py
@@ -13,7 +13,7 @@ from pupgui2.util import build_headers_with_authorization
 
 
 CT_NAME = 'Lutris-Wine'
-CT_LAUNCHERS = ['lutris', 'bottles']
+CT_LAUNCHERS = ['lutris', 'bottles', 'winezgui']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_lutriswine', '''Compatibility tool "Wine" to run Windows games on Linux. Improved by Lutris to offer better compatibility or performance in certain games.''')}
 
 

--- a/pupgui2/resources/ctmods/ctmod_winetkg_valve_otherdistro.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_valve_otherdistro.py
@@ -8,7 +8,7 @@ from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstall
 
 
 CT_NAME = 'Wine Tkg (Valve Wine Bleeding Edge)'
-CT_LAUNCHERS = ['lutris', 'heroicwine']
+CT_LAUNCHERS = ['lutris', 'heroicwine', 'winezgui']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_winetkg_valve_otherdistro', '''Custom Wine build for running Windows games, built with the Wine-tkg build system based on <b>Valve Wine bleeding_edge</b>.''')}
 
 

--- a/pupgui2/resources/ctmods/ctmod_winetkg_winemaster.py
+++ b/pupgui2/resources/ctmods/ctmod_winetkg_winemaster.py
@@ -8,7 +8,7 @@ from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstall
 
 
 CT_NAME = 'Wine Tkg (Wine Master)'
-CT_LAUNCHERS = ['lutris', 'heroicwine', 'advmode']
+CT_LAUNCHERS = ['lutris', 'heroicwine', 'winezgui', 'advmode']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_winetkg_vanilla_ubuntu', '''Custom Wine build for running Windows games, built with the Wine-tkg build system (Ubuntu CI) based on <b>Wine Master</b>.''')}
 
 


### PR DESCRIPTION
Close https://github.com/DavidoTek/ProtonUp-Qt/issues/373

- [X] Adds support for [WineZGUI](https://github.com/fastrizwaan/WineZGUI/)
- [X] Allows installing all Wine-based compatibility tools (Wine-GE, Lutriswine, Wine-Tkg, Kron4ekVanilla)
- [ ] (**In a later PR**) Possibly add support for Proton-based compatibility tools using uwu, see https://github.com/DavidoTek/ProtonUp-Qt/issues/191#issuecomment-2058037459

---

@DavidoTek Requires additional filesystem permissions for the Flatpak, https://github.com/flathub/net.davidotek.pupgui2/
- `--filesystem=~/.local/share/winezgui/Runners/`
- `--filesystem=~/.var/app/io.github.fastrizwaan.WineZGUI/data/winezgui/Runners/`
