### PR TITLE
SteamTinkerLaunch: Type hinting and refactoring improvements

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -93,7 +93,7 @@ class CtInstaller(QObject):
         self.p_download_progress_percent = value
         self.download_progress_percent.emit(value)
 
-    def __download(self, url, destination):
+    def __download(self, url: str, destination: str) -> bool:
         """
         Download files from url to destination
         Return Type: bool

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -2,7 +2,13 @@
 # SteamTinkerLaunch
 # Copyright (C) 2021 DavidoTek, partially based on AUNaseef's protonup
 
-import datetime, locale, os, requests, shutil, subprocess, tarfile
+import datetime
+import locale
+import os
+import requests
+import shutil
+import subprocess
+import tarfile
 
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 from PySide6.QtWidgets import QMessageBox

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -77,7 +77,7 @@ class CtInstaller(QObject):
             proc_prefix + ['cat', '/etc/lsb-release', '/etc/os-release'],
             universal_newlines=True,
             stdout=subprocess.PIPE
-            ).stdout.strip().lower()
+        ).stdout.strip().lower()
 
     def get_download_canceled(self):
         return self.p_download_canceled
@@ -240,7 +240,7 @@ class CtInstaller(QObject):
 
         return branches
 
-    def get_tool(self, version, install_dir, temp_dir):
+    def get_tool(self, version: str, install_dir: str, temp_dir: str) -> bool:
         """
         Download and install the compatibility tool
         Return Type: bool
@@ -248,6 +248,7 @@ class CtInstaller(QObject):
 
         has_existing_install = False
 
+        ## Check for and handle any external SteamTinkerLaunch installations
         # If there's an existing STL installation that isn't installed by ProtonUp-Qt, ask the user if they still want to install
         has_external_install = get_external_steamtinkerlaunch_intall(os.path.join(install_dir, 'SteamTinkerLaunch'))
         if os.path.exists(has_external_install):
@@ -276,8 +277,8 @@ class CtInstaller(QObject):
                 print('User opted to not continue installing SteamTinkerLaunch. Aborting...')
                 return False
 
+        ## Download SteamTinkerLaunch tool
         print('Downloading SteamTinkerLaunch...')
-
         data = self.__fetch_github_data(version)
         if not data or 'download' not in data:
             return False
@@ -289,6 +290,7 @@ class CtInstaller(QObject):
         if not self.__download(url=data['download'], destination=destination):
             return False
 
+        ## Extract SteamTinkerLaunnch
         with tarfile.open(destination, "r:gz") as tar:
             print('Extracting SteamTinkerLaunch...')
             if os.path.exists(constants.STEAM_STL_INSTALL_PATH) and len(os.listdir(constants.STEAM_STL_INSTALL_PATH)) > 0:
@@ -303,61 +305,62 @@ class CtInstaller(QObject):
 
             tarname = tar.getnames()[0]
             
-            # Location of SteamTinkerLaunch script to add to path later
-            old_stl_path = os.path.join(constants.STEAM_STL_INSTALL_PATH, tarname)
+        # Location of SteamTinkerLaunch script to add to path later
+        old_stl_path = os.path.join(constants.STEAM_STL_INSTALL_PATH, tarname)
+        stl_path = os.path.join(constants.STEAM_STL_INSTALL_PATH, 'prefix')
+
+        # Rename folder ~/stl/<tarname> to ~/stl/prefix
+        os.rename(old_stl_path, stl_path)
+        os.chdir(stl_path)
+
+        # ProtonUp-Qt Flatpak: Run STL on host system
+        stl_proc_prefix: list[str] = ['flatpak-spawn', '--host'] if constants.IS_FLATPAK else []
+
+        ## Run any required SteamTinkerLaunch installation steps (e.g. execute script on SteamOS, configure locale, etc)
+        # If on Steam Deck, run script for initial Steam Deck config
+        # On Steam Deck, STL is installed to "/home/deck/stl/prefix"
+        self.__set_download_progress_percent(99.5) # 99.5 installing tool
+        print('Setting up SteamTinkerLaunch...')
+        if "steamos" in self.distinfo:
+            subprocess.run(['chmod', '+x', 'steamtinkerlaunch'])
+            subprocess.run(stl_proc_prefix + ['./steamtinkerlaunch'])
+
+            # Change location of STL script to add to path as this is different on Steam Deck 
             stl_path = os.path.join(constants.STEAM_STL_INSTALL_PATH, 'prefix')
 
