### PR TITLE
constants: Bump copyright year

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -15,7 +15,7 @@ DAVIDOTEK_KOFI_URL = 'https://ko-fi.com/davidotek'
 PROTONUPQT_GITHUB_URL = 'https://github.com/DavidoTek/ProtonUp-Qt'
 ABOUT_TEXT = '''\
 {APP_NAME} v{APP_VERSION} by DavidoTek: <a href="{PROTONUPQT_GITHUB_URL}">https://github.com/DavidoTek/ProtonUp-Qt</a><br />
-Copyright (C) 2021-2023 DavidoTek, licensed under GPLv3
+Copyright (C) 2021-2024 DavidoTek, licensed under GPLv3
 '''.format(APP_NAME=APP_NAME, APP_VERSION=APP_VERSION, PROTONUPQT_GITHUB_URL=PROTONUPQT_GITHUB_URL)
 BUILD_INFO = 'built from source'
 


### PR DESCRIPTION
Was tinkering around with the new Flatpak KDE 6.7 update to see if any of the small oddities were fixed (like the wrong cursor being used, and some things displaying incorrectly on Wayland, and they were fixed!) and happened to notice the copyright year wasn't bumped.

As far as I could see, this text isn't translated, and has only been changed a handful of times (most recently in #222). Making this text translatable _might_ be as straightforward as changing its usage in `pupgui2aboutdialog.py` to be `self.ui.lblAboutVersion.setText(self.tr(ABOUT_TEXT))`, but my understanding of translations is still not great. Since this text is using `.format` in `constants.py` and would not be calling it directly on `self.tr` I'm not sure if all that would play nicely together.