### PR TITLE
util: Use os.path.abspath for is_valid_launcher_installation

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -210,7 +210,7 @@ def is_valid_launcher_installation(loc) -> bool:
     #
     # In future we could expand this to other Steam flavours and other launchers.
     if loc['display_name'] == 'Steam':  # This seems to get called many times, why?
-        return is_valid_steam_install(os.path.realpath(os.path.join(install_dir, '..')))
+        return is_valid_steam_install(os.path.abspath(os.path.join(install_dir, '..')))
     
     return os.path.exists(install_dir)  # Default to path check for all other launchers
 


### PR DESCRIPTION
Fix #378.

If the compatibilitytools.d dir is a symlink, `realpath` will resolve the symlink before expanding and moving up a directory, meaning we will end up looking for the Steam data files in the symlink's parent directory instead of the Steam root, as we assumed the parent folder of compatibilitytools.d would always be a Steam root directory.

To fix this, we use `abspath` which will resolve the path without expanding symlinks.

We probably use `realpath` in a lot of places where symlinks might be used, so we might want to consider revisiting these. Anywhere we might expand an install directory path before moving up a directory is likely unsafe. I thought we did this for some cases with Lutris/Heroic (to install in the runtimes folder instead of the runners folder, for example) but I didn't spot any with a quick glance. It's also pretty late so I might've just missed it :smile: 

Reference:
- Python docs: https://docs.python.org/3/library/os.path.html#os.path.abspath
- StackOverflow answer with better explanation: https://stackoverflow.com/questions/37863476/why-would-one-use-both-os-path-abspath-and-os-path-realpath/40311142#40311142