### PR TITLE
CID: Add WineZGUI

### DIFF
--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -25,7 +25,8 @@ class PupguiCustomInstallDirectoryDialog(QObject):
             'lutris': 'Lutris',
             'heroicwine': 'Heroic (Wine)',
             'heroicproton': 'Heroic (Proton)',
-            'bottles': 'Bottles'
+            'bottles': 'Bottles',
+            'winezgui': 'WineZGUI',
         }
 
         self.load_ui()


### PR DESCRIPTION
WineZGUI was missing from the Custom Install Dialog dropdown. Sorry that I didn't find this in time for v2.10.0 (v.2.10.2?)'s release :sweat_smile: 