### PR TITLE
constants: Use constant to determine if Flatpak

### DIFF
--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -23,6 +23,8 @@ CONFIG_FILE = os.path.join(xdg_config_home, 'pupgui/config.ini')
 TEMP_DIR = os.path.join(os.getenv('XDG_CACHE_HOME'), 'tmp', 'pupgui2.a70200/') if os.path.exists(os.getenv('XDG_CACHE_HOME', '')) else '/tmp/pupgui2.a70200/'
 HOME_DIR = os.path.expanduser('~')
 
+IS_FLATPAK: bool = os.path.exists('/.flatpak-info')
+
 # DBus constants
 DBUS_APPLICATION_URI = f'application://{APP_ID}.desktop'
 DBUS_DOWNLOAD_OBJECT_BASEPATH = '/net/davidotek/pupgui2'

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -14,7 +14,7 @@ from PySide6.QtUiTools import QUiLoader
 from PySide6.QtDBus import QDBusConnection
 
 from pupgui2.constants import APP_NAME, APP_VERSION, APP_ID, BUILD_INFO, TEMP_DIR, STEAM_STL_INSTALL_PATH
-from pupgui2.constants import STEAM_BOXTRON_FLATPAK_APPSTREAM, STEAM_STL_FLATPAK_APPSTREAM
+from pupgui2.constants import STEAM_BOXTRON_FLATPAK_APPSTREAM, STEAM_STL_FLATPAK_APPSTREAM, IS_FLATPAK
 from pupgui2 import ctloader
 from pupgui2.datastructures import CTType, MsgBoxType, MsgBoxResult
 from pupgui2.gamepadinputworker import GamepadInputWorker
@@ -591,7 +591,7 @@ def main():
     shutil.rmtree(TEMP_DIR, ignore_errors=True)
 
     # Flatpak workaround: Delete STL dir if it isn't installed (folder is always created for sandbox access)
-    if os.path.exists('/.flatpak-info') and len(os.listdir(STEAM_STL_INSTALL_PATH)) == 0:
+    if IS_FLATPAK and len(os.listdir(STEAM_STL_INSTALL_PATH)) == 0:
         subprocess.run(['flatpak-spawn', '--host', 'rm', '-r', STEAM_STL_INSTALL_PATH])
 
     dbus_progress_message(-1, 0)  # Reset any previously set download information to be blank

--- a/pupgui2/pupgui2gamelistdialog.py
+++ b/pupgui2/pupgui2gamelistdialog.py
@@ -9,7 +9,7 @@ from PySide6.QtGui import QPixmap, QBrush, QColor, QKeySequence, QShortcut
 from PySide6.QtWidgets import QLabel, QComboBox, QPushButton, QTableWidgetItem
 from PySide6.QtUiTools import QUiLoader
 
-from pupgui2.constants import PROTONDB_COLORS, STEAM_APP_PAGE_URL, AWACY_WEB_URL, PROTONDB_APP_PAGE_URL, LUTRIS_WEB_URL
+from pupgui2.constants import PROTONDB_COLORS, STEAM_APP_PAGE_URL, AWACY_WEB_URL, PROTONDB_APP_PAGE_URL, LUTRIS_WEB_URL, IS_FLATPAK
 from pupgui2.datastructures import AWACYStatus, SteamApp, SteamDeckCompatEnum, LutrisGame, HeroicGame
 from pupgui2.lutrisutil import get_lutris_game_list, is_lutris_game_using_runner
 from pupgui2.pupgui2shortcutdialog import PupguiShortcutDialog
@@ -35,7 +35,7 @@ class PupguiGameListDialog(QObject):
 
         self.install_loc = get_install_location_from_directory_name(install_dir)
         self.launcher = self.install_loc.get('launcher', '')
-        self.should_show_steam_warning = (is_steam_running() or os.path.exists('/.flatpak-info')) and self.launcher == 'steam'
+        self.should_show_steam_warning = (is_steam_running() or IS_FLATPAK) and self.launcher == 'steam'
 
         self.load_ui()
         self.setup_ui()
