### PR TITLE
Add Unit Testing Workflow using PyTest

### DIFF
--- a/.github/workflows/testing-ci.yml
+++ b/.github/workflows/testing-ci.yml
@@ -24,13 +24,17 @@ jobs:
         cache: "pip"
 
     - name: Install dependencies
-      run: pip install pytest pytest-md pytest-emoji
+      run: |
+        sudo apt install -y libegl1 libxkbcommon0
+        pip install pytest pytest-md pytest-emoji
 
     - name: Install ProtonUp-Qt
       run: pip install -e .
 
     - name: Run pytest
       uses: pavelzw/pytest-action@v2
+      env:
+        QT_QPA_PLATFORM: "offscreen"
       with:
         verbose: true
         emoji: true

--- a/.github/workflows/testing-ci.yml
+++ b/.github/workflows/testing-ci.yml
@@ -18,9 +18,10 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "${{ matrix.python-version }}"
+        cache: "pip"
 
     - name: Install dependencies
       run: pip install pytest pytest-md pytest-emoji

--- a/.github/workflows/testing-ci.yml
+++ b/.github/workflows/testing-ci.yml
@@ -1,0 +1,39 @@
+name: Test using Pytest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  tests:
+    name: "Run PyTest"
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: "${{ matrix.python-version }}"
+
+    - name: Install dependencies
+      run: pip install pytest pytest-md pytest-emoji
+
+    - name: Install ProtonUp-Qt
+      run: pip install -e .
+
+    - name: Run pytest
+      uses: pavelzw/pytest-action@v2
+      with:
+        verbose: true
+        emoji: true
+        job-summary: true
+        custom-arguments: '-q'
+        click-to-expand: true
+        report-title: 'ProtonUp-Qt Test Report'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,22 @@
+from pupgui2.util import *
+
+from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame
+
+
+def test_get_random_game_name():
+    """ test whether get_random_game_name returns a valid game name """
+    names = ["game", "A super cool game", "A game with a very long name that is very long", "0123456789"]
+
+    steam_app = [SteamApp() for _ in range(len(names))]
+    lutris_game = [LutrisGame() for _ in range(len(names))]
+    heroic_game = [HeroicGame() for _ in range(len(names))]
+
+    for i, name in enumerate(names):
+        steam_app[i].game_name = name
+        lutris_game[i].name = name
+        heroic_game[i].title = name
+
+    for i in range(10):
+        assert get_random_game_name(steam_app) in names
+        assert get_random_game_name(lutris_game) in names
+        assert get_random_game_name(heroic_game) in names


### PR DESCRIPTION
Fix https://github.com/DavidoTek/ProtonUp-Qt/issues/347

- Adds a CI workflow for Unit Testing using `pytest`
  - Runs on *Pull Requests* and *Pushes to main*
  - Currently tests on Ubuntu 22.04 and Python 3.10
- Adds an initial test for `util.py#get_random_game_name`
- Produces Markdown Test Report using [pytest-md](https://github.com/hackebrot/pytest-md)

---

<details>
  <summary>Fixed Qt import for PyTest by installing libEGL and libxcbcommon and setting QT_QPA_PLATFORM=offscreen</summary>


**Previously**: Currently fails due to missing `libEGL`, i.e. the runner is headless but the Qt imports expect a graphics library. I will investigate that.

```sql
==================================== ERRORS ====================================
_____________________ ERROR collecting tests/test_util.py ______________________
ImportError while importing test module '/home/runner/work/ProtonUp-Qt/ProtonUp-Qt/tests/test_util.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_util.py:1: in <module>
    from pupgui2.util import *
pupgui2/util.py:20: in <module>
    from PySide6.QtWidgets import QApplication, QStyleFactory, QMessageBox, QCheckBox
E   ImportError: libEGL.so.1: cannot open shared object file: No such file or directory
---------------- generated Markdown report: /tmp/tmp.t8xQFKNH8p ----------------
```
</details>