### PR TITLE
test_util: Improve type hints for `test_get_random_game_name`

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -883,14 +883,14 @@ def create_missing_dependencies_message(ct_name: str, dependencies: List[str]) -
     return tr_msg, False
 
 
-def get_random_game_name(games: List[Union[SteamApp, LutrisGame, HeroicGame]]) -> str:
+def get_random_game_name(games: list[SteamApp] | list[LutrisGame] | list[HeroicGame]) -> str:
     """ Return a random game name from list of SteamApp, LutrisGame, or HeroicGame """
 
     if len(games) <= 0:
         return ''
     
-    tooltip_game_name = ''
-    random_game = random.choice(games)
+    tooltip_game_name: str = ''
+    random_game: SteamApp | LutrisGame | HeroicGame = random.choice(games)
     if type(random_game) is SteamApp:
         tooltip_game_name = random_game.game_name
     elif type(random_game) is LutrisGame:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,13 +3,15 @@ from pupgui2.util import *
 from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame
 
 
-def test_get_random_game_name():
-    """ test whether get_random_game_name returns a valid game name """
-    names = ["game", "A super cool game", "A game with a very long name that is very long", "0123456789"]
+def test_get_random_game_name() -> None:
 
-    steam_app = [SteamApp() for _ in range(len(names))]
-    lutris_game = [LutrisGame() for _ in range(len(names))]
-    heroic_game = [HeroicGame() for _ in range(len(names))]
+    """ Test whether get_random_game_name returns a valid game name for each launcher game type. """
+
+    names: list[str] = ["game", "A super cool game", "A game with a very long name that is very long", "0123456789"]
+
+    steam_app: list[SteamApp] = [SteamApp() for _ in range(len(names))]
+    lutris_game: list[LutrisGame] = [LutrisGame() for _ in range(len(names))]
+    heroic_game: list[HeroicGame] = [HeroicGame() for _ in range(len(names))]
 
     for i, name in enumerate(names):
         steam_app[i].game_name = name


### PR DESCRIPTION
Improve type hints for the unit test `test_get_random_game_name`, which also leads to improving the type hints for the `util#get_random_game_name` function, which was incorrect (it was hinting for a single list which could have Steam Games, Lutris Games, and/or Heroic Games, instead of a list which would _only_ contain one of these types rather than any combination).

This also means we get rid of some deprecated types in `util.py`.

Adding hints to unit tests and the functions they are testing is a good pairing imo; we are improving the hints of the actual function, and being explicit about the types we are expecting in our tests.