### PR TITLE
Main: Use `APP_ID` constant in place of `net.davidotek.pupgui2`

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -12,7 +12,7 @@ from PySide6.QtWidgets import QApplication, QDialog, QMessageBox, QLabel, QPushB
 from PySide6.QtWidgets import QProgressBar, QVBoxLayout, QSpacerItem, QSizePolicy
 from PySide6.QtUiTools import QUiLoader
 
-from pupgui2.constants import APP_NAME, APP_VERSION, BUILD_INFO, TEMP_DIR, STEAM_STL_INSTALL_PATH
+from pupgui2.constants import APP_NAME, APP_VERSION, APP_ID, BUILD_INFO, TEMP_DIR, STEAM_STL_INSTALL_PATH
 from pupgui2.constants import STEAM_BOXTRON_FLATPAK_APPSTREAM, STEAM_STL_FLATPAK_APPSTREAM
 from pupgui2 import ctloader
 from pupgui2.datastructures import CTType, MsgBoxType, MsgBoxResult
@@ -123,7 +123,7 @@ class MainWindow(QObject):
         self.progressBarDownload = QProgressBar()
         self.progressBarDownload.setVisible(False)
         self.ui.statusBar().addPermanentWidget(self.progressBarDownload)
-        self.ui.setWindowIcon(QIcon.fromTheme('net.davidotek.pupgui2'))
+        self.ui.setWindowIcon(QIcon.fromTheme(APP_ID))
         self.ui.txtInstalledVersions.setText('0')
 
         self.update_combo_install_location()
@@ -530,8 +530,8 @@ def main():
     app = PupguiApp(sys.argv)
     app.setApplicationName(APP_NAME)
     app.setApplicationVersion(APP_VERSION)
-    app.setWindowIcon(QIcon.fromTheme('net.davidotek.pupgui2'))
-    app.setDesktopFileName('net.davidotek.pupgui2')
+    app.setWindowIcon(QIcon.fromTheme(APP_ID))
+    app.setDesktopFileName(APP_ID)
 
     PupguiExceptionHandler(app)
 

--- a/pupgui2/pupgui2aboutdialog.py
+++ b/pupgui2/pupgui2aboutdialog.py
@@ -7,7 +7,7 @@ from PySide6.QtGui import QPixmap, QIcon
 from PySide6.QtWidgets import QApplication, QMessageBox
 from PySide6.QtUiTools import QUiLoader
 
-from pupgui2.constants import APP_NAME, APP_VERSION, APP_GHAPI_URL, ABOUT_TEXT, BUILD_INFO, APP_THEMES
+from pupgui2.constants import APP_NAME, APP_VERSION, APP_ID, APP_GHAPI_URL, ABOUT_TEXT, BUILD_INFO, APP_THEMES
 from pupgui2.constants import DAVIDOTEK_KOFI_URL, PROTONUPQT_GITHUB_URL
 from pupgui2.steamutil import install_steam_library_shortcut
 from pupgui2.util import config_theme, apply_dark_theme, config_advanced_mode
@@ -36,7 +36,7 @@ class PupguiAboutDialog(QObject):
 
         translator_text = QApplication.instance().translate('translator-text', 'Translated by DavidoTek')
 
-        self.ui.lblAppIcon.setPixmap(QIcon.fromTheme('net.davidotek.pupgui2').pixmap(QSize(96, 96)))
+        self.ui.lblAppIcon.setPixmap(QIcon.fromTheme(APP_ID).pixmap(QSize(96, 96)))
 
         self.ui.lblAboutTranslator.setText(translator_text)
         self.ui.lblAboutVersion.setTextFormat(Qt.RichText)


### PR DESCRIPTION
Replaces usage of `net.davidotek.pupgui2` around the codebase with `APP_ID`, which should always be equivalent. I noticed this when working on something unrelated and thought it would be a useful change for consistency :-) Didn't seem to break anything in my testing.