### PR TITLE
dbusutil: Type hinting improvements

### DIFF
--- a/pupgui2/dbusutil.py
+++ b/pupgui2/dbusutil.py
@@ -6,11 +6,15 @@ from PySide6.QtDBus import QDBusConnection, QDBusMessage
 from pupgui2.constants import DBUS_APPLICATION_URI, DBUS_DOWNLOAD_OBJECT_BASEPATH, DBUS_INTERFACES_AND_SIGNALS
 
 
-def create_and_send_dbus_message(object: str, interface: str, signal_name: str, arguments: list[Any], bus: QDBusConnection | None = None) -> None:
+def create_and_send_dbus_message(object: str, interface: str, signal_name: str, arguments: list[Any], bus: QDBusConnection | None = None) -> bool:
 
     """
     Create and send a QDBusMessage over a given bus.
     If no bus is given, will default to sessionBus
+
+    Returns `True` if the message was sent to DBus successfully, `False` otherwise.
+
+    Return Type: bool
     """
 
     if bus is None:
@@ -24,14 +28,20 @@ def create_and_send_dbus_message(object: str, interface: str, signal_name: str, 
 
     # Don't send the message if bus is not valid (i.e. DBus is not running)
     if bus.isConnected():
-        _ = bus.send(message)
+        return bus.send(message)
+
+    return False
 
 
-def dbus_progress_message(progress: float, count: int = 0, bus: QDBusConnection | None = None) -> None:
+def dbus_progress_message(progress: float, count: int = 0, bus: QDBusConnection | None = None) -> bool:
 
     """
     Create and send download progress (between 0 and 1) information with optional count parameter on a given bus.
     If no bus is given, will default to sessionBus.
+
+    Returns `True` if the message was sent to DBus successfully, `False` otherwise.
+
+    Return Type: bool
     """
 
     if bus is None:
@@ -59,6 +69,6 @@ def dbus_progress_message(progress: float, count: int = 0, bus: QDBusConnection 
     signal: str = launcher_entry_update['signal']
     object = 'Update'
 
-    create_and_send_dbus_message(object, interface, signal, message_arguments, bus=bus)
+    return create_and_send_dbus_message(object, interface, signal, message_arguments, bus=bus)
 
 

--- a/pupgui2/dbusutil.py
+++ b/pupgui2/dbusutil.py
@@ -37,7 +37,7 @@ def dbus_progress_message(progress: float, count: int = 0, bus: QDBusConnection 
     if bus is None:
         bus = QDBusConnection.sessionBus()
 
-    arguments: dict[str, Any] = {
+    arguments: dict[str, int | float | bool] = {
         'progress': progress,
         'progress-visible': progress >= 0 and progress < 1,
         'count': count,
@@ -48,7 +48,7 @@ def dbus_progress_message(progress: float, count: int = 0, bus: QDBusConnection 
     # plus an 'arguments' dict with some extra information
     #
     # i.e. { 'progress': 0.7, 'progress-visible': True }
-    message_arguments: list[str | dict[str, Any]] = [
+    message_arguments: list[str | dict[str, int | float | bool]] = [
         DBUS_APPLICATION_URI,
         arguments
     ]

--- a/pupgui2/dbusutil.py
+++ b/pupgui2/dbusutil.py
@@ -1,36 +1,43 @@
 import os
+from typing import Any
 
 from PySide6.QtDBus import QDBusConnection, QDBusMessage
 
 from pupgui2.constants import DBUS_APPLICATION_URI, DBUS_DOWNLOAD_OBJECT_BASEPATH, DBUS_INTERFACES_AND_SIGNALS
 
 
-def create_and_send_dbus_message(object: str, interface: str, signal_name: str, arguments: list, bus: QDBusConnection = QDBusConnection.sessionBus):
+def create_and_send_dbus_message(object: str, interface: str, signal_name: str, arguments: list[Any], bus: QDBusConnection | None = None) -> None:
 
     """
     Create and send a QDBusMessage over a given bus.
     If no bus is given, will default to sessionBus
     """
 
+    if bus is None:
+        bus = QDBusConnection.sessionBus()
+
     # i.e. /net/davidotek/pupgui2/Update
-    object_path = os.path.join(DBUS_DOWNLOAD_OBJECT_BASEPATH, object)
+    object_path: str = os.path.join(DBUS_DOWNLOAD_OBJECT_BASEPATH, object)
 
     message: QDBusMessage = QDBusMessage.createSignal(object_path, interface, signal_name)
     message.setArguments(arguments)
 
     # Don't send the message if bus is not valid (i.e. DBus is not running)
     if bus.isConnected():
-        bus.send(message)
+        _ = bus.send(message)
 
 
-def dbus_progress_message(progress: float, count: int = 0, bus: QDBusConnection = QDBusConnection.sessionBus()):
+def dbus_progress_message(progress: float, count: int = 0, bus: QDBusConnection | None = None) -> None:
 
     """
     Create and send download progress (between 0 and 1) information with optional count parameter on a given bus.
     If no bus is given, will default to sessionBus.
     """
 
-    arguments = {
+    if bus is None:
+        bus = QDBusConnection.sessionBus()
+
+    arguments: dict[str, Any] = {
         'progress': progress,
         'progress-visible': progress >= 0 and progress < 1,
         'count': count,
@@ -41,15 +48,15 @@ def dbus_progress_message(progress: float, count: int = 0, bus: QDBusConnection 
     # plus an 'arguments' dict with some extra information
     #
     # i.e. { 'progress': 0.7, 'progress-visible': True }
-    message_arguments = [
+    message_arguments: list[str | dict[str, Any]] = [
         DBUS_APPLICATION_URI,
         arguments
     ]
 
-    launcher_entry_update = DBUS_INTERFACES_AND_SIGNALS['LauncherEntryUpdate']
+    launcher_entry_update: dict[str, str] = DBUS_INTERFACES_AND_SIGNALS['LauncherEntryUpdate']
     
-    interface = launcher_entry_update['interface']
-    signal = launcher_entry_update['signal']
+    interface: str = launcher_entry_update['interface']
+    signal: str = launcher_entry_update['signal']
     object = 'Update'
 
     create_and_send_dbus_message(object, interface, signal, message_arguments, bus=bus)

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -106,7 +106,7 @@ class MainWindow(QObject):
         self.msgcb_answer_lock = QMutex()
 
         self.dbus_session_bus = QDBusConnection.sessionBus()
-        dbus_progress_message(-1, 0)  # Reset any previously set download information to be blank
+        _ = dbus_progress_message(-1, 0)  # Reset any previously set download information to be blank
 
         self.load_ui()
         self.setup_ui()
@@ -201,7 +201,7 @@ class MainWindow(QObject):
         if progress < 0:  # negative progress indicates cancellation/failure/etc
             num_downloads = 0
 
-        dbus_progress_message(progress_pct, num_downloads, self.dbus_session_bus)
+        _ = dbus_progress_message(progress_pct, num_downloads, self.dbus_session_bus)
 
     def update_combo_install_location(self, custom_install_dir = None):
         self.updating_combo_install_location = True
@@ -594,5 +594,5 @@ def main():
     if IS_FLATPAK and len(os.listdir(STEAM_STL_INSTALL_PATH)) == 0:
         subprocess.run(['flatpak-spawn', '--host', 'rm', '-r', STEAM_STL_INSTALL_PATH])
 
-    dbus_progress_message(-1, 0)  # Reset any previously set download information to be blank
+    _ = dbus_progress_message(-1, 0)  # Reset any previously set download information to be blank
     sys.exit(ret)


### PR DESCRIPTION
This PR improves the type hinting in `dbusutil`.
- Fixes the default argument for `bus`. basedPyright was warning "Function calls and mutable objects not allowed within parameter default value expression", and when looking it up, [it seems this is for good reason](https://www.inspiredpython.com/article/watch-out-for-mutable-defaults-in-function-arguments). This has been replaced with defaulting the parameter to `None` and if it is `None`, assign it to `QDBusConnection.sessionBus` inside of the function body.
    - This extra definition isn't typed because then it flags up a shadowed definition warning, even if the original hinting was possibly `None` and you just want to state in the re-definition that it will never be `None` (I guess the expectation is  that the code speaks for itself, and basedPyright is able to infer that the type will never be `None`)
    - In `create_and_send_dbus_message` I accidentally set it as `QDBusConnection.sessionBus` without the parentheses, so if we ever actually called this without `bus` it would probably have crashed!
- Typed the variables used in the functions that weren't explicitly clear or that came from values accessed from `constants.py`'s `DBUS_INTERFACES_AND_SIGNALS` constant.
    - The arguments dict is typed as `dict[str, Any]` in `create_and_send_dbus_message` because DBus should always get a string key (e.g. `progress`) but the actual value given could be `Any`thing depending on what signal we give.
    - I chose to explicitly type the dict in `dbus_progress_message` because we know what the valid values are for this dict, we know that it should only ever have an int, float, or boolean as values (int/float for progress, int for count, and bool for the visibility indicators).
- Assigned the result of `bus.send` to `_` to make it explicit that `bus.send` does return a value, but we don't capture it (this was flagged up by basedPyright). The `bus.send` cal returns a `bool` (I assume a success boolean). Ignoring this is something we might want to discuss for a couple of reasons.
    - Do we actually want to ignore this, or do we want to return a `bool` from these functions? Right now we don't consume any return at all when we call this so we'd have to move the `_ =` pattern up a level into the caller of this function, but it's up to you.
        - I would personally lean more into returning the `bool` from these functions but just ignoring it at the caller level, so that we have the return if we ever decide we want it (e.g. for unit tests)
    - Is this `_ =` ignore pattern we want to have in place across the codebase? I'm cautious of doing things just to appease a checker, but it can make it clear that a function is expected to return a value, but that we aren't using it.
    - I have no preference, and it's fine if we want to ignore the pattern for now and leave this for a discussion in #417.

Just some general typing improvements with this one, motivated by a desire to write some form of test for `dbusutil`. It helps a lot to have good hinting for tests alone it feels like from my (albeit brief) experience, and usage and readability of course is also helped :smile: 