-            # Rename folder ~/stl/<tarname> to ~/stl/prefix
-            os.rename(old_stl_path, stl_path)
+            # Change to STL prefix dir on Steam Deck so that the compatibility tool is symlinked correctly
             os.chdir(stl_path)
+        else:
+            # Get STL language and default to 'en_US' if the language is not available
+            # This step should not be necessary on Steam Deck
+            syslang: str = locale.getdefaultlocale()[0] or 'en_US'
+            stl_langs: dict[str, str] = {
+                'de_DE': 'german.txt',
+                'en_GB': 'englishUK.txt',
+                'en_US': 'english.txt',
+                'fr_FR': 'french.txt',
+                'il_IL': 'italian.txt',
+                'nl_NL': 'dutch.txt',
+                'pl_PL': 'polish.txt',
+                'ru_RU': 'russian.txt',
+                'zh_CN': 'chinese.txt',
+            }
+            stl_lang = stl_langs[syslang] if syslang in stl_langs else stl_langs['en_US']
+            stl_lang_path = os.path.join(constants.STEAM_STL_CONFIG_PATH, 'lang')
 
-            # ProtonUp-Qt Flatpak: Run STL on host system
-            stl_proc_prefix = ['flatpak-spawn', '--host'] if constants.IS_FLATPAK else []
-
-            # If on Steam Deck, run script for initial Steam Deck config
-            # On Steam Deck, STL is installed to "/home/deck/stl/prefix"
-            self.__set_download_progress_percent(99.5) # 99.5 installing tool
-            print('Setting up SteamTinkerLaunch...')
-            if "steamos" in self.distinfo:
-                subprocess.run(['chmod', '+x', 'steamtinkerlaunch'])
-                subprocess.run(stl_proc_prefix + ['./steamtinkerlaunch'])
-
-                # Change location of STL script to add to path as this is different on Steam Deck 
-                stl_path = os.path.join(constants.STEAM_STL_INSTALL_PATH, 'prefix')
-
-                # Change to STL prefix dir on Steam Deck so that the compatibility tool is symlinked correctly
-                os.chdir(stl_path)
-            else:
-                # Get STL language and default to 'en_US' if the language is not available
-                # This step should not be necessary on Steam Deck
-                syslang = locale.getdefaultlocale()[0] or 'en_US'
-                stl_langs = {
-                    'de_DE': 'german.txt',
-                    'en_GB': 'englishUK.txt',
-                    'en_US': 'english.txt',
-                    'fr_FR': 'french.txt',
-                    'il_IL': 'italian.txt',
-                    'nl_NL': 'dutch.txt',
-                    'pl_PL': 'polish.txt',
-                    'ru_RU': 'russian.txt',
-                    'zh_CN': 'chinese.txt',
-                }
-                stl_lang = stl_langs[syslang] if syslang in stl_langs else stl_langs['en_US']
-                stl_lang_path = os.path.join(constants.STEAM_STL_CONFIG_PATH, 'lang')
-
-                # Generate config file structure and copy relevant lang file
-                os.makedirs(stl_lang_path, exist_ok=True)
-                if not os.path.isfile(os.path.join(stl_lang_path, 'english.txt')):
-                    shutil.copyfile('lang/english.txt', os.path.join(stl_lang_path, 'english.txt'))
-                if not os.path.isfile(os.path.join(stl_lang_path, stl_lang)):
-                    shutil.copyfile(f'lang/{stl_lang}', os.path.join(stl_lang_path, stl_lang))
-                subprocess.run(stl_proc_prefix + ['./steamtinkerlaunch', f'lang={stl_lang.replace(".txt", "")}'])
-                self.__stl_config_change_language(constants.STEAM_STL_CONFIG_PATH, stl_lang)
+            ## Generate config file structure and copy relevant lang file
+            os.makedirs(stl_lang_path, exist_ok=True)
+            if not os.path.isfile(os.path.join(stl_lang_path, 'english.txt')):
+                shutil.copyfile('lang/english.txt', os.path.join(stl_lang_path, 'english.txt'))
+            if not os.path.isfile(os.path.join(stl_lang_path, stl_lang)):
+                shutil.copyfile(f'lang/{stl_lang}', os.path.join(stl_lang_path, stl_lang))
+            subprocess.run(stl_proc_prefix + ['./steamtinkerlaunch', f'lang={stl_lang.replace(".txt", "")}'])
+            self.__stl_config_change_language(constants.STEAM_STL_CONFIG_PATH, stl_lang)
 
             # Add SteamTinkerLaunch to all available shell paths (native Linux)
             # Dialog warning - Only warn on new installs or overwritten manual installs
             # For background see this issue: https://github.com/DavidoTek/ProtonUp-Qt/issues/127
