### PR TITLE
steamutil: Force SteamApp `game_name` to string

### DIFF
--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -296,7 +296,7 @@ def update_steamapp_info(steam_config_folder: str, steamapp_list: List[SteamApp]
                     # Example: {'0': {'src_os': 'windows', 'dest_os': 'linux', 'appid': 1826330, 'comment': 'EAC runtime'}}
                     app_additional_dependencies = app_appinfo.get('extended', {}).get('additional_dependencies', {})
 
-                    a.game_name = app_appinfo_common.get('name', '')
+                    a.game_name = str(app_appinfo_common.get('name', ''))
                     a.deck_compatibility = app_appinfo_common.get('steam_deck_compatibility', {})
                     for dep in app_additional_dependencies.values():
                         a.anticheat_runtimes[RuntimeType.EAC] = dep.get('appid', -1) == PROTON_EAC_RUNTIME_APPID

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -279,11 +279,11 @@ def update_steamapp_info(steam_config_folder: str, steamapp_list: list[SteamApp]
     """
     appinfo_file = os.path.join(os.path.expanduser(steam_config_folder), '../appcache/appinfo.vdf')
     appinfo_file = os.path.realpath(appinfo_file)
-    sapps = {app.get_app_id_str(): app for app in steamapp_list}
+    sapps: dict[str, SteamApp] = {app.get_app_id_str(): app for app in steamapp_list}
     len_sapps = len(sapps)
     cnt = 0
     try:
-        ctool_map = _get_steam_ctool_info(steam_config_folder)
+        ctool_map: dict[str, dict[str, str]] = _get_steam_ctool_info(steam_config_folder)
         with open(appinfo_file, 'rb') as f:
             _, apps = parse_appinfo(f, mapper=dict)
             for steam_app in apps:

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -272,7 +272,7 @@ def _get_steam_ctool_info(steam_config_folder: str) -> Dict[str, Dict[str, str]]
     return ctool_map
 
 
-def update_steamapp_info(steam_config_folder: str, steamapp_list: List[SteamApp]) -> List[SteamApp]:
+def update_steamapp_info(steam_config_folder: str, steamapp_list: list[SteamApp]) -> list[SteamApp]:
     """
     Get Steam game names and information for provided SteamApps
     Return Type: List[SteamApp]


### PR DESCRIPTION
## Overview
This PR casts our `a.game_name` assignment in `steamutil#update_steamapp_info` to always return a string. This fixes an error coming back `Error updating SteamApp info from appinfo.vdf: argument of type 'int' is not iterable` when `a.game_name` is not a string. With the new `appinfo.vdf` format, it seems name can be stored as an integer in `appinfo.vdf` now if the game's name in the library only contains numbers.

If we try to parse this game's name, it'll be stored as an integer, and we will run into the mentioned error when we try to perform string operations on it. The one causing the error mentioned is our [`elif 'Steamworks' in a.game_name`](https://github.com/DavidoTek/ProtonUp-Qt/blob/f2573d588a349fbdc77ccbe8fe720f41bf6a5305/pupgui2/steamutil.py#L310) check inside of the `update_steamapp_info` function.

The error does not present `appinfo.vdf` from being parsed and _only_ the problematic game that has its `a.game_name` as an integer gets skipped. This causes the game to be missing from our apps list. With this PR we force `a.game_name`'s assignment to be a string, which allows ProtonUp-Qt to parse the games properly.

This PR also makes a couple of type-hinting improvements, including removing the deprecated `List` type from this function.

To emphasise, I don't think this is a regression on our part of a problem caused by the `steam` or `vdf` dependency, I think this is a change on Valve's side.

## `main` @ f2573d588a349fbdc77ccbe8fe720f41bf6a5305
![image](https://github.com/user-attachments/assets/87770380-b983-42d8-a187-45771ed833a5)

## This PR
![image](https://github.com/user-attachments/assets/399c5296-95d1-459d-b9c4-499d6f6c476a)

## Background
I noticed when working on a PR that I was seeing a new error on ProtonUp-Qt startup: `Error updating SteamApp info from appinfo.vdf: argument of type 'int' is not iterable`. I tracked this back to being present since the `steam` and `vdf` dependency update (e8197bc393553f0f9cd2ac84fa2a4d10888ffe8d). I can't test before that because parsing `appinfo.vdf` doesn't work at all.

After troubleshooting I tracked this error down the `a.game_name` assignment. When we try to assign `a.game_name` in [`steamutil#update_steamapp_info`](https://github.com/DavidoTek/ProtonUp-Qt/blob/f2573d588a349fbdc77ccbe8fe720f41bf6a5305/pupgui2/steamutil.py#L299), our `app_appinfo_common.get('name', '')` assignment to retrieve the game name from `appinfo.vdf` _is not guaranteed_ to return a string. This causes us to hit an exception when we try to check if an app in the loop is a Steamworks app with [`'if Steamworks' in a.game_name`](https://github.com/DavidoTek/ProtonUp-Qt/blob/f2573d588a349fbdc77ccbe8fe720f41bf6a5305/pupgui2/steamutil.py#L310) check which is an Iterative operation. So if `a.game_name = 21`, then we'll hit this exception.

The case where `app_appinfo_common.get('name', '')` is not guaranteed to return a string seems to be new. This was not happening in the old `appinfo.vdf` format and seems to be a result of the Steam `appinfo.vdf` format changing.

Games that can reproduce this problem are ones which only have numbers as their title in the library, such as [Twenty One](https://store.steampowered.com/app/938520/Twenty_One/) which is named "Twenty One" on the store page, but the actual app name in the library is "21". The name of this app is `21` in `appinfo.vdf`, inspecting the value that ProtonUp-Qt gets with a debugger.

## Solution
The solution is just to wrap our `app_appinfo_common.get` in a `str()` cast.

We will pretty much always expect the SteamApp game_name to be a string, I don't think it makes sense to account for it as an integer. For our purposes we will always want it to be represented as a string. Even though the `appinfo.vdf` does store the name as an integer, it used to store it as a string, which is why this problem never came up before. I have owned the game that caused this bug and had it installed for a while, and it previously showed up in ProtonUp-Qt before the `appinfo.vdf` format change. This could be an oversight by Valve or an intentional change, but either way I think casting to a string allows us to be on the safe side :smile: 

<hr>

Not much else to say on this one! `appinfo.vdf` can store game names as integers now and we weren't accounting for it, causing an exception and resulting in the game being missing from our app list, so the game would not be displayed in ProtonUp-Qt. But I wanted to give background because this is an edge-case. It is rare for games that people are likely to have installed, play often, and care about and so would want to interact with in ProtonUp-Qt that would only have numbers in their name. Even from searching SteamDB for a bit [I only found 1](https://steamdb.info/app/1204870/) (pun intended) and it isn't even available anymore.

Thanks!

P.S. - Ironically, Twenty One, the game that caused the issue for me, does not work and has never worked with Proton :smile: 