### PR TITLE
networkutil: Add new download_file utility function

### DIFF
--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -1,0 +1,94 @@
+import os
+from PySide6.QtCore import Property
+import requests
+
+from typing import Callable
+
+
+def download_file(url: str, destination: str, progress_callback: Callable[[int], None], download_cancelled: Property | bool = None, buffer_size: int = 65536, stream: bool = True, known_size: int = 0):
+    """
+    Download a file from a given URL using `requests` to a destination directory with download progress, with some optional parameters:
+    * `download_cancelled`: Qt Property that can stop the download
+    * `buffer_size`: Size of chunks to download the file in
+    * `stream`: Lazily parse response - If response headers won't contain `'Content-Length'` and the file size is not known ahead of time, set this to `False` to get file size from response content length
+    * `known_size`: If size is known ahead of time, this can be given to calculate download progress in place of Content-Length header (e.g. where it may be missing)
+
+    Returns `True` if download succeeds, `False` otherwise.
+
+    Return Type: bool
+    """
+
+    # Try to get the data for the file we want
+    try:
+        response: requests.Response = requests.get(url, stream=stream)
+        progress_callback(1)  # 1 = download started
+    except OSError as e:
+        print(f'Error: Failed to make request to URL {url}, cannot complete download! Reason: {e}')
+        return False
+
+    # Figure out file size for reporting download progress    
+    if stream and response.headers.get('Transfer-Encoding', '').lower() == 'chunked':
+        print("Warning: Using 'stream=True' in request but 'Transfer-Encoding' in Response is 'Chunked', so we may not get 'Content-Length' to parse file size!")
+
+    # Sometimes ctmods can have access to the asset size, so they can give it to us
+    # If it is not specified, or if it is zero/Falsey, try to get it from the response
+    file_size = known_size
+    if not known_size:
+        file_size = int(response.headers.get('Content-Length', 0))
+
+        # Sometimes Content-Length is not sent (such as for DXVK Async), so use response length in that case
+        # See: https://stackoverflow.com/questions/53797628/request-has-no-content-length#53797919
+        #
+        # Only get response.content if we aren't streaming so that we don't hold up the entire function,
+        # and defeating the point of streaming to begin with
+        if not stream:
+            file_size = len(response.content)
+
+    if file_size <= 0:
+        print('Error: Failed to get file size, cannot download file!')
+        return False
+
+    # NOTE: If we don't get a known_size or if we can't get the size from Cotent-Length or the response size,
+    #       we cannot report download progress!
+    #
+    #       Right now, only GitLab doesn't give us Content-Length because it uses Chunked Transfer-Encoding,
+    #       but ctmods should be able to get the size and pass it as known_size.
+    #
+    #       If we ever make it this far without a file_size (e.g. we are stream=True and we don't get a
+    #       Content-Length, or len(response.content) is 0), then then the progress bar will stall at 1% until
+    #       the download finishes where it will jump to 99%, until extraction completes.
+    chunk_count = int(file_size / buffer_size)
+    current_chunk = 1
+
+    # Get download filepath and download directory path without filename
+    destination_file_path: str = os.path.expanduser(destination)
+    destination_dir_path: str = os.path.dirname(destination_file_path)
+
+    # Create download path if it doesn't exist (and make sure we have permission to do so)
+    try:
+        os.makedirs(destination_dir_path, exist_ok=True)
+    except OSError as e:
+        print(f'Error: Failed to create path to destination directory, cannot complete download! Reason: {e}')
+        return False
+    
+    # Download file and return progress to any given callback
+    with open(destination, 'wb') as destination_file:
+        for chunk in response.iter_content(chunk_size=buffer_size):
+            if download_cancelled:
+                progress_callback(-2)  # -2 = Download cancelled
+                return False
+
+            if not chunk:
+                continue
+
+            destination_file.write(chunk)
+            destination_file.flush()
+
+            download_progress = int(min(current_chunk / chunk_count * 98.0, 98.0))  # 1...98 = Download in progress
+            progress_callback(download_progress)
+
+            current_chunk += 1
+
+    progress_callback(99)  # 99 = Download completed successfully
+    return True
+