-            should_show_shellmod_dialog = has_external_install or not has_existing_install
+            should_show_shellmod_dialog = bool(has_external_install or not has_existing_install)
             should_add_path = True
 
             # Checkbox is only shown to users who have ProtonUp-Qt Advanced mode enalbed
@@ -378,7 +381,7 @@ class CtInstaller(QObject):
                     should_add_path = False  # Shouldn't matter since installation will end here, but setting for completeness
                     remove_steamtinkerlaunch(remove_config=False, ctmod_object=self)  # shouldn't need compat_folder arg     -     (compat_folder=os.path.join(install_dir, 'SteamTinkerLaunch'))
                     self.__set_download_progress_percent(-2)
-                    return
+                    return False
                 elif not shellmod_msgbox_result.is_checked and shellmod_msgbox_result.button_clicked == MsgBoxResult.BUTTON_OK:
                     # Continue installation but skip adding to PATH
                     print('User asked not to add SteamTinkerLaunch to shell paths, skipping...')
@@ -400,21 +403,23 @@ class CtInstaller(QObject):
                 for shell_file in present_shell_files:
                     with open(shell_file, 'r+') as mfile:
                         stl_already_in_path = constants.STEAM_STL_INSTALL_PATH in [line for line in mfile.readlines()]
-                        if not stl_already_in_path:
-                            # Add Fish user path, preserving any existing paths 
-                            if 'fish' in mfile.name:
-                                mfile.seek(0)
-                                curr_fish_user_paths = get_fish_user_paths(mfile)
-                                curr_fish_user_paths.insert(0, stl_path)
-                                updated_fish_user_paths = '\\x1e'.join(curr_fish_user_paths)
-                                pup_stl_path_line = f'SETUVAR fish_user_paths:{updated_fish_user_paths}'
+                        if stl_already_in_path:
+                            continue
 
-                                mfile.seek(0)
-                                new_fish_contents = ''.join([line for line in mfile.readlines() if 'fish_user_paths:' not in line])
-                                mfile.seek(0)
-                                mfile.write(new_fish_contents)
-                            
-                            mfile.write(f'\n{pup_stl_path_date}\n{pup_stl_path_line}\n')
+                        # Add Fish user path, preserving any existing paths
+                        if 'fish' in mfile.name:
+                            mfile.seek(0)
+                            curr_fish_user_paths = get_fish_user_paths(mfile)
+                            curr_fish_user_paths.insert(0, stl_path)
+                            updated_fish_user_paths = '\\x1e'.join(curr_fish_user_paths)
+                            pup_stl_path_line = f'SETUVAR fish_user_paths:{updated_fish_user_paths}'
+
+                            mfile.seek(0)
+                            new_fish_contents = ''.join([line for line in mfile.readlines() if 'fish_user_paths:' not in line])
+                            mfile.seek(0)
+                            mfile.write(new_fish_contents)
+
+                        mfile.write(f'\n{pup_stl_path_date}\n{pup_stl_path_line}\n')
 
             # Install Compatibility Tool (Proton games)
             print('Adding SteamTinkerLaunch as a compatibility tool...')
@@ -422,9 +427,8 @@ class CtInstaller(QObject):
 
             os.chdir(constants.HOME_DIR)
 
-        protondir = os.path.join(install_dir, 'SteamTinkerLaunch')
-
         # We can't use the version arg to this method because we need to list the PROGVERS stored by the SteamTinkerLaunch script
+        protondir: str = os.path.join(install_dir, 'SteamTinkerLaunch')
         if os.path.exists(protondir):
             # Get PROGVERS from STL script
             stl_filename = 'steamtinkerlaunch'

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -87,7 +87,7 @@ class CtInstaller(QObject):
 
     download_canceled = Property(bool, get_download_canceled, set_download_canceled)
 
-    def __set_download_progress_percent(self, value : int):
+    def __set_download_progress_percent(self, value: int | float):
         if self.p_download_progress_percent == value:
             return
         self.p_download_progress_percent = value

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -82,7 +82,7 @@ class CtInstaller(QObject):
     def get_download_canceled(self):
         return self.p_download_canceled
 
-    def set_download_canceled(self, val):
+    def set_download_canceled(self, val: int):
         self.p_download_canceled = val
 
     download_canceled = Property(bool, get_download_canceled, set_download_canceled)

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -250,7 +250,7 @@ class CtInstaller(QObject):
 
         # If there's an existing STL installation that isn't installed by ProtonUp-Qt, ask the user if they still want to install
         has_external_install = get_external_steamtinkerlaunch_intall(os.path.join(install_dir, 'SteamTinkerLaunch'))
