### PR TITLE
Custom Install Directory: Try to open txtInstallDirectory first

### DIFF
--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -56,7 +56,6 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.ui.btnDefault.clicked.connect(self.btn_default_clicked)
         self.ui.btnClose.clicked.connect(self.ui.close)
 
-        self.is_valid_custom_install_path = lambda path: len(path.strip()) > 0 and os.path.isdir(os.path.expanduser(path)) and os.access(os.path.expanduser(path), os.W_OK)
         self.ui.txtInstallDirectory.textChanged.connect(lambda text: self.ui.btnSave.setEnabled(self.is_valid_custom_install_path(text)))
 
     def btn_save_clicked(self):
@@ -96,3 +95,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
             index = get_combobox_index_by_value(self.ui.comboLauncher, ctool_name)
             if index >= 0:
                 self.ui.comboLauncher.setCurrentIndex(index)
+
+    def is_valid_custom_install_path(self, path: str) -> bool:
+        expand_path = os.path.expanduser(path)
+        return len(path.strip()) > 0 and os.path.isdir(expand_path) and os.access(expand_path, os.W_OK)

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -80,11 +80,14 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.custom_id_set.emit('')
 
     def txt_id_browse_action_triggered(self):
-        dialog = QFileDialog(self.ui)
+        # Open dialog at entered path if it exists, and fall back to HOME_DIR
+        txt_install_dir = os.path.expanduser(self.ui.txtInstallDirectory.text())
+        initial_dir = txt_install_dir if self.is_valid_custom_install_path(txt_install_dir) else HOME_DIR
+
+        dialog = QFileDialog(self.ui, directory=initial_dir)
         dialog.setFileMode(QFileDialog.Directory)
         dialog.setOption(QFileDialog.ShowDirsOnly)
         dialog.setWindowTitle(self.tr('Select Custom Install Directory — ProtonUp-Qt'))
-        dialog.setDirectory(HOME_DIR)
         dialog.fileSelected.connect(self.ui.txtInstallDirectory.setText)
         dialog.open()
 


### PR DESCRIPTION
## Overview
This PR adds functionality to open the Custom Install Dialog directory at the path in `self.ui.txtInstallDirectory` first, if it is a valid directory. If you enter some text manually, or select a folder using the dialog, and then open the dialog again, it will then open from that entered/selected path again, which can be handy if you only enter part of a path and want to browse for the rest, or if you select the wrong path and want to continue navigating from where you left off.

If the path is not valid, we fall back to `HOME_DIR`.

## Implementation
We already have a lambda that can check if an install directory is valid in `PupguiCustomInstallDirectoryDialog` called `is_valid_custom_install_path`, we use this to enable/disable the "Save" button each time the text in `txtInstallDirectory` is changed. So when checking which path to open the dialog with, we re-use this. If `is_valid_custom_install_path` is not true, then we fall back to using `HOME_DIR` as the default location for the dialog.

There is a side-effect to this approach of checking the path: `is_valid_custom_install_path` checks if the path is writeable. So if we enter a path to a folder that is readable but not writeable, then the dialog won't open that directory. On one hand this makes sense, this prevents you from selecting an invalid folder, but on the other hand it may be unexpected if the user doesn't realise they can't write into that directory. When using this lambda for toggling the save button, it makes sense to disable the button if we can't write into the dialog, but maybe it doesn't make as much sense here? Although that would mean we'd have to basically duplicate the `is_valid_custom_install_path` check.

We could optionally make `is_valid_custom_install_path` a full function and give it a parameter to dictate whether or not we want to check if the selected directory is writeable. Then we can call it with that parameter as false for checking the path to open the diialog in (meaning we want to ignore if the path is not writeable in that instance) but set the parameter is true when we call it for toggling the "Save" button.

## Future Work
The path is wrapped in `expanduser` since the user could enter a path like `~/.local/share/Steam`. Setting the directory for the dialog with a path like this results in Qt becoming a little confused and opening the dialog in incorrect paths. We should probably make a util function at some point called like `sanitize_path` or something that can manage expanding paths, and optionally resolving symlinks. It might be cleaner than all of the nested path functions we use at the moment but that's future work :sweat_smile: 

<hr>

Thanks!