### PR TITLE
CtLoader: Remove deprecated types

### DIFF
--- a/pupgui2/ctloader.py
+++ b/pupgui2/ctloader.py
@@ -1,8 +1,6 @@
 import pkgutil
 import importlib
 
-from typing import List, Tuple
-
 from PySide6.QtCore import QObject
 from PySide6.QtWidgets import QMessageBox
 
@@ -24,7 +22,7 @@ class CtLoader(QObject):
         Load ctmods
         Return Type: bool
         """
-        failed_ctmods: List[Tuple[str, Exception]] = []
+        failed_ctmods: list[tuple[str, Exception]] = []
         for _, mod, _ in pkgutil.iter_modules(ctmods.__path__):
             if mod.startswith('ctmod_'):
                 try:
@@ -75,7 +73,7 @@ class CtLoader(QObject):
     def get_ctobjs(self, launcher=None, advanced_mode=True):
         """
         Get loaded compatibility tools, optionally sort by launcher
-        Return Type: List[dict]
+        Return Type: list[dict]
         Content(s):
             'name', 'launchers', 'installer'
         """


### PR DESCRIPTION
I've been using basedPyright as my linter and it actually warned me that the `List` and `Tuple` types from `typing` are deprecated in Python 3.9. I knew newer Python versions supported using the syntax of `foo: list` but I didn't realise it was deprecated.

I was going to open a discussion asking what our stance is on typing and I think I will do after this, however this was a very straightforward drop-in replacement for these types. Further changes and perhaps further explicit typing changes can be made in future, but I will open a discussion around this before going any further :smile: 