-        if has_external_install:
+        if os.path.exists(has_external_install):
             print('Non-ProtonUp-Qt installation of SteamTinkerLaunch detected. Asking the user what they want to do...')
             self.question_box_message.emit(
                 QCoreApplication.instance().translate('ctmod_steamtinkerlaunch', 'Existing SteamTinkerLaunch Installation'),

--- a/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
+++ b/pupgui2/resources/ctmods/ctmod_steamtinkerlaunch.py
@@ -440,7 +440,7 @@ class CtInstaller(QObject):
         print('Successfully installed SteamTinkerLaunch!')
         return True
     
-    def get_info_url(self, version):
+    def get_info_url(self, version: str) -> str:
         """
         Return link with GitHub release page.
         If SteamTinkerLaunch-git, returns the project homepage.

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -456,10 +456,10 @@ def is_steam_running() -> bool:
 get_fish_user_paths = lambda mfile: ([line.strip() for line in mfile.readlines() if 'fish_user_paths' in line] or ['SETUVAR fish_user_paths:\\x1d'])[0].split('fish_user_paths:')[1:][0].split('\\x1e')
 
 
-def get_external_steamtinkerlaunch_intall(compat_folder):
+def get_external_steamtinkerlaunch_intall(compat_folder) -> str:
 
     symlink_path = os.path.join(compat_folder, 'steamtinkerlaunch')
-    return os.path.dirname(os.readlink(symlink_path)) if os.path.exists(symlink_path) and os.readlink(symlink_path) != os.path.join(STEAM_STL_INSTALL_PATH, 'prefix', 'steamtinkerlaunch') else None
+    return os.path.dirname(os.readlink(symlink_path)) if os.path.exists(symlink_path) and os.readlink(symlink_path) != os.path.join(STEAM_STL_INSTALL_PATH, 'prefix', 'steamtinkerlaunch') else ''
 
 
 def remove_steamtinkerlaunch(compat_folder='', remove_config=True, ctmod_object=None) -> bool:


### PR DESCRIPTION
*(Note: This PR is opened as a draft because I have not yet had a chance to extensively test the changes.)*

I've been meaning to take a look at the SteamTinkerLaunch ctmod for a while, as it could be brought up-to-date with the other ctmods to use the new utility functions like the fetching project data functions and even the new `download_file` utility function.  Also, the ctmod was written a while ago and not very many changes have been made, and I think there are some logic improvements that could be made (for example, `get_tool` is huge and could really be split out into separate methods). However before we get that far there are some higher level improvements that I wanted to make, mainly around better type hinting and refactoring to make the ctmod a bit nicer to work with.

This PR adds various type hints around the ctmod (this will help when other functions and methods are more thoroughly type-hinted) and does a bit of refactoring to reduce indentation and make code paths cleaner. Namely:
- Return much earlier from `is_system_compatible` if we're on SteamOS, as we don't check dependencies _at all_ on SteamOS.
- De-indent a *lot* in `get_tool` from the tarfile context manager, as we don't need to be indented so much in that block.
    - In future we may even be able to forego the `tarfile.open` entirely in favour of our helper methods to handle extraction, but I didn't do that in this PR
- Use `continue` in at least one loop to continue if a condition is met instead of keeping the logic in an indented block.

Generally in this PR I only made surface-level comfort changes to make the ctmod a bit less "scary". In my head I have a mental image of this ctmod being a bit on the "unclean" side and getting back into this part of the code, it isn't nearly as much of a disaster as I pictured it in my head, but I see a lot of potential for improvement and I want to split it across multiple PRs sequentially. I want to get some basic cleanup in place with this PR, and then move onto splitting parts of the code up a bit better, and then moving onto using our helper methods such as `download_file. All of these steps should help "modernize" this ctmod and make it a lot less "dated". I know a lot more than I did 2 years ago when I initially stepped up to work on this and want to give back by bringing this ctmod up to speed with the other improvements made in the codebase since that time.

If you have any other suggestions for changes I should include in this PR, please let me know and I'll be happy to include them! But again this PR is mainly for those "higher level" changes, like removing unnecessary indentation, returning early, and improving readibility. I understand bigger changes are probably desired but I didn't want to make some monster PR. I think this PR might already be a bit difficult to review with the number of changes despite my best efforts to keep it on the smaller side :sweat_smile: 

All feedback is welcome on this. Thanks!