### PR TITLE
Flatpak Metainfo: Add Affiliation Note

### DIFF
--- a/share/metainfo/net.davidotek.pupgui2.appdata.xml
+++ b/share/metainfo/net.davidotek.pupgui2.appdata.xml
@@ -50,6 +50,16 @@
     </ul>
     <p>Double click compatibility tools to show more information and games using the tool.</p>
     <p>Advanced settings and the color theme can be managed in the About dialog.</p>
+
+    <hr/>
+
+    <p>
+      <b><a href="https://github.com/DavidoTek/ProtonUp-Qt/pull/413">Affiliation Note</a></b>: ProtonUp-Qt is an independent tool for managing gaming compatibility tools. It is neither directly affiliated with the compatibility tool creators nor with the providers of the individual game launchers. However, we try to work with them where possible.
+    </p>
+
+    <p>
+      The official development takes place on GitHub at <a href="https://github.com/DavidoTek/ProtonUp-Qt">DavidoTek/ProtonUp-Qt</a>, and the official website is <a href="https://davidotek.github.io/protonup-qt">https://davidotek.github.io/protonup-qt</a>. We distribute ProtonUp-Qt as a Flatpak on <a href="https://flathub.org/apps/net.davidotek.pupgui2">Flathub</a> and as an AppImage in the <a href="https://github.com/DavidoTek/ProtonUp-Qt/releases">releases section</a> of the GitHub repository. Additionally, we check the integrity of the AUR (<code><a href="https://aur.archlinux.org/packages/protonup-qt">protonup-qt</a></code> and <code><a href="https://aur.archlinux.org/packages/protonup-qt-bin">protonup-qt-bin</a></code>) and <a href="https://pacstall.dev/packages/protonup-qt-app">Pacstall</a> distribution on an irregular basis. 
+    </p>
   </description>
   
   <launchable type="desktop-id">net.davidotek.pupgui2.desktop</launchable>


### PR DESCRIPTION
Adds the affilication note about the fake website to the Flatpak Metainfo which should also, if my understanding is correct, make it appear on the Flathub page (and possibly elsewhere that can pull this data, such as on the commandline?).

I think I got it right in terms of styling but I haven't ever written anything like this before. I am unsure if the links for example work this way, and if the markup is fairly standard, or if there are some Flatpak (or more specifically, Flathub) specific guidelines in place for excessive linking/linking at all.