@@ -80,7 +80,7 @@ class PupguiGameListDialog(QObject):
     def setup_steam_list_ui(self):
         self.ui.tableGames.setHorizontalHeaderLabels([self.tr('Game'), self.tr('Compatibility Tool'), self.tr('Deck Compatibility'), self.tr('Anticheat'), 'ProtonDB'])
         self.ui.tableGames.horizontalHeaderItem(3).setToolTip('https://areweanticheatyet.com')
-        self.ui.lblSteamRunningWarning.setStyleSheet('QLabel { color: grey; }' if os.path.exists('/.flatpak-info') else self.ui.lblSteamRunningWarning.styleSheet())
+        self.ui.lblSteamRunningWarning.setStyleSheet('QLabel { color: grey; }' if IS_FLATPAK else self.ui.lblSteamRunningWarning.styleSheet())
 
         self.update_game_list_steam()
         self.protondb_status_fetched.connect(self.update_protondb_status)

--- a/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
+++ b/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
@@ -8,6 +8,7 @@ import requests
 
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
+from pupgui2.constants import IS_FLATPAK
 from pupgui2.util import extract_tar
 from pupgui2.util import build_headers_with_authorization, fetch_project_release_data, fetch_project_releases
 
@@ -95,7 +96,7 @@ class CtInstaller(QObject):
         Are the system requirements met?
         Return Type: bool
         """
-        proc_prefix = ['flatpak-spawn', '--host'] if os.path.exists('/.flatpak-info') else []
+        proc_prefix = ['flatpak-spawn', '--host'] if IS_FLATPAK else []
         ldd = subprocess.run(proc_prefix + ['ldd', '--version'], capture_output=True)
         ldd_out = ldd.stdout.split(b'\n')[0].split(b' ')
         ldd_ver = ldd_out[len(ldd_out) - 1]

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -66,7 +66,7 @@ class CtInstaller(QObject):
         self.rs.headers.update(rs_headers)
 
         self.allow_git = allow_git
-        proc_prefix = ['flatpak-spawn', '--host'] if os.path.exists('/.flatpak-info') else []
+        proc_prefix = ['flatpak-spawn', '--host'] if constants.IS_FLATPAK else []
         self.distinfo = subprocess.run(
             proc_prefix + ['cat', '/etc/lsb-release', '/etc/os-release'],
             universal_newlines=True,
@@ -172,7 +172,7 @@ class CtInstaller(QObject):
         Return Type: bool
         """
         # Possibly excuse some of these if not on Steam Deck and ignore if Flatpak
-        proc_prefix = ['flatpak-spawn', '--host'] if os.path.exists('/.flatpak-info') else []
+        proc_prefix = ['flatpak-spawn', '--host'] if constants.IS_FLATPAK else []
         yad_exe = host_which('yad')
         if yad_exe:
             try:
@@ -295,7 +295,7 @@ class CtInstaller(QObject):
             os.chdir(stl_path)
 
             # ProtonUp-Qt Flatpak: Run STL on host system
-            stl_proc_prefix = ['flatpak-spawn', '--host'] if os.path.exists('/.flatpak-info') else []
+            stl_proc_prefix = ['flatpak-spawn', '--host'] if constants.IS_FLATPAK else []
 
             # If on Steam Deck, run script for initial Steam Deck config
             # On Steam Deck, STL is installed to "/home/deck/stl/prefix"

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import QMessageBox, QApplication
 from pupgui2.constants import APP_NAME, APP_ID, APP_ICON_FILE
 from pupgui2.constants import PROTON_EAC_RUNTIME_APPID, PROTON_BATTLEYE_RUNTIME_APPID, PROTON_NEXT_APPID, STEAMLINUXRUNTIME_APPID, STEAMLINUXRUNTIME_SOLDIER_APPID, STEAMLINUXRUNTIME_SNIPER_APPID
 from pupgui2.constants import LOCAL_AWACY_GAME_LIST, PROTONDB_API_URL
-from pupgui2.constants import STEAM_STL_INSTALL_PATH, STEAM_STL_CONFIG_PATH, STEAM_STL_SHELL_FILES, STEAM_STL_FISH_VARIABLES, HOME_DIR
+from pupgui2.constants import STEAM_STL_INSTALL_PATH, STEAM_STL_CONFIG_PATH, STEAM_STL_SHELL_FILES, STEAM_STL_FISH_VARIABLES, HOME_DIR, IS_FLATPAK
 from pupgui2.datastructures import SteamApp, AWACYStatus, BasicCompatTool, CTType, SteamUser, RuntimeType
 
 
