### PR TITLE
Games List: Add checks for skipping invalid games

### DIFF
--- a/pupgui2/lutrisutil.py
+++ b/pupgui2/lutrisutil.py
@@ -38,9 +38,16 @@ def get_lutris_game_list(install_loc) -> List[LutrisGame]:
             lutris_install_dir = g[5]
             if not lutris_install_dir:
                 lg_config = lg.get_game_config()
-                working_dir = lg_config.get('game', {}).get('working_dir')
-                exe_dir = lg_config.get('game', {}).get('exe')
+                lg_game_config = lg_config.get('game', {})
+
+                working_dir = lg_game_config.get('working_dir')
+                exe_dir = lg_game_config.get('exe')
+
                 lutris_install_dir = working_dir or (os.path.dirname(str(exe_dir)) if exe_dir else None)
+
+                # If a LutrisGame config has an 'appid' in its 'game' section in its yml, assume runner is Steam
+                if lg_game_config.get('appid', None) is not None:
+                    lg.runner = 'steam'
 
             lg.install_dir = os.path.abspath(lutris_install_dir) if lutris_install_dir else ''
             lgs.append(lg)

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -454,8 +454,9 @@ class PupguiGameListDialog(QObject):
     def is_valid_lutris_gameslist_game(self, game: LutrisGame) -> bool:
         """
         Check if a LutrisGame should be displayed on the Games List based on some criteria.
-        * Steam Games are excluded
-        * Games with no runner, install_loc, or installed_at are exluded
+        * Steam Games are excluded.
+        * Games with no runner are excluded.
+        * Games with no install_dir are excluded.
 
         Return Type: bool
         """
@@ -463,7 +464,7 @@ class PupguiGameListDialog(QObject):
         # Lutris DB may store Steam games even if they are not installed
         #
         # This results in only the game.name being available, and many
-        # other values like game.runner and game.install_loc being 'None'
+        # other values like game.runner and game.install_dir being 'None'
         #
         # We can assume a game is not valid to display on the Games List
         # if the runner and install_dir are Falsey, and if 

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -1,7 +1,7 @@
 import os
 import pkgutil
 
-from typing import List, Callable, Tuple, Union
+from typing import Callable
 from datetime import datetime
 
 from PySide6.QtCore import QObject, Signal, Slot, QDataStream, QByteArray, Qt
@@ -31,7 +31,7 @@ class PupguiGameListDialog(QObject):
         self.install_dir = install_dir
         self.parent = parent
         self.queued_changes = {}
-        self.games: List[Union[SteamApp, LutrisGame, HeroicGame]] = []
+        self.games: list[SteamApp | LutrisGame | HeroicGame] = []
 
         self.install_loc = get_install_location_from_directory_name(install_dir)
         self.launcher = self.install_loc.get('launcher', '')
@@ -111,7 +111,7 @@ class PupguiGameListDialog(QObject):
 
     def update_game_list_steam(self, cached=True):
         """ update the game list for the Steam launcher """
-        self.games = get_steam_game_list(steam_config_folder=self.install_loc.get('vdf_dir'), cached=cached)
+        self.games: list[SteamApp] = get_steam_game_list(steam_config_folder=self.install_loc.get('vdf_dir'), cached=cached)
         ctools = [c if c != 'SteamTinkerLaunch' else 'Proton-stl' for c in sort_compatibility_tool_names(list_installed_ctools(self.install_dir, without_version=True), reverse=True)]
         ctools.extend(t.ctool_name for t in get_steam_ctool_list(steam_config_folder=self.install_loc.get('vdf_dir'), cached=True))
 
@@ -180,7 +180,7 @@ class PupguiGameListDialog(QObject):
         """ update the game list for the Lutris launcher """
         # Filter blank runners and Steam games, because we can't change any compat tool options for Steam games via Lutris
         # Steam games can be seen from the Steam games list, so no need to duplicate it here
-        self.games = [game for game in get_lutris_game_list(self.install_loc) if self.is_valid_lutris_gameslist_game(game)]
+        self.games: list[LutrisGame] = [game for game in get_lutris_game_list(self.install_loc) if self.is_valid_lutris_gameslist_game(game)]
 
         self.ui.tableGames.setRowCount(len(self.games))
 
@@ -241,7 +241,7 @@ class PupguiGameListDialog(QObject):
 
     def update_game_list_heroic(self):
         heroic_dir = os.path.join(os.path.expanduser(self.install_loc.get('install_dir')), '../..')
-        self.games = list(filter(lambda heroic_game: (heroic_game.is_installed and len(heroic_game.runner) > 0 and not heroic_game.is_dlc), get_heroic_game_list(heroic_dir)))
+        self.games: list[HeroicGame] = list(filter(lambda heroic_game: (heroic_game.is_installed and len(heroic_game.runner) > 0 and not heroic_game.is_dlc), get_heroic_game_list(heroic_dir)))
 
         self.ui.tableGames.setRowCount(len(self.games))
 