--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -47,8 +47,7 @@ def download_file(url: str, destination: str, progress_callback: Callable[[int],
             file_size = len(response.content)
 
     if file_size <= 0:
-        print('Error: Failed to get file size, cannot download file!')
-        return False
+        print('Warning: Failed to get file size, the progress bar may not display accurately!')
 
     # NOTE: If we don't get a known_size or if we can't get the size from Cotent-Length or the response size,
     #       we cannot report download progress!

--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -21,10 +21,11 @@ def download_file(url: str, destination: str, progress_callback: Callable[[int],
     # Try to get the data for the file we want
     try:
         response: requests.Response = requests.get(url, stream=stream)
-        progress_callback(1)  # 1 = download started
-    except OSError as e:
+    except (OSError, requests.ConnectionError, requests.Timeout) as e:
         print(f'Error: Failed to make request to URL {url}, cannot complete download! Reason: {e}')
         return False
+
+    progress_callback(1)  # 1 = download started
 
     # Figure out file size for reporting download progress    
     if stream and response.headers.get('Transfer-Encoding', '').lower() == 'chunked':

--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -5,7 +5,7 @@ import requests
 from typing import Callable
 
 
-def download_file(url: str, destination: str, progress_callback: Callable[[int], None], download_cancelled: Property | bool = None, buffer_size: int = 65536, stream: bool = True, known_size: int = 0):
+def download_file(url: str, destination: str, progress_callback: Callable[[int], None], download_cancelled: Property | None = None, buffer_size: int = 65536, stream: bool = True, known_size: int = 0):
     """
     Download a file from a given URL using `requests` to a destination directory with download progress, with some optional parameters:
     * `download_cancelled`: Qt Property that can stop the download

--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -24,7 +24,7 @@ def download_file(url: str, destination: str, progress_callback: Callable[[int],
     try:
         response: requests.Response = requests.get(url, stream=stream)
     except (OSError, requests.ConnectionError, requests.Timeout) as e:
-        print(f'Error: Failed to make request to URL {url}, cannot complete download! Reason: {e}')
+        print(f'Error: Failed to make request to URL '{url}', cannot complete download! Reason: {e}')
         raise e
 
     progress_callback(1)  # 1 = download started

--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -24,7 +24,7 @@ def download_file(url: str, destination: str, progress_callback: Callable[[int],
     try:
         response: requests.Response = requests.get(url, stream=stream)
     except (OSError, requests.ConnectionError, requests.Timeout) as e:
-        print(f'Error: Failed to make request to URL '{url}', cannot complete download! Reason: {e}')
+        print(f"Error: Failed to make request to URL '{url}', cannot complete download! Reason: {e}")
         raise e
 
     progress_callback(1)  # 1 = download started

--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -5,9 +5,10 @@ import requests
 from typing import Callable
 
 
-def download_file(url: str, destination: str, progress_callback: Callable[[int], None], download_cancelled: Property | None = None, buffer_size: int = 65536, stream: bool = True, known_size: int = 0):
+def download_file(url: str, destination: str, progress_callback: Callable[[int], None] | Callable[..., None] = lambda *args, **kwargs: None, download_cancelled: Property | None = None, buffer_size: int = 65536, stream: bool = True, known_size: int = 0):
     """
     Download a file from a given URL using `requests` to a destination directory with download progress, with some optional parameters:
+    * `progress_callback`: Function or Lambda that gets called with the download progress each time it changes
     * `download_cancelled`: Qt Property that can stop the download
     * `buffer_size`: Size of chunks to download the file in
     * `stream`: Lazily parse response - If response headers won't contain `'Content-Length'` and the file size is not known ahead of time, set this to `False` to get file size from response content length

--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -24,7 +24,7 @@ def download_file(url: str, destination: str, progress_callback: Callable[[int],
         response: requests.Response = requests.get(url, stream=stream)
     except (OSError, requests.ConnectionError, requests.Timeout) as e:
         print(f'Error: Failed to make request to URL {url}, cannot complete download! Reason: {e}')
-        return False
+        raise e
 
     progress_callback(1)  # 1 = download started
 
@@ -81,7 +81,7 @@ def download_file(url: str, destination: str, progress_callback: Callable[[int],
         os.makedirs(destination_dir_path, exist_ok=True)
     except OSError as e:
         print(f'Error: Failed to create path to destination directory, cannot complete download! Reason: {e}')
-        return False
+        raise e
     
     # Download file and return progress to any given callback
     with open(destination, 'wb') as destination_file:

--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -16,7 +16,7 @@ def download_file(url: str, destination: str, progress_callback: Callable[[int],
 
     Returns `True` if download succeeds, `False` otherwise.
 
-    Raises: OSError, requests.ConnectionError, requests.Timeout
+    Raises: `OSError`, `requests.ConnectionError`, `requests.Timeout`
     Return Type: bool
     """
 

--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -49,6 +49,10 @@ def download_file(url: str, destination: str, progress_callback: Callable[[int],
     if file_size <= 0:
         print('Warning: Failed to get file size, the progress bar may not display accurately!')
 
+    if buffer_size <= 0:
+        print(f"Warning: Buffer Size was '{buffer_size}', defaulting to '65536'")
+        buffer_size = 65536
+
     # NOTE: If we don't get a known_size or if we can't get the size from Cotent-Length or the response size,
     #       we cannot report download progress!
     #
@@ -58,7 +62,14 @@ def download_file(url: str, destination: str, progress_callback: Callable[[int],
     #       If we ever make it this far without a file_size (e.g. we are stream=True and we don't get a
     #       Content-Length, or len(response.content) is 0), then then the progress bar will stall at 1% until
     #       the download finishes where it will jump to 99%, until extraction completes.
-    chunk_count = int(file_size / buffer_size)
+
+    try:
+        chunk_count = int(file_size / buffer_size)
+    except ZeroDivisionError as e:
+        print(f'Error: Could not calculate chunk_count, {e}')
+        print('Defaulting to chunk count of 1')
+        chunk_count = 1
+
     current_chunk = 1
 
     # Get download filepath and download directory path without filename

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -74,9 +74,11 @@ class CtInstaller(QObject):
         except Exception as e:
             print(f"Failed to download tool {CT_NAME} - Reason: {e}")
 
-            msgbox_title: str = self.tr("Download Error!")
-            msgbox_text: str = self.tr("Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e))
-            self.message_box_message.emit(msgbox_title, msgbox_text, QMessageBox.Icon.Warning)
+            self.message_box_message.emit(
+                self.tr("Download Error!"),
+                self.tr("Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e)),
+                QMessageBox.Icon.Warning
+            )
 
     def __fetch_github_data(self, tag):
         """

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -74,13 +74,7 @@ class CtInstaller(QObject):
         except Exception as e:
             print(f"Failed to download tool {CT_NAME} - Reason: {e}")
 
-            ## TODO this causes a segfault and "The cached device pixel ratio value was stale on window expose.  Please file a QTBUG which explains how to reproduce."
-            # create_msgbox(
-            #     title=self.tr('Error!'),
-            #     text=self.tr("Failed to download tool {CT_NAME}".format(CT_NAME=CT_NAME)),
-            #     icon=QMessageBox.Warning,
-            #     detailed_text="{EXCEPTION}".format(EXCEPTION=e)
-            # )
+            self.message_box_message.emit("Error!", "Failed to download tool {CT_NAME}!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e), QMessageBox.Icon.Warning)
 
 
     def __fetch_github_data(self, tag):

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -74,7 +74,7 @@ class CtInstaller(QObject):
         except Exception as e:
             print(f"Failed to download tool {CT_NAME} - Reason: {e}")
 
-            self.message_box_message.emit("Error!", "Failed to download tool {CT_NAME}!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e), QMessageBox.Icon.Warning)
+            self.message_box_message.emit("Download Error!", "Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e), QMessageBox.Icon.Warning)
 
 
     def __fetch_github_data(self, tag):

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -9,7 +9,7 @@ from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 from PySide6.QtWidgets import QMessageBox
 
 from pupgui2.networkutil import download_file
-from pupgui2.util import extract_tar, write_tool_version
+from pupgui2.util import create_msgbox, extract_tar, write_tool_version
 from pupgui2.util import build_headers_with_authorization, create_missing_dependencies_message, fetch_project_release_data, fetch_project_releases
 
 
@@ -61,15 +61,27 @@ class CtInstaller(QObject):
         Return Type: bool
         """
 
-        return download_file(
-            url=url,
-            destination=destination,
-            progress_callback=self.__set_download_progress_percent,
-            download_cancelled=self.download_canceled,
-            buffer_size=self.BUFFER_SIZE,
-            stream=True,
-            known_size=known_size
-        )
+        try:
+            return download_file(
+                url=url,
+                destination=destination,
+                progress_callback=self.__set_download_progress_percent,
+                download_cancelled=self.download_canceled,
+                buffer_size=self.BUFFER_SIZE,
+                stream=True,
+                known_size=known_size
+            )
+        except Exception as e:
+            print(f"Failed to download tool {CT_NAME} - Reason: {e}")
+
+            ## TODO this causes a segfault and "The cached device pixel ratio value was stale on window expose.  Please file a QTBUG which explains how to reproduce."
+            # create_msgbox(
+            #     title=self.tr('Error!'),
+            #     text=self.tr("Failed to download tool {CT_NAME}".format(CT_NAME=CT_NAME)),
+            #     icon=QMessageBox.Warning,
+            #     detailed_text="{EXCEPTION}".format(EXCEPTION=e)
+            # )
+
 
     def __fetch_github_data(self, tag):
         """

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -9,8 +9,9 @@ from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 from PySide6.QtWidgets import QMessageBox
 
 from pupgui2.networkutil import download_file
-from pupgui2.util import create_msgbox, extract_tar, write_tool_version
-from pupgui2.util import build_headers_with_authorization, create_missing_dependencies_message, fetch_project_release_data, fetch_project_releases
+from pupgui2.util import extract_tar, write_tool_version, fetch_project_releases
+from pupgui2.util import fetch_project_release_data, build_headers_with_authorization
+from pupgui2.util import create_missing_dependencies_message
 
 
 CT_NAME = 'Luxtorpeda'

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -8,6 +8,7 @@ import requests
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 from PySide6.QtWidgets import QMessageBox
 
+from pupgui2.networkutil import download_file
 from pupgui2.util import extract_tar, write_tool_version
 from pupgui2.util import build_headers_with_authorization, create_missing_dependencies_message, fetch_project_release_data, fetch_project_releases
 
@@ -54,35 +55,21 @@ class CtInstaller(QObject):
         self.p_download_progress_percent = value
         self.download_progress_percent.emit(value)
 
-    def __download(self, url, destination):
+    def __download(self, url: str, destination: str, known_size: int = 0):
         """
         Download files from url to destination
         Return Type: bool
         """
-        try:
-            file = requests.get(url, stream=True)
-        except OSError:
-            return False
 
-        self.__set_download_progress_percent(1) # 1 download started
-        f_size = int(file.headers.get('content-length'))
-        c_count = int(f_size / self.BUFFER_SIZE)
-        c_current = 1
-        destination = os.path.expanduser(destination)
-        os.makedirs(os.path.dirname(destination), exist_ok=True)
-        with open(destination, 'wb') as dest:
-            for chunk in file.iter_content(chunk_size=self.BUFFER_SIZE):
-                if self.download_canceled:
-                    self.download_canceled = False
-                    self.__set_download_progress_percent(-2) # -2 download canceled
-                    return False
-                if chunk:
-                    dest.write(chunk)
-                    dest.flush()
-                self.__set_download_progress_percent(int(min(c_current / c_count * 98.0, 98.0))) # 1-98, 100 after extract
-                c_current += 1
-        self.__set_download_progress_percent(99) # 99 download complete
-        return True
+        return download_file(
+            url=url,
+            destination=destination,
+            progress_callback=self.__set_download_progress_percent,
+            download_cancelled=self.download_canceled,
+            buffer_size=self.BUFFER_SIZE,
+            stream=True,
+            known_size=known_size
+        )
 
     def __fetch_github_data(self, tag):
         """
@@ -131,7 +118,7 @@ class CtInstaller(QObject):
             return False
 
         luxtorpeda_tar = os.path.join(temp_dir, data['download'].split('/')[-1])
-        if not self.__download(url=data['download'], destination=luxtorpeda_tar):
+        if not self.__download(url=data['download'], destination=luxtorpeda_tar, known_size=data.get('size', 0)):
             return False
 
         luxtorpeda_dir = os.path.join(install_dir, self.extract_dir_name)

--- a/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
+++ b/pupgui2/resources/ctmods/ctmod_luxtorpeda.py
@@ -74,8 +74,9 @@ class CtInstaller(QObject):
         except Exception as e:
             print(f"Failed to download tool {CT_NAME} - Reason: {e}")
 
-            self.message_box_message.emit("Download Error!", "Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e), QMessageBox.Icon.Warning)
-
+            msgbox_title: str = self.tr("Download Error!")
+            msgbox_text: str = self.tr("Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e))
+            self.message_box_message.emit(msgbox_title, msgbox_text, QMessageBox.Icon.Warning)
 
     def __fetch_github_data(self, tag):
         """

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -55,15 +55,26 @@ class CtInstaller(QObject):
         Return Type: bool
         """
 
-        return download_file(
-            url=url,
-            destination=destination,
-            progress_callback=self.__set_download_progress_percent,
-            download_cancelled=self.download_canceled,
-            buffer_size=self.BUFFER_SIZE,
-            stream=True,
-            known_size=known_size
-        )
+        try:
+            return download_file(
+                url=url,
+                destination=destination,
+                progress_callback=self.__set_download_progress_percent,
+                download_cancelled=self.download_canceled,
+                buffer_size=self.BUFFER_SIZE,
+                stream=True,
+                known_size=known_size
+            )
+        except Exception as e:
+            print(f"Failed to download tool {CT_NAME} - Reason: {e}")
+
+            ## TODO this causes a segfault and "The cached device pixel ratio value was stale on window expose.  Please file a QTBUG which explains how to reproduce."
+            # create_msgbox(
+            #     title=self.tr('Error!'),
+            #     text=self.tr("Failed to download tool {CT_NAME}".format(CT_NAME=CT_NAME)),
+            #     icon=QMessageBox.Warning,
+            #     detailed_text="{EXCEPTION}".format(EXCEPTION=e)
+            # )
 
     def __fetch_data(self, tag: str = '') -> dict:
         """

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -70,7 +70,7 @@ class CtInstaller(QObject):
         except Exception as e:
             print(f"Failed to download tool {CT_NAME} - Reason: {e}")
 
-            self.message_box_message.emit("Error!", "Failed to download tool {CT_NAME}!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e), QMessageBox.Icon.Warning)
+            self.message_box_message.emit("Download Error!", "Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e), QMessageBox.Icon.Warning)
 
     def __fetch_data(self, tag: str = '') -> dict:
         """

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -9,7 +9,8 @@ import requests
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.networkutil import download_file
-from pupgui2.util import extract_tar, get_launcher_from_installdir, fetch_project_releases, fetch_project_release_data, build_headers_with_authorization
+from pupgui2.util import extract_tar, get_launcher_from_installdir, fetch_project_releases
+from pupgui2.util import fetch_project_release_data, build_headers_with_authorization
 from pupgui2.datastructures import Launcher
 
 

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -71,9 +71,11 @@ class CtInstaller(QObject):
         except Exception as e:
             print(f"Failed to download tool {CT_NAME} - Reason: {e}")
 
-            msgbox_title: str = self.tr("Download Error!")
-            msgbox_text: str = self.tr("Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e))
-            self.message_box_message.emit(msgbox_title, msgbox_text, QMessageBox.Icon.Warning)
+            self.message_box_message.emit(
+                self.tr("Download Error!"),
+                self.tr("Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e)),
+                QMessageBox.Icon.Warning
+            )
 
     def __fetch_data(self, tag: str = '') -> dict:
         """

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
 
 import os
+from PySide6.QtWidgets import QMessageBox
 import requests
 
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
@@ -25,6 +26,7 @@ class CtInstaller(QObject):
 
     p_download_progress_percent = 0
     download_progress_percent = Signal(int)
+    message_box_message = Signal((str, str, QMessageBox.Icon))
 
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
@@ -68,13 +70,7 @@ class CtInstaller(QObject):
         except Exception as e:
             print(f"Failed to download tool {CT_NAME} - Reason: {e}")
 
-            ## TODO this causes a segfault and "The cached device pixel ratio value was stale on window expose.  Please file a QTBUG which explains how to reproduce."
-            # create_msgbox(
-            #     title=self.tr('Error!'),
-            #     text=self.tr("Failed to download tool {CT_NAME}".format(CT_NAME=CT_NAME)),
-            #     icon=QMessageBox.Warning,
-            #     detailed_text="{EXCEPTION}".format(EXCEPTION=e)
-            # )
+            self.message_box_message.emit("Error!", "Failed to download tool {CT_NAME}!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e), QMessageBox.Icon.Warning)
 
     def __fetch_data(self, tag: str = '') -> dict:
         """

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -5,8 +5,6 @@
 import os
 import requests
 
-from typing import Dict
-
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.networkutil import download_file
@@ -67,8 +65,7 @@ class CtInstaller(QObject):
             known_size=known_size
         )
 
-    def __fetch_data(self, tag: str = '') -> Dict:
-
+    def __fetch_data(self, tag: str = '') -> dict:
         """
         Fetch release information
         Return Type: dict

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -70,7 +70,9 @@ class CtInstaller(QObject):
         except Exception as e:
             print(f"Failed to download tool {CT_NAME} - Reason: {e}")
 
-            self.message_box_message.emit("Download Error!", "Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e), QMessageBox.Icon.Warning)
+            msgbox_title: str = self.tr("Download Error!")
+            msgbox_text: str = self.tr("Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e))
+            self.message_box_message.emit(msgbox_title, msgbox_text, QMessageBox.Icon.Warning)
 
     def __fetch_data(self, tag: str = '') -> dict:
         """

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -637,7 +637,7 @@ def fetch_project_release_data(release_url: str, release_format: str, rs: reques
     Fetch information about a given release based on its tag, with an optional condition lambda.
     Return Type: dict
     Content(s):
-        'version', 'date', 'download'
+        'version', 'date', 'download', 'size' (if available)
     """
 
     date_key: str = ''


### PR DESCRIPTION
## Overview
This PR adds a new utility function, `download_file`, which takes the repeated download code in ctmods and turns it into a generic function.

This function lives in a new file, `networkutil.py`, and in future we can refactor and move the other network-related functions in here. Instead of further polluting `util.py` I figured I'd make a new file, which should also hopefully reduce the load when refactoring and moving the other methods for fetching from GitHub/GitLab into this file. Doing this should also aid in writing tests!

## Background
Each ctmod has to download the respective archive from its API. In almost every ctmods case (or *maybe actually for all of them*) the code is duplicated and does the same thing:
- Make a request to the API endpoint
- Figure out the filesize
- Figure out how many chunks we need to download in based on the file size and buffer size
    - So if we want to download `65536` bytes at a time, when downloading we only load `65536` bytes into memory at a time when downloading.
    - Since we `stream` the request, we can do this lazily and overall save on memory.
    - Using chunks also lets us figure out the download progress
- Create the destination path _and_ file to write the bytes of the response content into
- Loop over the response content as per the buffer size (i.e. `65536` bytes at a time)
    - Stop the download if it was cancelled at any point (i.e. ProtonUp-Qt closes)
    - If we have a valid chunk, write it into the file
    - Figure out the download progress and emit it to the progress bar
- Return `True` if download succeeded, `False` otherwise

This is a repeated 25 lines or so across each ctmod. Each time we create a new ctmod this is copied and pasted. If we ever had to adjust this we would have to potentially touch quite a few ctmods. A base ctmod class may resolve this somewhat but in the meantime it puts complexity for a generic action inside of a ctmod. There is a better way!

## The Better Way
(Okay, "better way" is an exaggeration :smile:)

The tl;dr is that we now have a util function that can download files. It is a close copy of each ctmod's `__download` method but has more catches for handling errors, and also has better logic for grabbing the file size by allowing us to pass a known file size, so we can consistently work out the download progress, even if `Content-Length` is blank, without needing to resort to `len(response.content)` which defeats the purpose of streaming the file and stalls the function call. We should have the file size head of time in most cases as when using `fetch_project_release_data` one of the fields we try to parse from the assets list is the filesize. GitHub and GitLab should have the `size` in its data, but GitLab is the only one that doesn't have `Content-Length` in the response headers because it uses `Transfer-Encoding: Chunked`. So instead of using `len(response.content)` we can use the known `size` to work out the download progress. This also means this new util function fixes the currently broken DXVK Async progress bar.

Instead of repeating all of this logic in each ctmod, we can make a util function for this. Downloading files is a very generic action  we would *generally* want to use the same implementation, at least when it comes to ctmods.

So that's what this PR does. I re-wrote the ctmod download function by hand, added in some extra try/except checks, and even did a little extra spice I'll talk about in a second.

The function takes the following parameters:
- **Required**: The URL to download from, as standard
- **Required**: The destination path to download to, again as standard
- **Required**: The `progress_callback` which is a function we can call from inside our download function to send the download progress
    - For us, this is the `__set_download_progress_percent` method on each ctmod that handles emitting to the progress bar! This is how we update the progress from inside this function.
-  **Optional**:  `download_cancelled` property, which is a `Property` class specific to Qt. We use this to manage if the download was cancelled on-the-fly (i.e. if ProtonUp-Qt was closed)
    - I am not so comfortable with this. `Property` is specific to Qt, which makes this function far less generic than I'd like. The only alternative I found was to use some kind of async signals that Python has, but then that becomes a bit *too* generic. So I think using `Property` was the path of least resistance.
    - It is optional at least, since if we used this elsewhere we may not care about cancelling the download.
- **Optional**: The `buffer_size` which defaults to the same as what most ctmods use, `65536`
- **Optional**: The `stream` boolean given to `requests.get` to know whether to `stream` the request or not. This defaults to `True`, which is what the current ctmod download method uses.
    - This is allowed to be defined for a specific reason I'll discuss below
- **Optional**: The `known_size` which is the size of the file we want to download, if we know it ahead of time we can pass it in meaning we don't have to rely on `Content-Length` which may not always be available, and we may not always be able to get the file size (meaning we won't be able to calculate the download progress)
    - This defaults to `0` which means we fall back to trying to figure out the file size ourselves.

A lot of this is pretty standard, but being able to specify `stream` and `known_size` might seem strange, so I'll explain. This is the "extra spice" I was talking about!

### Getting the File Size to Calculate Download Progress 
Currently when we download files, we pretty much always use `stream=True`. This won't load the whole request to my knowledge, saving on memory. We then get the file size by taking it from the response's `Content-Length` header. _But_, this header is not always available. It should always be given when making a request to GitHub, but GitLab does not send it.

The reason GitLab does not send this header is because it uses a `Transfer-Encoding` type of `Chunked`. This basically downloads  the files in chunks already I guess. But this means we can't get the file size! To work around this in #302, I simply used `len(response.content)` based on guidance in [this StackOverflow answer](https://stackoverflow.com/questions/53797628/request-has-no-content-length#53797919). But this has two problems:
- This defeats the whole purpose of `stream=True` as it loads the entire response.
- This stalls the function. As a result, the download progress does not work properly for DXVK Async. The progress bar goes to 1% and then zooms up to 98-99%, and then extracts very quickly.

In other words, right now, if we don't have `Content-Type`, we can't set the download progress properly.

However, we aren't defeated yet! When we grab the `asset` we want to download from GitHub or GitLab using `fetch_project_release_data` we can get back the `size` from the release asset. This should be available on release API responses for both GitHub and GitLab, but we only *need* it for GitLab because we have no other way of getting the file size without resorting to `len(response.content)`, which is undesirable for the reasons above.

So when we call our new util function, it will do the following to figure out the filesize:
- If we gave it a `known_size` above 0, we will use this.
- Otherwise
    - Try to set the file size to the `Content-Length` header value
    - If we don't have the `Content-Length` header:
        - Try to use `len(response.content)` to get the file size, but ONLY if we are NOT streaming the response.
        - This is because if we try to do this we won't even end up reporting the progress anyway, and it would defeat the purpose of passing `stream=True`.
            - If we know we won't have a known filesize, we should set `stream=False` when calling the util function.
- If after all this the filesize is still `0`, print an error and `return False` because if we don't have the file size we can't report the download progress, resulting in a broken progress bar (and we are probably using the function wrong in such a scenario).

This is why we can pass whether or not to `stream` the response, and why we can pass a known file size to the function. If we already have the size when calling the function, there is no need to fetch it in the function, we should prefer our known size. Similarly if we know we won't get `Content-Length` back in our response headers (such as if we know we're making a GitLab API call *without* a known file size ahead of time) then we can pass `stream=False` so that we load the request response upfront when making the call.

And because we can pass `known_size` to this util function, this means our GitLab calls now have fixed progress bars! DXVK Async is the only GitLab call we make right now, and it has a broken progress bar because we have to use `len(response.content)`. This results in the progress bar going to 1% and then when the download finishes it goes to 99% when the function ends. With this PR, the progress bar works correctly. 

The explanation may be a bit long-winded but I hope it helps illustrate what the function does similarly and differently, why I made certain choices, and the benefits of those choices. It basically allows us to set the file size ahead of time if we know it instead of relying on the response which may not always give us the results we want, and for ctmods we should usually have this in the `data` dict anyway.

## Implementation
Now that explanation of how it works is out of the way, here's how the function is implemented in this PR.

I decided to only refactor the `__download` call in two ctmods for now: DXVK (includes DXVK Async) and Luxtorpeda (includes Boxtron and Roberta). The rationale here is that we modify a lower-risk ctmod for each launcher; DXVK for Lutris and Heroic, Luxtorpeda for Steam.

Modifying these ctmods acts as a "proof of concept" for this util function and to serve as a base implementation. I think I did something similar with the other network functions for refactoring how we fetch the release information for each ctmod.  

With this change the DXVK and Luxtorpeda ctmods look a lot cleaner in my opinion. The majority of the complexity is now stripped out and replaced behind generic functions. The only remaining complexity in these ctmods really is the boilerplate ctmod stuff and the extraction logic probably being better suited to go behind an `__extract_tool` method in each ctmod. But it is overall much cleaner now in my opinion!

## Concerns
I am not sure if we should fail if we cannot get the file size. Right now we fall over in that case by returning `False` but let me know if we should just print a warning and continue!

Also, I am unsure if we should have any catches around writing to the file in case it fails. We have this brand new function so we might as well try to make it as safe as possible. We already have some new catches in place.

And I am also concerned that the function may not be as generic as it could be. Please let me know if there is anything I can improve with it!

## Remaining work
I think the remaining thing is to add in the ability to take a request's session, i.e. each ctmod's `self.rs`. But I'll let this be reviewed in its current state first :smile: 

Apart from that, we can either add other ctmods in this PR or do them in follow-up PRs. I would prefer to do them in follow-up PRs personally but I understand wanting to get them all out of the way in this PR!

<hr>

I hope this is seen as a welcome change. I have an interest in improving things like this around the codebase where possible, and doing it in a maintainable way. Breaking things into generic functions that we can use around the codebase as well as eventually moving things into separate files (such as breaking up `util.py` a bit more), is something I hope can bring "architectural" improvements to the codebase :smile: 

ProtonUp-Qt is my reference when I start a personal Python project so any enhancements on the technical side might help others that do the same. And it might also help others get into contributing if we can break apart complexity into smaller re-usable chunks. Plus, this PR actually fixes a small bug, so it has some user-facing impact too!

As usual all feedback is welcome. Thanks!

P.S. The diff for this is more into the additions than deletions, but as this gets extended to more ctmods, the lines removed will outweigh the lines added. The initial additions cost comes from writing the function, which is a bit large.