### PR TITLE
util: Don't download AWACY list if offline

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -456,6 +456,10 @@ def download_awacy_gamelist() -> None:
         r = requests.get(AWACY_GAME_LIST_URL)
         with open(LOCAL_AWACY_GAME_LIST, 'wb') as f:
             f.write(r.content)
+
+    if not is_online():
+        return
+
     t = threading.Thread(target=_download_awacy_gamelist_thread)
     t.start()
 


### PR DESCRIPTION
When troubleshooting to see if another issue was related to offline behaviour, I found out that if we open ProtonUp-Qt while offline, there is an ugly error coming from requests if we try to download the game list while offline.

This PR returns early from `download_awacy_gamelist` if we are offline. We do this before we even create the thread that tries to download the game list, which should be very, very slightly more efficient than doing this after the thread is created :sweat_smile:

<hr>

This has the side-effect of not creating the file at all if we open ProtonUp-Qt while offline. We use this file in `update_steamapp_awacystatus` to populate `SteamApp` anti-cheat info and we have a check that if the file doesn't exist, we return early. So no worries here.

Something to consider for the future is that the AWACY list is not updated if we don't create it on startup. Since the file won't be populated while offline, even if the user re-connects later, we don't re-download the file. We might want to consider doing this, but I am not sure how. Just a note from being in and around this part of the code :smile:  

<hr>

Since this calls out directly to the raw file data we shouldn't have to worry about any GitHub rate limits. But we might want to look in future at making `_download_awacy_gamelist_thread` a bit safer, to avoid writing any data if we don't get a success code, just to avoid writing out bad data to the file.

This `update_steamapp_awacystatus` function does account for the file not having the fields we expect by wrapping the logic in a try/except block, so we raise an exception if we do have a file but it has bad data (so if we ever end up writing garbage data like a rate-limit or GitHub-down response it'll be safe).

<hr>