@@ -510,7 +510,7 @@ def remove_steamtinkerlaunch(compat_folder='', remove_config=True, ctmod_object=
                 print(f'Error: SteamTinkerLaunch is installed to {stl_symlink_path}, ProtonUp-Qt cannot modify this folder. Folder must be removed manually.')
         elif os.path.exists(STEAM_STL_INSTALL_PATH):
             # Regular Steam Deck/ProtonUp-Qt installation structure
-            if os.path.exists('/.flatpak-info'):
+            if IS_FLATPAK:
                 if os.path.exists(os.path.join(STEAM_STL_INSTALL_PATH, 'prefix')):
                     shutil.rmtree(os.path.join(STEAM_STL_INSTALL_PATH, 'prefix'))
             else:
@@ -600,7 +600,7 @@ def install_steam_library_shortcut(steam_config_folder: str, remove_shortcut=Fal
             with open(shortcuts_file, 'wb') as f:
                 if not remove_shortcut:
                     run_config = ['', '']
-                    if os.path.exists('/.flatpak-info'):
+                    if IS_FLATPAK:
                         run_config = [f'/usr/bin/flatpak', f'run {APP_ID}']
                     elif exe := subprocess.run(['which', APP_ID], universal_newlines=True, stdout=subprocess.PIPE).stdout.strip():
                         run_config = [exe, '']

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -19,7 +19,7 @@ import PySide6
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QApplication, QStyleFactory, QMessageBox, QCheckBox
 
-from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS, CONFIG_FILE, PALETTE_DARK, TEMP_DIR
+from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS, CONFIG_FILE, PALETTE_DARK, TEMP_DIR, IS_FLATPAK
 from pupgui2.constants import AWACY_GAME_LIST_URL, LOCAL_AWACY_GAME_LIST
 from pupgui2.constants import GITHUB_API, GITLAB_API, GITLAB_API_RATELIMIT_TEXT
 from pupgui2.datastructures import BasicCompatTool, CTType, Launcher, SteamApp, LutrisGame, HeroicGame
@@ -492,7 +492,7 @@ def host_which(name: str) -> str:
     Runs 'which <name>' on the host system (either normal or using 'flatpak-spawn --host' when inside Flatpak)
     Return Type: str
     """
-    proc_prefix = ['flatpak-spawn', '--host'] if os.path.exists('/.flatpak-info') else []
+    proc_prefix = ['flatpak-spawn', '--host'] if IS_FLATPAK else []
     which = subprocess.run(proc_prefix + ['which', name], universal_newlines=True, stdout=subprocess.PIPE).stdout.strip()
     return None if which == '' else which
 
@@ -510,7 +510,7 @@ def host_path_exists(path: str, is_file: bool) -> bool:
     Return Type: bool
     """
     path = os.path.expanduser(path)
-    proc_prefix = 'flatpak-spawn --host' if os.path.exists('/.flatpak-info') else ''
+    proc_prefix = 'flatpak-spawn --host' if IS_FLATPAK else ''
     parameter = 'f' if is_file else 'd'  # check file using -f and directory using -d
     ret = os.system(proc_prefix + ' bash -c \'if [ -' + parameter + ' "' + path + '" ]; then exit 1; else exit 0; fi\'')
     return bool(ret) 


### PR DESCRIPTION
We use a lot of `os.path.exists('/.flatpak-info')` calls to determine if we're running inside Flatpak. This can be stored as a constant. Maybe you could consider this a micro-optimisation as we don't call `os.path.exists` as much anymore, but my main motivation here was readibility.

I didn't test this in Flatpak, please feel free to do so to make sure I didn't screw anything up (or direct me on how to do it :smile:)

Thanks!

<hr>

P.S. - This touches the dreaded SteamTinkerLaunch ctmod :wink: I have a laptop again (that I installed SteamTinkerLaunch on using ProtonUp-Qt!) so I am planning to tinker around with that ctmod again and make the code a bit less scary.