### PR TITLE
pupgui2: Display install location combobox text in tooltip

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -296,6 +296,10 @@ class MainWindow(QObject):
         self.ui.txtUnusedVersions.setText(self.tr('Unused: {unused_ctools}').format(unused_ctools=unused_ctools) if unused_ctools > 0 else '')
         self.ui.txtInstalledVersions.setText(f'{len(self.compat_tool_index_map)}')
 
+        combo_install_location_val: str = self.ui.comboInstallLocation.currentText()
+        if len(combo_install_location_val) > 0:
+            self.ui.comboInstallLocation.setToolTip(combo_install_location_val)
+
     def get_installed_versions(self, ctool_name, ctool_dir):
         for ct in get_installed_ctools(ctool_dir):
             if ctool_name not in ct.get_displayname().lower():


### PR DESCRIPTION
Adds a tooltip to the installation location dropdown `comboInstallLocation` on the Main Menu which displays the dropdown's text. This can be useful if the path in the dropdown text is long, usually for paths. Resizing the window to see the full path is awkward, and not possible in some scenarios (like in GameScope). Some paths are so long that they are truncated in the dropdown itself at the Main Window's default size.

![Steam](https://github.com/user-attachments/assets/75325c4f-5580-43d6-9678-41c2e5026b93)

![Heroic](https://github.com/user-attachments/assets/9bc2944f-27d2-4529-95aa-da5919d200a5)

One thing not implemented here that might be cool to display is if the launcher path is custom. We could maybe add `[CUSTOM]` somewhere in the tooltip. But I think making it more obvious when a chosen launcher path is custom is a general enhancement for the future, so we could tackle it then.