### PR TITLE
Add vdf_safe_load function

### DIFF
--- a/pupgui2/datastructures.py
+++ b/pupgui2/datastructures.py
@@ -150,7 +150,9 @@ class BasicCompatTool:
         """
         compat_tool_vdf_path = os.path.join(self.install_dir, self.install_folder, 'compatibilitytool.vdf')
         if os.path.exists(compat_tool_vdf_path):
-            compat_tool_vdf = vdf.load(open(compat_tool_vdf_path))
+            # TODO: Move this somewhere else and use steamutil.py#vdf_safe_load
+            with open(compat_tool_vdf_path, 'r', encoding='utf-8', errors='replace') as f:
+                compat_tool_vdf = vdf.loads(f.read())
             if 'compatibilitytools' in  compat_tool_vdf and 'compat_tools' in compat_tool_vdf['compatibilitytools']:
                 return list(compat_tool_vdf['compatibilitytools']['compat_tools'].keys())[0]
 

--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -809,3 +809,22 @@ def is_valid_steam_install(steam_path) -> bool:
     is_valid_steam_install = os.path.exists(config_vdf) and os.path.exists(libraryfolders_vdf)
 
     return is_valid_steam_install
+
+def vdf_safe_load(vdf_file: str) -> dict:
+    """
+    Loads a vdf file and returns its contents as a dict.
+    In case of an error, the error is printed and {} is returned.
+
+    Args:
+        vdf_file (str): Path to the vdf file
+
+    Returns:
+        dict
+    """
+
+    try:
+        # See https://github.com/DavidoTek/ProtonUp-Qt/issues/424 (unicode errors)
+        with open(vdf_file, 'r', encoding='utf-8', errors='replace') as f:
+            return vdf.loads(f.read())
+    except Exception as e:
+        print(f'An error occured while calling vdf_safe_load({vdf_file}): {e}')


### PR DESCRIPTION
Fix https://github.com/DavidoTek/ProtonUp-Qt/issues/424

Adds a new function `vdf_safe_load(vdf_file: str) -> dict` to `steamutil.py`

It opens and parses vdf files using the vdf library. Defective UTF-8 characters are replaced with a unicode question mark symbol. The error is printed in case of other Exceptions and an empty dict is returned.