### PR TITLE
CID: Disable `btnDefault` if no Custom Install Directory path is set

### DIFF
--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -45,7 +45,10 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         self.txtIdBrowseAction = self.ui.txtInstallDirectory.addAction(QIcon.fromTheme('document-open'), QLineEdit.TrailingPosition)
         self.txtIdBrowseAction.triggered.connect(self.txt_id_browse_action_triggered)
 
-        self.ui.txtInstallDirectory.setText(config_custom_install_location().get('install_dir', ''))
+        custom_install_directory = config_custom_install_location().get('install_dir', '')
+
+        self.ui.txtInstallDirectory.setText(custom_install_directory)
+        self.ui.btnDefault.setEnabled(bool(custom_install_directory))  # Don't enable btnDefault if there is no Custom Install Directory set
 
         self.ui.comboLauncher.addItems([
             display_name for display_name in self.install_locations_dict.values()

--- a/pupgui2/pupgui2customiddialog.py
+++ b/pupgui2/pupgui2customiddialog.py
@@ -48,7 +48,7 @@ class PupguiCustomInstallDirectoryDialog(QObject):
         custom_install_directory = config_custom_install_location().get('install_dir', '')
 
         self.ui.txtInstallDirectory.setText(custom_install_directory)
-        self.ui.btnDefault.setEnabled(bool(custom_install_directory))  # Don't enable btnDefault if there is no Custom Install Directory set
+        self.ui.btnDefault.setEnabled(self.has_custom_install_directory(custom_install_directory))  # Don't enable btnDefault if there is no Custom Install Directory set
 
         self.ui.comboLauncher.addItems([
             display_name for display_name in self.install_locations_dict.values()
@@ -76,7 +76,9 @@ class PupguiCustomInstallDirectoryDialog(QObject):
 
     def btn_default_clicked(self):
         self.ui.txtInstallDirectory.setText('')
-        config_custom_install_location(remove=True)
+
+        custom_install_directory = config_custom_install_location(remove=True).get('install_dir', '')
+        self.ui.btnDefault.setEnabled(self.has_custom_install_directory(custom_install_directory))
 
         self.custom_id_set.emit('')
 
@@ -103,3 +105,17 @@ class PupguiCustomInstallDirectoryDialog(QObject):
     def is_valid_custom_install_path(self, path: str) -> bool:
         expand_path = os.path.expanduser(path)
         return len(path.strip()) > 0 and os.path.isdir(expand_path) and os.access(expand_path, os.W_OK)
+
+    def has_custom_install_directory(self, custom_install_directory: str = '') -> bool:
+
+        """
+        Returns whether a Custom Install Directory is set to a Truthy value.
+        If `custom_install_directory` is not passed, it will be retrieved.
+
+        Return Type: bool
+        """
+
+        if not custom_install_directory:
+            return bool(config_custom_install_location().get('install_dir', ''))
+
+        return bool(custom_install_directory)


### PR DESCRIPTION
Based on suggestion in https://github.com/DavidoTek/ProtonUp-Qt/issues/454#issuecomment-2351673220.

This PR disables the "Default" button (`btnDefault`) if no Custom Install Directory has been configured. It also disables the button on click, if it successfully clears the value from the INI (i.e. if after clicking, the Custom Install Directory is successfully removed, toggle `btnDefault` enabled/disabled based on the `bool` cast of the value in the INI file).

The Custom Install Directory path is saved to the ProtonUp-Qt config file, and we can retrieve it using `config_custom_install_location`. I believe this is also responsible for writing out the path as well to the INI file. We can toggle whether `btnDefault` is enable on dialog load based on if `custom_install_directory` is defined.

`custom_install_directory: str = config_custom_install_location().get('install_dir', '')` will retrieve the value of `install_dir` based on the value in the INI. If this is not set, trying to fetch `install_dir` will actually return `None`. I am not _entirely_ sure why this is, I would've thought calling `.get('install_dir', '')` would return `''` for `False`y values, but I guess not. The `config_custom_install_location` function can take an `install_dir` keyword argument and this defaults to `install_dir=None`, so that's where the `None` comes from. If no Custom Install Directory is set, `config_custom_install_location` returns `None`.

Instead of refactoring behaviour in `config_custom_install_location` for this PR and potentially breaking things (i.e. changing the default argument to `install_dir=''`), I rolled with it and called `setEnabled` with a `bool` cast of `custom_install_directory`. If `custom_install_directory` returns `None` (which it should if there is no Custom Install Directory is set) then we call `bool(None)` to toggle the enabled state of `btnDefault`, which will disable it (`bool(None)` is `False`). Also, if `custom_install_directory` contained other `False`y values like an empty string (`''`) (which shouldn't be possible normally, but could happen if a user manually edited their INI file), we would also disable `btnDefault`. I think this is desirable; `False`y values should be considered equal to having no Custom Install Directory set, and so should disable `btnDefault`

Since this functionality is also used on `btnDefault` click, I broke it out into a method that handles checking if a `custom_install_directory` is set to a `Truth`y value. This makes the code a bit cleaner, as instead of doing the `bool` cast ourselves, we just tell `btnDefault.setEnabled` to toggle based on `self.has_custom_install_directory` return value, and that method handles the implementation detail. This also means if we wanted to change this implementation in future it would be more straightforward (e.g. if we ever wanted to validate the path in any way).

I have attached some screenshots to show this change.

### Before (`main`)
![image](https://github.com/user-attachments/assets/31c43dbe-a320-4920-b345-33157d6d3223)

### After (This PR)
![image](https://github.com/user-attachments/assets/6135727f-23fb-4170-99bd-fe5555c85c91)

It is also enabled again when a Custom Install Directory is saved and the dialog is re-opened.

![image](https://github.com/user-attachments/assets/ff4bba5f-8957-45ae-8537-040f2594d09a)

<hr>

Thanks!