### PR TITLE
pupgui2: Send Download Progress and Active Downloads to DBus

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -23,6 +23,17 @@ CONFIG_FILE = os.path.join(xdg_config_home, 'pupgui/config.ini')
 TEMP_DIR = os.path.join(os.getenv('XDG_CACHE_HOME'), 'tmp', 'pupgui2.a70200/') if os.path.exists(os.getenv('XDG_CACHE_HOME', '')) else '/tmp/pupgui2.a70200/'
 HOME_DIR = os.path.expanduser('~')
 
+# DBus constants
+DBUS_APPLICATION_URI = f'application://{APP_ID}.desktop'
+DBUS_DOWNLOAD_OBJECT_BASEPATH = '/net/davidotek/pupgui2'
+
+DBUS_INTERFACES_AND_SIGNALS = {
+    'LauncherEntryUpdate': {
+        'interface': 'com.canonical.Unity.LauncherEntry',
+        'signal': 'Update',
+    }
+}
+
 # support different Steam root directories, building paths relative to HOME_DIR (i.e. /home/gaben/.local/share/Steam)
 # Use os.path.realpath to expand all _STEAM_ROOT paths
 _POSSIBLE_STEAM_ROOTS = [

--- a/pupgui2/dbusutil.py
+++ b/pupgui2/dbusutil.py
@@ -8,11 +8,11 @@ from pupgui2.constants import DBUS_APPLICATION_URI, DBUS_DOWNLOAD_OBJECT_BASEPAT
 def create_and_send_dbus_message(object: str, interface: str, signal_name: str, arguments: list, bus: QDBusConnection = QDBusConnection.sessionBus):
 
     """
-    Create and send a QDBusMessage over a given bus, with some preset information such as the 'application://' identifier
+    Create and send a QDBusMessage over a given bus.
     If no bus is given, will default to sessionBus
     """
 
-    # i.e. /net/davidotek/pupgui2/CompatToolDownload
+    # i.e. /net/davidotek/pupgui2/Update
     object_path = os.path.join(DBUS_DOWNLOAD_OBJECT_BASEPATH, object)
 
     message: QDBusMessage = QDBusMessage.createSignal(object_path, interface, signal_name)

--- a/pupgui2/dbusutil.py
+++ b/pupgui2/dbusutil.py
@@ -1,0 +1,55 @@
+import os
+
+from PySide6.QtDBus import QDBusConnection, QDBusMessage
+
+from pupgui2.constants import DBUS_APPLICATION_URI, DBUS_DOWNLOAD_OBJECT_BASEPATH, DBUS_INTERFACES_AND_SIGNALS
+
+
+def create_and_send_dbus_message(object: str, interface: str, signal_name: str, arguments: dict, bus: QDBusConnection = QDBusConnection.sessionBus):
+
+    """
+    Create and send a QDBusMessage over a given bus, with some preset information such as the 'application://' identifier
+    If no bus is given, will default to sessionBus
+    """
+
+    # i.e. /net/davidotek/pupgui2/CompatToolDownload
+    object_path = os.path.join(DBUS_DOWNLOAD_OBJECT_BASEPATH, object)
+
+    # All DBus signals should contain DBUS_APPLICATION_URI, plus an 'arguments' dict with some extra information
+    # i.e. { 'progress': 0.7, 'progress-visible': True }
+    message_arguments = [
+        DBUS_APPLICATION_URI,
+        arguments
+    ]
+
+    message: QDBusMessage = QDBusMessage.createSignal(object_path, interface, signal_name)
+    message.setArguments(message_arguments)
+
+    # Don't send the message if bus is not valid (i.e. DBus is not running)
+    if bus.isConnected():
+        bus.send(message)
+
+
+def dbus_progress_message(progress: float, count: int = 0, bus: QDBusConnection = QDBusConnection.sessionBus()):
+
+    """
+    Create and send download progress (between 0 and 1) information with optional count parameter on a given bus.
+    If no bus is given, will default to sessionBus.
+    """
+
+    arguments = {
+        'progress': progress,
+        'progress-visible': progress >= 0 and progress < 1,
+        'count': count,
+        'count-visible': count > 0
+    }
+
+    launcher_entry_update = DBUS_INTERFACES_AND_SIGNALS['LauncherEntryUpdate']
+    
+    interface = launcher_entry_update['interface']
+    signal = launcher_entry_update['signal']
+    object = 'Update'
+
+    create_and_send_dbus_message(object, interface, signal, arguments, bus=bus)
+
+

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -196,7 +196,7 @@ class MainWindow(QObject):
         Send Download Progress and Pending Downloads count using DBus.
         """
 
-        progress_pct = progress / 100  # LauncherEntry expects i.e. 70% as 0.7
+        progress_pct = progress / 100  # DBus progress signal expects progress between 0-1
         num_downloads = len(self.pending_downloads)
         if progress < 0:  # negative progress indicates cancellation/failure/etc
             num_downloads = 0

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -11,6 +11,7 @@ from PySide6.QtGui import QIcon, QKeyEvent, QKeySequence, QShortcut
 from PySide6.QtWidgets import QApplication, QDialog, QMessageBox, QLabel, QPushButton, QCheckBox
 from PySide6.QtWidgets import QProgressBar, QVBoxLayout, QSpacerItem, QSizePolicy
 from PySide6.QtUiTools import QUiLoader
+from PySide6.QtDBus import QDBusConnection
 
 from pupgui2.constants import APP_NAME, APP_VERSION, APP_ID, BUILD_INFO, TEMP_DIR, STEAM_STL_INSTALL_PATH
 from pupgui2.constants import STEAM_BOXTRON_FLATPAK_APPSTREAM, STEAM_STL_FLATPAK_APPSTREAM
@@ -25,6 +26,7 @@ from pupgui2.pupgui2gamelistdialog import PupguiGameListDialog
 from pupgui2.pupgui2installdialog import PupguiInstallDialog
 from pupgui2.steamutil import get_steam_acruntime_list, get_steam_app_list, get_steam_ct_game_map, get_steam_global_ctool_name, ctool_is_runtime_for_app
 from pupgui2.heroicutil import is_heroic_launcher, get_heroic_game_list
+from pupgui2.dbusutil import dbus_progress_message
 from pupgui2.util import apply_dark_theme, create_compatibilitytools_folder, get_installed_ctools, remove_ctool
 from pupgui2.util import install_directory, available_install_directories, get_install_location_from_directory_name
 from pupgui2.util import print_system_information, single_instance, download_awacy_gamelist, is_online, config_advanced_mode, config_github_access_token, config_gitlab_access_token, compat_tool_available
@@ -102,6 +104,9 @@ class MainWindow(QObject):
         self.compat_tool_index_map = []
         self.msgcb_answer : MsgBoxResult = None
         self.msgcb_answer_lock = QMutex()
+
+        self.dbus_session_bus = QDBusConnection.sessionBus()
+        dbus_progress_message(-1, 0)  # Reset any previously set download information to be blank
 
         self.load_ui()
         self.setup_ui()
@@ -184,6 +189,19 @@ class MainWindow(QObject):
                 update_statusbar_message.emit(f'{APP_NAME} {APP_VERSION}')
         t = threading.Thread(target=_set_default_statusbar_thread, args=[self.update_statusbar_message])
         t.start()
+
+    def send_dbus_download_progress(self, progress: float) -> None:
+
+        """
+        Send Download Progress and Pending Downloads count using DBus.
+        """
+
+        progress_pct = progress / 100  # LauncherEntry expects i.e. 70% as 0.7
+        num_downloads = len(self.pending_downloads)
+        if progress < 0:  # negative progress indicates cancellation/failure/etc
+            num_downloads = 0
+
+        dbus_progress_message(progress_pct, num_downloads, self.dbus_session_bus)
 
     def update_combo_install_location(self, custom_install_dir = None):
         self.updating_combo_install_location = True
@@ -308,14 +326,12 @@ class MainWindow(QObject):
         if len(self.pending_downloads):
             compat_tool = self.pending_downloads[0]
             self.current_compat_tool_name = compat_tool['name'] + ' ' + compat_tool['version']
-        if value == -2:
+        elif value == -2:
             self.ui.statusBar().showMessage(self.tr('Download canceled.'))
             self.progressBarDownload.setVisible(False)
-            return
-        if value == -1:
+        elif value == -1:
             self.ui.statusBar().showMessage(self.tr('Could not install {current_compat_tool_name}...').format(current_compat_tool_name=self.current_compat_tool_name))
             self.progressBarDownload.setVisible(False)
-            return
         if value == 1:
             self.progressBarDownload.setVisible(True)
             self.ui.comboInstallLocation.setEnabled(False)
@@ -328,6 +344,9 @@ class MainWindow(QObject):
         elif value == 100:
             self.ui.statusBar().showMessage(self.tr('Installed {current_compat_tool_name}.').format(current_compat_tool_name=self.current_compat_tool_name))
             self.update_ui()
+
+        # Send DBus progress
+        self.send_dbus_download_progress(value)
 
     def btn_add_version_clicked(self, compat_tool: str = ''):
         advanced_mode = (config_advanced_mode() == 'enabled')
@@ -575,4 +594,5 @@ def main():
     if os.path.exists('/.flatpak-info') and len(os.listdir(STEAM_STL_INSTALL_PATH)) == 0:
         subprocess.run(['flatpak-spawn', '--host', 'rm', '-r', STEAM_STL_INSTALL_PATH])
 
+    dbus_progress_message(-1, 0)  # Reset any previously set download information to be blank
     sys.exit(ret)


### PR DESCRIPTION
## Overview
This PR enables displaying Download Progress and Active Downloads count on Task Managers, Docks, etc that listen for the `com.canonical.Unity.LauncherEntry.Update` DBus signal. When downloading tools, a progress bar will now appear on the Task Manager / Dock, displaying the same progress as the progress bar on the main window, as well as a count of the total active downloads. This can be useful if you have many windows open across different screens, or conversely on a single small display like the Steam Deck where you may set a tool to download and then open another fullscreen window as screen real estate is at a premium. It provides a visual indication of download progress outside of the ProtonUp-Qt main window and download count, similar to what a browser might show when downloading files. 

Despite the signal name, this is supported by KDE Plasma's built-in Task Manager widgets (it may also be supported by Latte Dock, unsure), and should be supported by GNOME as well.

If a system does not have DBus, or in Flatpak if DBus is disabled, nothing will happen. We check if we can use a given DBus bus first with `isConnected()`.

#### KDE Plasma Icons-Only Task Manager
This Task Manager is also used by default on SteamOS and many KDE Plasma installations with the default panel.
![pupgui2downloadexample2](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/9de61a3b-d015-4909-a9d5-f28b74d1e798)

#### KDE Plasma Task Manager
This is a built-in alternative to the Icons-Only Task Manager. I don't think it's used by default though.
![pupgui2downloadexample1](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/dec9cf16-1beb-4432-8a37-cbcae8403e67)

## Background
The tl;dr is that we have to get down-and-dirty with DBus as there is no higher-level wrapper for this functionality that I could find with Qt, at least not in Qt6. There have been requests to replace the signal with a Freedesktop Portal (https://github.com/flatpak/xdg-desktop-portal/discussions/1276) but nothing has materialized as of yet. 

This started because I noticed on SteamOS that Discover displays its download progress (I don't use a Task Manager or a Dock on my main PC), and I wondered how this was possible. After much research, I discovered based on https://github.com/ValveSoftware/steam-for-linux/issues/4777 that this is done via DBus.

From this, I figured that since Qt is fairly modern, there should be a good built-in way to hook into this DBus signal, as it is standard across at least two major Desktop Environments, KDE and GNOME. [There is not](https://forum.qt.io/topic/134105/analog-of-qwintaskbarprogress-in-qt-6), and someone actually created a custom Qt C++ class called [QTaskbarControl](https://github.com/Skycoder42/QTaskbarControl) to manage exactly this in a cross-platform way, using DBus on Linux (labelled as X11, but the underlying DBus logic works on Wayland as well).

At the time, I knew absolutely nothing about DBus, so I didn't really understand how to copy this over effectively. I didn't understand when and where to use certain identifiers. Instead of working backwards from how QtDBus does it I first started with understanding how the `gdbus` command works and what each part of that meant. It took a long time and a lot of playing around with things in ProtonUp-Qt, but I finally got somewhere, and so here we are!

Some other things I referenced were:
- General PySide6 DBus examples: https://github.com/flyfire/pyside6-examples/tree/7de66d333cc5ec22c8a5d1c322c988692e8da72e/dbus.
- C/C++ Qt implementation of this exact signal: https://askubuntu.com/questions/65054/unity-launcher-api-for-c/65199.
- All of the [PySide6 QDBusMessage docs](https://doc.qt.io/qtforpython-6/PySide6/QtDBus/QDBusMessage.html).
- This PyQt5 gist on using QtDBus with Python: https://gist.github.com/dpineiden/8254dd35f37ee05720a0ad13abf0ad3f.

## Implementation
You might know a lot more about DBus than me, and my explanations may be wrong, but I will try to explain this the way I would've liked it broken down and explained to me yesterday when I was coming at this fresh.

### Emitting to `com.canonical.Unity.LauncherEntry.Update` via The Command Line
In order to send the DBus progress information, here's how a `gdbus` command would look:

```bash
# Send a 60% progress message to com.canonical.Unity.LauncherEntry.Update signal
gdbus emit --session \
    --object-path /net/davidotek/pupgui2/Update \
    --signal com.canonical.Unity.LauncherEntry.Update \
        "application://net.davidotek.pupgui2.desktop" \
        "{'progress': <0.6>, 'progress-visible': <true> }"
```

I'm not an expert with DBus, but here's a breakdown of my understanding:
- `gdbus emit`: Send a message over DBus. We specify `emit` because you can probably also receive messages too.
- `--session`: This says to use the "session bus". DBus has many busses or paths to send information. The session bus is I believe used to specify only for the current user session OR, in the case of Flatpak, only for that Flatpak session.
    - There are probably messages you'd want to send to, say, system-level processes that may not be available on the session bus. I'm not sure it's strictly _necessary_ for this particular command to use the session bus, but it is good practice.
- `--object-path /net/davidotek/pupgui2/Update` - This is an identifier for the DBus message, if you use something like `dbus-monitor`, it allows you a readable way to see what exactly is sending this message. It doesn't have to be this name, this is just the one I chose.
    - Applications could also listen to messages on a specific path, which would make it more important, but for this example and this PR, it doesn't matter. It could just as easily be `/com/valvesoftware/SteamForBSD`.
- `--signal com.canonical.Unity.LauncherEntry.Update` - This is the signal we want to send our message to. Processes can listen for messages to a given signal, in this case, Task Managers can listen for messages on the signal `com.canonical.Unity.LauncherEntry.Update` and use the arguments given to that signal to do _something_.
    - The purpose of this signal is to update a display item on a launcher, i.e. a Dock, a Task Manager widget on a panel, etc. Or, to put it another way, to `Update` the `LauncherEntry`.
    - Technically, this is two parts:
        - `com.canonical.Unity.LauncherEntry` is an *interface*, which to my understanding is like a grouping of signals.
        - `Update` is the actual signal on this interface. An `Update` signal could exist on many interfaces.
- Everything after this is arguments to the signal and specific to the signal.
    - `"application://net.davidotek.pupgui2.desktop"` - Since this `Update`s the `LauncherEntry`, this argument is the `.desktop` file representing the Launcher Entry. To my knowledge it doesn't _have_ to be using the `application://` URI, but this was the most prevalent one I found in examples. So, we use this to tell the signal "Update applications associated to _this_ `.desktop` file on any Task Managers listening for this signal".
    - `"{'progress': <0.6>, 'progress-visible': <true> }"`. This is a dictionary that contains information that the `Update` signal can take and parse. You don't have to pass just these, you can actually pass more, you are basically giving a dictionary of data to the `Update` signal that, if it is looking for it, can parse and use. So in this case the `Update` signal listens for `progress`. You also have to set `progress-visible` otherwise it won't display anything (similarly, you can use this to hide the progress once the Progress is complete, as this won't happen automatically).
        - I'm not sure why the values have to be wrapped in `<angle brackets>`, but in my testing, they do.
        - Optionally you can add `count` and `count-visible`, like this: `"{'progress': <0.6>, 'progress-visible': <true>, 'count': <1>, 'count-visible': <true> }"`.

Putting all this together, this will set the a Download Progress indicator for ProtonUp-Qt on a Task Manager, if it is running, to 60% completion.

![wide task manager progress](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/c6d8f408-0047-4b91-a16d-7926800daf86)

![icons only task manager progress](https://github.com/DavidoTek/ProtonUp-Qt/assets/7917345/119ac49b-9a1c-49d2-8ac7-51b18f371d49)

### Emitting DBus Messages with PySide6 and QtDbus
Qt has some built-in classes for working with DBus. Since this is all still very low-level they are mostly wrappers around various DBus actions, and still very close to their C++ counterparts.

I didn't have the benefit of all of the above knowledge or how to implement in PySide6 at first, so a lot of this I figured out by hacking away in Python. The main way we can emit this signal in PySide6 and QtDBus is as follows, using `QtDBus.QDBusConnection` and `QtDBus.QDBusMessage`.
- Get a handle on the session bus with `QDBusConnection.sessionBus()` (i.e. `session_bus`), as we will be sending the message over this bus.
- Create a `QDBusMessage` object (i.e. `messageObject`), which we can do with `QDBusMessage.createSignal()`. It takes three arguments
    - `path` - This would be `object-path` in the above example, this would be `/net/davidotek/pupgui2/Update`
    - `interface` - This is where we deviate. From the above example, this would be `com.canonical.LauncherEntry`. Note how we don't include `Update` here, we just specify the Interface.
    - `name` - This is where we include the `Update` part.
        - When using `gdbus` we would send this all as `--signal com.canonical.LauncherEntry.Update`, but here we have to split this up.
        - This tripped me up and I spent a while trying to figure out why I couldn't get the code to work, I thought the `name` argument could be a name that we came up with and that the `interface` was the same as `--signal` in the `gdbus` command. But I eventually figured it out by re-reading the OP for https://github.com/ValveSoftware/steam-for-linux/issues/4777 and referencing https://askubuntu.com/questions/65054/unity-launcher-api-for-c/65199
- Add the arguments data (the `application://` URI and dictionary with the download progress information) to the message with `messageObject.setArguments()`. The above only created the message with information on where to send it but not the data; like writing the recipient information on a letter but not putting anything inside!
    - `setArguments` expects a `list`, and this list can contain anything. This is is because any signal could expect any data in any form.
    - For us, it just so happens that we need to send two types of information: a `str`ing for the application identifier, and a dictionary with data to `Update` on the `LauncherEntry`. - Again, this is specific to this signal, and other signals may take different pieces of information.
    - So we would want to send the following data to mirror the earlier `gdbus` example: `QDBusMessage.setArguments([ 'application://net.davidotek.pupgui2.desktop', { 'progress': 0.6, 'progress-visible': True } ])`.
        - These arguments are equivalent to the `"application://net.davidotek.pupgui2.desktop" "{'progress': <0.6>, 'progress-visible': <true> }"` lines in the `gdbus` command. Note how in Python we don't have to use any of the weird syntax around the arguments, we can just pass them as-is and Qt takes care of the rest.
- Now we can send the message along the session bus with `session_bus.send(messageObject)`. That is exactly how we mirror the above `gdbus` command
    - It is also a good idea to check if the bus is still alive/was ever valid, with `session_bus.isConnected()`, before sending any messages over that bus.

### Implementing in ProtonUp-Qt
So the first part covers how we would generally send this message along dbus from the command-line. Then we get more specific in how to do this in PySide6 with QtDBus and its quirks compared to the command.

So for ProtonUp-Qt, I implemented the download progress functionality by by doing this:
- The above PySide6 explanation breaks down how to send the message we want over DBus. So I made a util function in a new util file called `dbusutil.py` that abstracts this away. Since there's a lot of boilerplate in creating and sending messages, and basic messages like this have the same format, we have a util function called `create_and_send_dbus_message` that just takes some basic information and gets the bus, creates the message, adds the arguments, and sends the message for us. It does what was described in the above PySide6 bullet points in one helper function.
    - We create some constants to help us with this, mainly `DBUS_DOWNLOAD_OBJECT_BASEPATH` which is `/net/davidotek/pupgui2`. This means any DBus signals we send will be prefixed with this, making them more identifiable. When sending a message, we give an `object` string parameter that gets appended onto this. For example, `Update`, which would make our path `/net/davidotek/pupgui2/Update`.
    - We also have `DBUS_APPLICATION_URI`, which is our `application://net.davidotek.pupgui2` identifier.
    - This function checks to make sure the `bus` is connected for us to make sure messages are sent only if a valid bus is connected. It also
- To avoid having to do a lot of duplicated calls to a general `create_and_send_dbus_message`, I created another util function that wraps around this called `dbus_progress_message`, which is specifically for sending the progress message over DBus. This function handles creating the arguments for us and making sure the data we send to the `Update` signal is formatted properly (being a list with a specific string and a dict with specific data). It also handles setting whether the `progress-visible` and `count-visible` parameters should `True` or `False`, so we don't have to do that ourselves.
    - Instead of having to create and manage all of the other boilerplate needed when creating a message, or doing it all in `MainWindow#send_dbus_download_progress` (see below), we can put it all in `dbus_progress_message`. All we should really have to know to send to send the progress signal is that we need to give it `progress` and `count` which is the data displayed. Everything else should be taken care of in `dbusutil#dbus_progress_message`.
- Those two util functions handle crafting and sending the message for us. We actually call them in `pupgui2.py` though.
- We have a new method in `MainWindow` called `send_dbus_download_progress`. This handles massaging the progress and count variables to send to `dbusutil#dbus_progress_message` by making sure `progress` is `0-1`, and sending count as `len(self.active_downloads)` as this is a list of active downloads and not an actual count. It then calls `dbusutil#dbus_progress_message`.
- So now we have a `MainWindow` method that can send the data to our DBus helper functions. We call our `MainWindow` method in three main places:
    - `MainWindow#set_download_progress_percent` - This is where we update the progress bar, so after we do so, we send the data here to DBus.
    - `MainWindow#__init__` - We call this on startup of ProtonUp-Qt with a progress of `-1` and a count of `0`. The reason we do this is because the DBus data is not cleared automatically, we have to "clear" it by setting the `progress-visible` and `count-visible` properties to `False`. In order to make sure we properly do that, we call the DBus function with those values to clean up and hide any previous progress data we sent to DBus. This means if ProtonUp-Qt crashes or otherwise doesn't exit cleanly (Steam Deck dies mid-download, power outage, system crash, etc), then the next time we open ProtonUp-Qt, we will clear the previous download progress data we sent to DBus and so there won't be a progress bar or download count displayed.
        - We set `'progress-visible': progress >= 0 and progress < 1`, so if progress is `-1`, it gets set to `False`, so the progress bar is hidden.
        - We set `'count-visible': count > 0`, so if we send count as `0`, this will be `False` and the count indicator will not be displayed.
    - `pupgui2#main` - We call this function with a progress of `-1` and a count of `0` right before we call `sys.exit` at the end of the `main` function for the same reason we call this util function on startup: To make sure we clean up and remove any download progress on application shutdown, as without this, the progress bar and counter would show up with the same data when the program opens again.

## Concerns
I made a few decisions when implementing this PR that I wanted to address.

### Changes to `MainWindow#set_download_progress_percent`
I made some changes to `set_download_progress_percent` to use a full `if/elif/else`, and I removed the `return`s. This was because I want the method to always fall through and call `dbus_progress_message`. If a download is cancelled or fails it means we will properly send the negative progress and updated active downloads to DBus via `dbus_progress_message`, as otherwise the progress would hang. The alternative would've been putting calls to `dbus_progress_message` in each block that had a `return`.

It doesn't seem to have negatively impacted the progress method, it seems to work as it did before, since `value` doesn't cahnge inside of `set_download_progress_percent` so it should be safe. But let me know if these were not an `elif` for a reason, and we can revert that change and put the calls to `dbus_progress_message` in each of those blocks explicitly.

### `DBUS_INTERFACES_AND_SIGNALS` Constant
I created a new constant called `DBUS_INTERFACES_AND_SIGNALS`. This is a dictionary of dictionaries. Each nested dictionary contains an `interface` and a `signal` key/value pair, and each of these nested dictionaries is identified with a name representing the signal that the interface and signal belong to.

My rationale for this was, in future if we ever decide to send other information over DBus to other signals, instead of hardcoding the names, we should keep track of them as a constant. And when working with them in Qt, the names are broken down into the `interface` and `name`, for example `com.canonical.LauncherEntry` as the interface, and then `Update` as the signal.

This means in wrapper functions that wrap around sending a DBus message, such as `dbus_progress_message`, only that wrapper function has to be aware of what the interface and name are.

However, I am not _super_ happy about this approach. I think we should have _some_ constant to track these pairs, but I feel like having to remember them by their higher dictionary key, such as `LauncherEntryUpdate`, is a bit flimsy.

Maybe this should be a dataclass/enum or something that keeps track of these names, and then we can make the higher key something like `DBusSignals.LauncherEntryUpdate`? I am not sure, thoughts on the current approach and any improvements are welcome!

### Better Naming for `dbus_progress_message`
Perhaps we should make this a bit more general, like `send_task_manager_progress`, since it's on the `MainWindow`? That way as well, if this ever does get implemented at a higher level in Qt, we don't have a reference to DBus where it is unnecessary.

### Efficiency
I believe the current approach to sending information to DBus is efficient. I think you have to keep sending messages to a signal that listens for it, despite the name being `createSignal` which did have me a little concerned that we should only make one message this way and keep re-using it. But that doesn't seem possible, and messages seem to be one-time objects that you send and dispose of.

But, I knew nothing about DBus until yesterday afternoon. I still don't really know very much, just a very basic understanding on how to send this specific kind of message over DBus. So I want to caveat this PR with the fact that, it is very possible that my approach is not correct. I based it off of my own tinkering around and examples I seen online, primarily in C++, a language I am very unfamiliar with.

So if you spot anything in the code that doesn't look right please let me know!

### Systems Without DBus / Restricted Permissions
I believe handling the busses with `dbus.isConnected()` should be enough, but I am concerned in case the calls to QtDBus altogether fail if DBus is missing. I am not sure if this is the case and don't know how I would test for that, so it may be worth double-checking this.

In particular we may want to be careful with the Flatpak permissions, in case we need to explicitly add permissions.

## Future Work
Not much to note here other than, if this ever does get added as a Portal and/or if Qt ever adds a higher level wrapping around this for us, we may want to replace this approach with that.

<hr>

That was quite a lot for what should've been a very straightforward feature to implement. I hope my explanation and rationale made some sense.

All feedback on this implementation is appreciated!

Thanks!