### PR TITLE
test_util: Add test for `get_dict_key_from_value`

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -13,7 +13,7 @@ import random
 import zstandard
 
 from configparser import ConfigParser
-from typing import Dict, List, Union, Tuple, Optional, Callable
+from typing import Any, Dict, List, Union, Tuple, Optional, Callable
 
 import PySide6
 from PySide6.QtCore import QCoreApplication
@@ -686,11 +686,15 @@ def compat_tool_available(compat_tool: str, ctobjs: List[dict]) -> bool:
     return compat_tool in [ctobj['name'] for ctobj in ctobjs]
 
 
-def get_dict_key_from_value(d, searchval):
+def get_dict_key_from_value(d: dict[Any, Any], searchval: Any) -> Any:
+
     """
     Fetch a given dictionary key from a given value.
     Returns the given value if found, otherwise None.
+
+    Return Type: Any
     """
+
     for key, value in d.items():
         if value == searchval:
             return key

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,38 @@ from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS
 from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame, Launcher
 
 
+def test_get_dict_key_from_value() -> None:
+
+    """
+    Test whether get_dict_key_from_value can retrieve the expected key from a dict by a value,
+    where the key and value can be of any type.
+    """
+
+    dict_with_str_keys: dict[str, str] = {
+        'steam': 'Steam',
+        'lutris': 'Lutris',
+    }
+
+    dict_with_int_keys: dict[int, str] = {
+        2: 'two',
+        4: 'four'
+    }
+
+    dict_with_enum_keys: dict[Launcher, bool] = {
+        Launcher.WINEZGUI: True,
+        Launcher.HEROIC: False
+    }
+
+    test_dicts: list[dict[Any, Any]] = [
+        dict_with_str_keys,
+        dict_with_int_keys,
+        dict_with_enum_keys,
+    ]
+
+    for test_dict in test_dicts:
+        assert all( get_dict_key_from_value(test_dict, value) == key for key, value in test_dict.items() )
+
+
 def test_get_launcher_from_installdir() -> None:
 
     """


### PR DESCRIPTION
Adds a test for the `get_dict_key_from_value`. It is written so it tests dicts with various different values, far more exotic than the couple of uses in the codebase that only test `dict[str, str]`. Although we do test that case we also test cases with more exotic key types, to allow the test to give us more confidence in this function.

I also updated the type hints in `get_dict_key_from_value` function itself, although they are mostly `Any` [and basedPyright does not like the `Any` type by default](https://github.com/detachhead/basedpyright/blob/main/docs/configuration.md#based-options). Although in this case I think it makes sense, dicts can have pretty much any key and value, so it makes sense that we could give this function a dict of `Any` and so the value we're searching for (`searchval`) as well could also be `Any`.