### PR TITLE
Theming: Use Base Palette Colour for Tooltip Background Instead of `Qt.white`

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -65,12 +65,14 @@ POSSIBLE_INSTALL_LOCATIONS += [
 
 def PALETTE_DARK():
     """ returns dark color palette """
+    palette_base = QColor(12, 12, 12)
+
     palette_dark = QPalette()
     palette_dark.setColor(QPalette.Window, QColor(30, 30, 30))
     palette_dark.setColor(QPalette.WindowText, Qt.white)
-    palette_dark.setColor(QPalette.Base, QColor(12, 12, 12))
+    palette_dark.setColor(QPalette.Base, palette_base)
     palette_dark.setColor(QPalette.AlternateBase, QColor(30, 30, 30))
-    palette_dark.setColor(QPalette.ToolTipBase, Qt.white)
+    palette_dark.setColor(QPalette.ToolTipBase, palette_base)
     palette_dark.setColor(QPalette.ToolTipText, Qt.white)
     palette_dark.setColor(QPalette.Text, Qt.white)
     palette_dark.setColor(QPalette.Button, QColor(30, 30, 30))


### PR DESCRIPTION
When using the Dark theme, the `ToolTipBase` colour was set to the same colour as the `ToolTipText` colour. Both were set to `Qt.white`. This meant the tooltip text would not be readable against the tooltip background.

This PR changes the `ToolTipBase` colour to match the Palette base colour (`12, 12, 12`), which is very close to pure black (`0, 0, 0`), making it contrast well against the tooltip text and making it readable. We could use either of these two, or `Qt.black`, but I opted to go with the window base colour. The difference is so minute my eyes cannot tell the difference :smile: 

#### Before (db33194)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/f866ebda-6a16-4328-93db-d14d93e49cbb)

#### After (This PR)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/983af979-fde9-42fe-9886-3d95491a0241)

<hr>

Here are also some comparisons with other options, `Qt.black` and `QColor(0, 0, 0)`:

#### Comparison with `Qt.black` (NOT implemented in this PR)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/6ceb5e28-4616-465b-a289-786953a724a4)

#### Comparison with `QColor(0, 0, 0)` (NOT implemented in this PR)
![image](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/ccec5efa-a7c5-40ad-8e4b-8599192e7dc4)

<hr>

I caught this because I have switched to using the Dark theme. I put this down to Qt Wayland bugs with Plasma 5+Qt5, but now that we're onto Plasma 6+Qt6 with vastly improved Wayland support, the issue persisting felt a little strange, so I dug into it and this is what I found.

Thanks!