### PR TITLE
AppImage improvements (libxcb-cursor0, cleaning)

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -39,6 +39,7 @@ AppDir:
       - libk5crypto3
       - libkrb5-3
       - libgssapi-krb5-2
+      - libxcb-cursor0
     exclude: []
 
   runtime:

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -5,14 +5,11 @@ script:
   - cp pupgui2 AppDir/usr/lib/python3.10/site-packages -r
   - cp share AppDir/usr -r
   - python3 -m pip install --ignore-installed --prefix=/usr --no-cache-dir --root=AppDir -r ./requirements.txt
-  - rm -rf AppDir/usr/lib/python3.10/site-packages/PySide6/Qt/qml/
-  - rm -rf AppDir/usr/lib/python3.10/site-packages/PySide6/examples/
-  - rm -rf AppDir/usr/lib/python3.10/site-packages/PySide6/Qt/resources/
-  - rm -rf AppDir/usr/lib/python3.10/site-packages/PySide6/Qt/translations/qtwebengine_locales/
-  - rm -f AppDir/usr/lib/python3.10/site-packages/PySide6/{assistant,designer,linguist,lrelease,lupdate}
-  - rm -f AppDir/usr/lib/python3.10/site-packages/PySide6/{Qt3D*,QtBluetooth*,QtCharts*,QtConcurrent*,QtDataVisualization*,QtDBus*,QtDesigner*,QtHelp*,QtMultimedia*,QtNetwork*,QtOpenGL*,QtPositioning*,QtPrintSupport*,QtQml*,QtQuick*,QtRemoteObjects*,QtScxml*,QtSensors*,QtSerialPort*,QtSql*,QtStateMachine*,QtSvg*,QtTest*,QtWeb*,QtXml*}
+  - rm -rf AppDir/usr/local/lib/python3.10/dist-packages/PySide6/Qt/qml/
+  - rm -f AppDir/usr/local/lib/python3.10/dist-packages/PySide6/{assistant,designer,linguist,lrelease,lupdate}
+  - rm -f AppDir/usr/local/lib/python3.10/dist-packages/PySide6/{Qt3D*,QtBluetooth*,QtCharts*,QtConcurrent*,QtDataVisualization*,QtDBus*,QtDesigner*,QtHelp*,QtMultimedia*,QtNetwork*,QtOpenGL*,QtPositioning*,QtPrintSupport*,QtQml*,QtQuick*,QtRemoteObjects*,QtScxml*,QtSensors*,QtSerialPort*,QtSql*,QtStateMachine*,QtSvg*,QtTest*,QtWeb*,QtXml*}
   - shopt -s extglob
-  - rm -rf AppDir/usr/lib/python3.10/site-packages/PySide6/Qt/lib/!(libQt6OpenGL*|libQt6XcbQpa*|libQt6Wayland*|libQt6Egl*|libicudata*|libicuuc*|libicui18n*|libQt6DBus*|libQt6Network*|libQt6Qml*|libQt6Core*|libQt6Gui*|libQt6Widgets*|libQt6Svg*|libQt6UiTools*)
+  - rm -rf AppDir/usr/local/lib/python3.10/dist-packages/PySide6/Qt/lib/!(libQt6OpenGL*|libQt6XcbQpa*|libQt6Wayland*|libQt6Egl*|libicudata*|libicuuc*|libicui18n*|libQt6DBus*|libQt6Network*|libQt6Qml*|libQt6Core*|libQt6Gui*|libQt6Widgets*|libQt6Svg*|libQt6UiTools*)
 
 
 AppDir:


### PR DESCRIPTION
Fix https://github.com/DavidoTek/ProtonUp-Qt/issues/378

- Include `libxcb-cursor0` in the AppImage
- Use the correct paths for cleaning unused Qt files (Debian's pip seems to change `/usr` to `/usr/local`, see https://github.com/DavidoTek/ProtonUp-Qt/issues/378#issuecomment-2071492202)