### PR TITLE
Custom Install Directory: Show hidden folders by default

### DIFF
--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -1,7 +1,7 @@
 import os
 import pkgutil
 
-from PySide6.QtCore import Signal, QDataStream, QByteArray, QObject
+from PySide6.QtCore import Signal, QDataStream, QByteArray, QObject, QDir
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QFileDialog, QLineEdit
 from PySide6.QtUiTools import QUiLoader
@@ -83,6 +83,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         dialog = QFileDialog(self.ui)
         dialog.setFileMode(QFileDialog.Directory)
         dialog.setOption(QFileDialog.ShowDirsOnly)
+        dialog.setFilter(QDir.Dirs | QDir.Hidden | QDir.NoDotAndDotDot)
         dialog.setWindowTitle(self.tr('Select Custom Install Directory — ProtonUp-Qt'))
         dialog.setDirectory(HOME_DIR)
         dialog.fileSelected.connect(self.ui.txtInstallDirectory.setText)


### PR DESCRIPTION
## Overview
This PR enables hidden folders by default for the Custom Install Directory dialog. This makes the dialog easier to browse when clicking through folders to find, for example, an alternative Steam installation location. Launcher installations are often in hidden directories, so I think it makes sense to enable hidden files by default.

### `main`
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/180e60b3-a40f-44d9-ad24-b68a44222747)

### This PR
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/a7d4770d-5b48-4ae1-9865-97577b86dde0)

This change also has the benefit of allowing suggestions when typing the path to a hidden folder. On `main`, if you type `~/.local/share/Steam`, you won't get any autocomplete, which might suggest a folder doesn't exist when it in fact does, the dialog is just hiding the hidden folder.

Since launchers often deal with hidden folders, I think it makes sense to have this on by default. For example if a user was using a custom version of a launcher that had a different path but still in `~/.local/share`, with this change you can see the suggestion appears.

**Note:** Since the KDE Runtime 6.7 bump, the Flatpak is actually using the KDE Portal for the file dialog, but the AppImage and running from source, and possibly also AUR packages, are not. Also, if a user didn't have the relevant Portals on their system, Qt would probably fall back to the Qt file picker. I haven't been able to test if this change works for the native Portal dialogs, but given that all this should be managed by Qt, I would say either they should already work and if they don't it's likely an upstream bug out of our hands.

### `main`
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/396d3389-4e48-4ada-99cb-8809d4769c0e)

### This PR
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/3d11f184-c14a-4bb8-aec5-546929706546)

## Justification
You can right-click and select "Show hidden files", but ProtonUp-Qt doesn't use context menus anywhere else, and this context menu comes from Qt behaviour. I think a sensible default it showing the hidden folders by default. Also, even when the dialog is set to only show directories, the context menu item still says "Show hidden files" which may not be immediately obvious either. 

And with the Qt dialog, unlike the KDE (and I believe GNOME?) portals, there is no shortcut to show hidden files. The portal will also not show hidden files by default even if your file manager has this enabled. Likely because there's no sort of "global preference" for this and you can have multiple file managers, it's still worth noting that by default this behaviour is _always off_. Maybe I'm an edge case, but I would prefer to have these _always on_ and especially so in the use-case of looking for launcher directories that are often in hidden folders.

Also, when you select "Show hidden files" from the right-click context menu, this isn't remembered the next time you open the dialog. So if you enable this option and then close the dialog, this setting is forgotten and you have to enable hidden files again. Although with this change a user who doesn't want hidden files would have to _disable it_ each time.

## Implementation
This feature is something I personally have wanted for a long time but couldn't figure out how to do it with Qt, so I spent the last couple of days investigating and happened across a tucked-away section of the Qt docs on how to implement it: https://doc.qt.io/qtforpython-6.2/PySide6/QtCore/QDir.html (Ctrl+F for "List hidden files" to get the member reference).

We can use `QFileDialog.setFilter()` with a few options to achieve the result we want here. We can't just use `QDir.Hidden` because the filter doesn't know if we want to filter by directories, files, or both, so just using `QDir.Hidden` would result in an empty list. We can add `QDir.Dirs` to tell the dialog to show folders. Order probably doesn't matter but I put it at the start because I think it makes the filter read more naturally. Finally, these two options alone result in the `.` and `..` folders being shown on the dialog. Personally I felt it was best to hide those so I hid them with `QDir.NoDotAndDotDot` which is a fantastic name (we don't show them currently anyway and most file pickers don't, although it can be handy in some file browsers).

<hr>

If not wanted it's not a huge deal to keep hidden folders disabled by default, but I think it's a useful addition for the context that the dialog is used in, which can very often be to look for folders in hidden directories.

Thanks!