### PR TITLE
Games List: Add tooltip to Deck Compatibility column

### DIFF
--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -147,8 +147,13 @@ class PupguiGameListDialog(QObject):
             self.ui.tableGames.setItem(i, 4, QTableWidgetItem())
             self.ui.tableGames.setCellWidget(i, 4, btn_fetch_protondb)
 
+            # Steam Deck compatibility 
             lbltxt = self.get_steamdeck_compatibility(game)
-            self.ui.tableGames.setItem(i, 2, QTableWidgetItem(lbltxt))
+
+            lbltxt_item = QTableWidgetItem(lbltxt)
+            lbltxt_item.setToolTip(lbltxt_item.text())
+
+            self.ui.tableGames.setItem(i, 2, lbltxt_item)
 
             # AWACY status
             lblicon = QLabel()


### PR DESCRIPTION
Depending on the length of the compatibility tool name, or more importantly, the font selected on the user's system and the sizing of this font, the text for the Deck Compatibility tool name may be cut off.

This PR adds a tooltip to the cells on the Deck Compatibility column that displays the text of the cell. Below is a screenshot to illustrate the problem and the tooltip implemented here. For reference, the font used here is Inter Display Medium 10pt.

![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/bcda58d4-f86a-4eda-9a50-0b078c096a05)

The cell could be resized to see it, but we already display a tooltip for the Game Name, and resizing columns can create a misaligned UI, so I think this is a slight usability improvement. I discovered this because I tried to mouse over the cell to view the name in the tooltip to avoid resizing the columns. This could also go hand-in-hand with resizing the columns, as if a user made this column smaller to view others, the text would be cut off. This makes it easier to see the text on this column without resizing.