### PR TITLE
CID: Remove prints, some small cleanup+type hints

### DIFF
--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -93,8 +93,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         if not ctool_name:
             return
 
-        index = get_combobox_index_by_value(self.ui.comboLauncher, ctool_name)
-        if index >= 0:
+        if (index := get_combobox_index_by_value(self.ui.comboLauncher, ctool_name)) >= 0:
             self.ui.comboLauncher.setCurrentIndex(index)
 
     def is_valid_custom_install_path(self, path: str) -> bool:

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -59,14 +59,13 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.ui.txtInstallDirectory.textChanged.connect(lambda text: self.ui.btnSave.setEnabled(self.is_valid_custom_install_path(text)))
 
     def btn_save_clicked(self):
-        install_dir = os.path.expanduser(self.ui.txtInstallDirectory.text().strip())
+        install_dir: str = os.path.expanduser(self.ui.txtInstallDirectory.text().strip())
         if not install_dir.endswith(os.sep):
             install_dir += '/'
         launcher = get_dict_key_from_value(self.install_locations_dict, self.ui.comboLauncher.currentText()) or ''
 
         if self.is_valid_custom_install_path(install_dir):
             config_custom_install_location(install_dir, launcher)
-            print(f'New Custom Install Directory set to: {install_dir}')
 
         self.custom_id_set.emit(install_dir)
         self.ui.close()
@@ -74,13 +73,12 @@ class PupguiCustomInstallDirectoryDialog(QObject):
     def btn_default_clicked(self):
         self.ui.txtInstallDirectory.setText('')
         config_custom_install_location(remove=True)
-        print(f'Removed custom install directory')
 
         self.custom_id_set.emit('')
 
     def txt_id_browse_action_triggered(self):
         # Open dialog at entered path if it exists, and fall back to HOME_DIR
-        txt_install_dir = os.path.expanduser(self.ui.txtInstallDirectory.text())
+        txt_install_dir: str = os.path.expanduser(self.ui.txtInstallDirectory.text())
         initial_dir = txt_install_dir if self.is_valid_custom_install_path(txt_install_dir) else HOME_DIR
 
         dialog = QFileDialog(self.ui, directory=initial_dir)
@@ -92,10 +90,12 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         dialog.open()
 
     def set_selected_launcher(self, ctool_name: str):
-        if ctool_name:
-            index = get_combobox_index_by_value(self.ui.comboLauncher, ctool_name)
-            if index >= 0:
-                self.ui.comboLauncher.setCurrentIndex(index)
+        if not ctool_name:
+            return
+
+        index = get_combobox_index_by_value(self.ui.comboLauncher, ctool_name)
+        if index >= 0:
+            self.ui.comboLauncher.setCurrentIndex(index)
 
     def is_valid_custom_install_path(self, path: str) -> bool:
         expand_path = os.path.expanduser(path)

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Union, Tuple, Optional, Callable
 
 import PySide6
 from PySide6.QtCore import QCoreApplication
-from PySide6.QtWidgets import QApplication, QStyleFactory, QMessageBox, QCheckBox
+from PySide6.QtWidgets import QApplication, QComboBox, QStyleFactory, QMessageBox, QCheckBox
 
 from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS, CONFIG_FILE, PALETTE_DARK, TEMP_DIR, IS_FLATPAK
 from pupgui2.constants import AWACY_GAME_LIST_URL, LOCAL_AWACY_GAME_LIST
@@ -698,7 +698,7 @@ def get_dict_key_from_value(d, searchval):
         return None
 
 
-def get_combobox_index_by_value(combobox, value: str) -> int:
+def get_combobox_index_by_value(combobox: QComboBox, value: str) -> int:
     """
     Get the index in a combobox where a text value is located.
     Returns an integer >= 0 if found, otherwise -1.
@@ -706,10 +706,12 @@ def get_combobox_index_by_value(combobox, value: str) -> int:
     Return Type: int
     """
 
-    if value:
-        for i in range(combobox.count()):
-            if value == combobox.itemText(i):
-                return i
+    if not value:
+        return -1
+
+    for i in range(combobox.count()):
+        if value == combobox.itemText(i):
+            return i
 
     return -1
 


### PR DESCRIPTION
For #432 I was in and around the code for the Custom Install Dialog and found a couple of spots where I could make some changes.
- Remove unnecessary `print`s
- Add type hints for a couple of potentially ambiguous scenarios (not sure if we want to go all the day with the hints here, just added it for places where it might not be immediately obvious, mainly the `os.path.expanduser` calls)
- Reworked `set_selected_launcher` to be less nested ("Flat is better than nested" :wink:)
- Refactor + Type Hint for `util#get_combobox_index_by_value` to be less nested`