### PR TITLE
test_util: Add test for `build_headers_with_authorization`

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -82,7 +82,7 @@ class MainWindow(QObject):
     def __init__(self):
         super(MainWindow, self).__init__()
 
-        self.web_access_tokens = {
+        self.web_access_tokens: dict[str, str] = {
             'github': os.getenv('PUPGUI_GHA_TOKEN') or config_github_access_token(),
             'gitlab': os.getenv('PUPGUI_GLA_TOKEN') or config_gitlab_access_token(),
         }

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -666,7 +666,14 @@ def fetch_project_release_data(release_url: str, release_format: str, rs: reques
     return values
 
 
-def build_headers_with_authorization(request_headers: dict, authorization_tokens: dict, token_type: str):
+def build_headers_with_authorization(request_headers: dict[str, Any], authorization_tokens: dict[str, str], token_type: str) -> dict[str, Any]:
+
+    """
+    Generate an updated `request_headers` dict with the `Authorization` header containing the key for GitHub or GitLab, based on `token_type`
+    and removing any existing Authorization.
+
+    Return Type: dict[str, Any]
+    """
 
     request_headers['Authorization'] = ''  # Reset old authentication
     token: str = authorization_tokens.get(token_type, '')

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -675,17 +675,19 @@ def build_headers_with_authorization(request_headers: dict[str, Any], authorizat
     Return Type: dict[str, Any]
     """
 
-    request_headers['Authorization'] = ''  # Reset old authentication
+    updated_headers: dict[str, Any] = request_headers.copy()
+
+    updated_headers['Authorization'] = ''  # Reset old authentication
     token: str = authorization_tokens.get(token_type, '')
     if not token:        
-        return request_headers
+        return updated_headers
 
     if token_type == 'github':
-        request_headers['Authorization'] = f'token {token}'
+        updated_headers['Authorization'] = f'token {token}'
     elif token_type == 'gitlab':
-        request_headers['Authorization'] = f'Bearer {token}'
+        updated_headers['Authorization'] = f'Bearer {token}'
 
-    return request_headers
+    return updated_headers
 
 def compat_tool_available(compat_tool: str, ctobjs: List[dict]) -> bool:
     """ Return whether a compat tool is available for a given launcher """

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,42 @@ from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS
 from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame, Launcher
 
 
+def test_build_headers_with_authorization() -> None:
+
+    """
+    Test whether the expected Authorization Tokens get inserted into the returned headers dict,
+    that existing Authorization is replaced properly, and that all other existing headers are preserved.
+    """
+
+    user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36'
+
+    # Simulate existing headers with old Authentiation to be replaced, and a User-Agent that should remain untouched
+    request_headers: dict[str, Any] = {
+        'Authorization': 'ABC123',
+        'User-Agent': user_agent
+    }
+
+    # Simulate auth tokens that would normally come from the environment or config file
+    authorization_tokens: dict[str, str] = {
+        'github': 'gha_abc123daf456',
+        'gitlab': 'glpat-zyx987wvu654',
+    }
+
+    github_token_call: dict[str, Any] = build_headers_with_authorization(request_headers, authorization_tokens, 'github')
+    gitlab_token_call: dict[str, Any] = build_headers_with_authorization(request_headers, authorization_tokens, 'gitlab')
+
+    unknown_token_call: dict[str, Any] = build_headers_with_authorization(request_headers, authorization_tokens, '')
+    call_with_no_tokens: dict[str, Any] = build_headers_with_authorization(request_headers, {}, 'github')
+
+    assert github_token_call.get('Authorization', '') == f'token {authorization_tokens["github"]}'
+    assert gitlab_token_call.get('Authorization', '') == f'Bearer {authorization_tokens["gitlab"]}'
+
+    assert unknown_token_call.get('Authorization', '') == ''
+    assert call_with_no_tokens.get('Authorization', '') == ''
+
+    assert github_token_call.get('User-Agent', '') == user_agent
+
+
 def test_get_dict_key_from_value() -> None:
 
     """


### PR DESCRIPTION
## Overview
This PR creates a test for `build_headers_with_authorization`:
- Test that the token for GitHub gets pulled correctly.
- Test that the token for GitLab gets pulled correctly.
- Test that when we pass an unknown `token_type`, we don't set any authentication and handle it gracefully.
- Test that when we pass no tokens, we gracefully handle this and simply do not set any authentication.
- Test that the existing headers passed into the function are not overwritten by using a semi-realistic example of a `User-Agent` header.

I also added a docstring to the function and some type hinting.

## Changes to `build_headers_with_authorization`
When writing this test, I discovered a minor quirk that one could argue is a "defect": Python never passes copies, so when we perform operations on the current headers passed into the function, `request_headers`, we actually overwrite this dict. This is not really in line with what I expected based on how we use this function, which is to take in headers and return a new dict containing the headers with authentication. We never encountered this in practice because `build_headers_with_authorization` is always called with existing headers as an empty dict, `{}`.

When writing the test I decided to modify `build_headers_with_authorization` to use a copy of the headers passed in and modify that. But if we'd prefer to actually modify the parameters passed in and remove our `return`` altogether, we can modify the function to do that. In that case we would just call `build_headers_with_authorization` in places like ctmods and forego the `return` altogether.

I'm fine with either approach, I have no strong preference either way.

## Test Structure
This is a can of worms, but only a tiny one. A gourmet can of worms, if you will.

When writing this test, I followed the pattern I followed for the other tests I added, which followed the pattern laid out with `test_get_random_game_name`: One test per function that tests all cases. This has been fine for now but when writing this test specifically I noticed it is a little "unwieldy". I am wondering if there is a better way to write this test, which might end up with us restructuring the existing tests.

There are a few different patterns online for how to structure tests, and one that I see somewhat commonly is to have [multiple tests for the same function](https://betterstack.com/community/guides/testing/pytest-guide/#step-5-filtering-tests) to test separate test cases. Some test frameworks, like RSpec, have separate blocks for this, but PyTest is structured differently here. This keeps tests small but can be a bit repetitive. Some people group tests into classes, and I have also seen some things like [pytest-describe](https://github.com/pytest-dev/pytest-describe) to group tests with nested functions.

I haven't found a clear distinct winner for how people organise tests in PyTest. It gives you a lot of flexibility. I think having separate tests for each test case for a function is actually a nice approach, in this case of this PR we would have separate functions to test the GitHub case, the GitLab case, etc. My two concerns with this approach are:
- A good way to group the tests. Using something like `### BEGIN [blah] ###` and `### END [blah] ###` blocks with spacing is a low-tech way :smile: But maybe there are better alternatives.
- We would end up re-defining a lot of test data for each test. For this PR we would end up copying and pasting the `request_headers` for each test case. Some test frameworks allow you to specify `before` blocks for grouped tests to give that group of tests some stubbed data to work with, but I'm not sure what the approach is in PyTest to give ideally only a group of tests the same repeated data. Maybe this is something we would want to use PyTest fixtures for, but I mainly see that for stubbing larger pieces of data like database connections. 

If the existing approach is fine, we can stick with it, but this is something I wanted to raise just in case. :slightly_smiling_face: 

<hr>

I'm good with whatever direction we decide to go with for `build_headers_with_authorization`, and I can update the test in this PR accordingly. On the same lines, however we decide to go with structuring our test functions is also good with me. 

Thanks!