### PR TITLE
test_util: Add test for `get_launcher_from_installdir`

### DIFF
--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -233,3 +233,4 @@ class Launcher(Enum):
     LUTRIS = 2
     BOTTLES = 3
     HEROIC = 4
+    WINEZGUI = 5

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -846,7 +846,6 @@ def get_launcher_from_installdir(install_dir: str) -> Launcher:
     """
 
     if any(steam_path in install_dir.lower() for steam_path in ['steam/compatibilitytools.d', 'steam/root/compatibilitytools.d']):
-    # if 'steam/compatibilitytools.d' in install_dir.lower():
         return Launcher.STEAM
     elif 'lutris/runners' in install_dir.lower():
         return Launcher.LUTRIS

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -845,7 +845,8 @@ def get_launcher_from_installdir(install_dir: str) -> Launcher:
     Return Type: Launcher (Enum)
     """
 
-    if 'steam/compatibilitytools.d' in install_dir.lower():
+    if any(steam_path in install_dir.lower() for steam_path in ['steam/compatibilitytools.d', 'steam/root/compatibilitytools.d']):
+    # if 'steam/compatibilitytools.d' in install_dir.lower():
         return Launcher.STEAM
     elif 'lutris/runners' in install_dir.lower():
         return Launcher.LUTRIS
@@ -853,6 +854,8 @@ def get_launcher_from_installdir(install_dir: str) -> Launcher:
         return Launcher.HEROIC
     elif 'bottles/runners' in install_dir.lower():
         return Launcher.BOTTLES
+    elif 'winezgui/runners' in install_dir.lower():
+        return Launcher.WINEZGUI
     else:
         return Launcher.UNKNOWN
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
 requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "."
+]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,41 @@
 from pupgui2.util import *
 
-from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame
+from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS
+from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame, Launcher
+
+
+def test_get_launcher_from_installdir() -> None:
+
+    """
+    Test whether get_laucher_from_installdir returns the correct Launcher type Enum from the installdir path.
+    """
+
+    # All possible Steam paths
+    steam_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'steam' ]
+    steam_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(steam_path) for steam_path in steam_install_paths ]
+
+    # All possible Lutris paths
+    lutris_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'lutris' ]
+    lutris_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(lutris_path) for lutris_path in lutris_install_paths ]
+
+    # All possible Heroic paths
+    heroic_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] in ['heroicwine', 'heroicproton'] ]
+    heroic_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(heroic_path) for heroic_path in heroic_install_paths ]
+
+    # All possible Bottles paths
+    bottles_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'bottles' ]
+    bottles_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(bottles_path) for bottles_path in bottles_install_paths ]
+
+    # All possible Bottles paths
+    winezgui_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'winezgui' ]
+    winezgui_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(winezgui_path) for winezgui_path in winezgui_install_paths ]
+
+
+    assert all(launcher == Launcher.STEAM for launcher in steam_install_path_tests)
+    assert all(launcher == Launcher.LUTRIS for launcher in lutris_install_path_tests)
+    assert all(launcher == Launcher.HEROIC for launcher in heroic_install_path_tests)
+    assert all(launcher == Launcher.BOTTLES for launcher in bottles_install_path_tests)
+    assert all(launcher == Launcher.WINEZGUI for launcher in winezgui_install_path_tests)
 
 
 def test_get_random_game_name():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -26,7 +26,7 @@ def test_get_launcher_from_installdir() -> None:
     bottles_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'bottles' ]
     bottles_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(bottles_path) for bottles_path in bottles_install_paths ]
 
-    # All possible Bottles paths
+    # All possible WineZGUI paths
     winezgui_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'winezgui' ]
     winezgui_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(winezgui_path) for winezgui_path in winezgui_install_paths ]
 


### PR DESCRIPTION
This PR adds a unit test for `get_launcher_from_installdir`. It pulls the known `'install_dir'` for each launcher type from `POSSIBLE_INSTALL_LOCATIONS` from `constants.py` using a list comprehension. For Steam this might look like `[ '~/.local/share/Steam', '~/.snap/steam/root/compatibilitytools.d' ]`. We then create a list comprehension to store the result of `get_launcher_from_installdir`, and if the function works correctly we should get a list that contains the correct Launcher enum value. For Steam, this should look like `[ Launcher.STEAM, Launcher.STEAM ]` for example. Finally we assert that all of the values in the list containing the result of `get_launcher_from_installdir` for all the known `install_dir`s for that launcher, contain the expected Launcher enum type. For example with Steam, this would assert that all of the paths returned `Launcher.STEAM`.

In the process of adding this test, I found a couple of defects with the function:
- We didn't account for the Steam Snap path, which is slightly different with `steam/root/compatibilitytools.d` instead of just `steam/compatibilitytools.d`. I'm not sure if internally this is a symlink that gets expanded out, but the way we describe it in `constants.py` doesn't account for it as a symlink, so the test was failing because of this missing path.
- WineZGUI was missing from this function.

<hr>

The logic in this test is a bit repetitive, but I think that's fine, since if we automated it we'd want to test that somewhat too. There probably is room to reduce duplication but I think for tests it's acceptable to keep them repetitive like this. But let me know what you think and if you have some better suggestions! This is my first time playing around with PyTest :-)

<hr>

One thing I found when writing this is that getting PyTest running locally was a bit tricky. I had to make this change to `pyproject.toml` (I found this from [this StackOveflow answer](https://stackoverflow.com/a/49033954).):

```toml
[tool.pytest.ini_options]
pythonpath = [
  "."
]
```

However since this is working fine on CI, I am not sure if this is a breaking change, or if I configured something wrong on my PC. I included the file in this PR just in case.