@@ -399,7 +399,7 @@ class PupguiGameListDialog(QObject):
         else:
             item.setToolTip(tooltip_invalid)
 
-    def get_steamapp_awacystatus(self, game: SteamApp) -> Tuple[str, str]:
+    def get_steamapp_awacystatus(self, game: SteamApp) -> tuple[str, str]:
         """ Return translated status text and icon representing AreWeAntiCheatYet.com status for a Steam game """
         awacy_status: str = ''
         awacy_icon: str = ''


### PR DESCRIPTION
Fixes #397.

## Overview
This PR fixes a crash in the Lutris Games List if some games have data as `None` that we expect to be defined.

I covered this a lot in #397 but to reiterate briefly: When loading the games list, we get our list of `LutrisGame`s with `lutrisutil#get_lutris_game_list`. We filter out Steam games from this list. Then we extract data from each `LutrisGame` and display it on the UI; the name, runner, install directory, and installation time, as well as some other data for tooltips.

However some games can be missing this information. Lutris stores information about its games in an sqlite3 database, `pga.db`, which we query. Some games in this DB may be missing a lot of information though. The example I encountered this with was by syncing my Lutris Steam list. It stored information about all my Steam games including ones that weren't installed, and the ones not installed had lots of empty information including an empty runner.

This missing runner meant the check we do to skip Lutris games gotten from Steam with `lutrisutil#is_lutris_game_using_runner` were not catching these games. Since the runner was `None` and not `'steam'` then it was missing this.

## Solution
The fix I ended up going with was to create a method, `PupguiGameListDialog#is_valid_lutris_gameslist_game`. We then use this in our list comprehension when storing our list of Lutris games.

### Stricter checking with `is_valid_lutris_gameslist_game`
The purpose of this function is to check if a `LutrisGame` is valid to be displayed on the Games List. In 99.9999% of cases, this is essentially just ensuring a game is _installed_, as an entry in Lutris' DB does not guarantee that a game is installed. We have to try an infer this (this is even a problem in Lutris itself, where many a missing game may not always be marked as missing, and will simply fail to launch). Lutris does have a column in its DB to track if a game is installed but this is not very reliable from what I have observed from querying, and from what I recall in the past, which is why we don't simply check this.

So now we have `is_valid_lutris_gameslist_game` that will essentially perform a stricter check to make sure games we want to display on the Games List have all the data we need. Instead of working around with `None` checks all over the place, we can assume early when generating the `self.games` list, that if a game is missing a `runner` and an `install_dir`, and if the runner is `'steam'`, then we don't want to display it on the games list.

A small benefit to this method is that if later on we decide we want other criteria, for example if Lutris started displaying Bottles or Heroic games for some reason, we can exclude those with an additional runner check. This keeps the list comprehension cleaner and also using this method name should make it a bit more obvious why the conditional check is in place.

### Safer Logic for Parsing `LutrisGame#installed_at`
Despite what I said above, I decided that a safer check for `installed_at` wasn't out of the question. Based on my extensive querying of my own Lutris DB in https://github.com/DavidoTek/ProtonUp-Qt/issues/397#issuecomment-2116195449, a game that is installed and valid for our purposes (in other words, a game that passes `is_valid_lutris_gameslist_game`) should always have `installed_at`. However in case this is ever missing, it is a less important factor in determining if a game is valid, so I kept it out of `is_valid_lutris_gameslist_game` and instead did a slight refactor of our logic for setting this.

Instead of setting all the data when setting up the `QTableWidgetItem`, we instead store the data in variables. Then we set the variables to different values based on whether  `installed_at` is Truthy (not `None` and not an empty string). If we have an `installed_at` then we set it up as before. Otherwise, we set the text to `self.tr('Unknown')`, set the tooltip to "`Install Date is Unknown`", and then set the data to `0`. The data is used for sorting to know how to sort by a given column, so we simply set to `0`. here.

After this check we set up the `QTableWidgetItem` as before but we give it the variables defined above. This keeps our conditional logic out of the widget item setup at the expense of some extra lines.

### Minor Type Hinting Refactor
We recently updated our base Python version to 3.10, meaning we can finally start to use the type hinting in Python3.10 without all the imports or capitalizations (https://docs.python.org/3.10/library/typing.html). Just because I was working in this file I decided to update our type hintings in `pupgui2gamelistdialog.py` to use things like `list` and `tuple` instead of `List` and `Tuple`, meaning we can also remove those imports as well.

We couldn't replace the `Callable` type hint, but you win some, you lose some :smile: 

<hr>

In my testing this isn't missing any games in the Lutris Games List, all the games I would expect to be there are present (there are games I know is missing, but they were displayed before, and Lutris also does not display them as missing, but the files do not exist anymore).

Let me know if you have any concerns about the implementation here or if we need to do any additional work in the `is_valid_lutris_gameslist_game` check. I know we had some discussion in #397 already but sometimes it's easier to look at an implementation and realise there are problems :sweat_smile:  

Thanks!