### PR TITLE
Change AppImage PYTHONPATH to local lib

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -42,7 +42,7 @@ AppDir:
   runtime:
     env:
       PYTHONHOME: '${APPDIR}/usr'
-      PYTHONPATH: '${APPDIR}/usr/lib/python3.10/site-packages'
+      PYTHONPATH: '${APPDIR}/usr/local/lib/python3.10/dist-packages'
 
 
 AppImage:


### PR DESCRIPTION
Fix https://github.com/DavidoTek/ProtonUp-Qt/issues/390

Change `PYTHONPATH` from `${APPDIR}/usr/lib/python3.10/site-packages` to `${APPDIR}/usr/local/lib/python3.10/dist-packages`.

I need to check whether that really fixes it, marked as draft for now.