### PR TITLE
config_custom_install_location: Type hint improvements

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -284,7 +284,7 @@ def install_directory(target=None) -> str:
     return ''
 
 
-def config_custom_install_location(install_dir=None, launcher='', remove=False) -> Dict[str, str]:
+def config_custom_install_location(install_dir=None, launcher='', remove=False) -> Dict[str, Any]:
     """
     Read/update config for the custom install location
     Write install_dir, launcher to config or read if install_dir=None or launcher=None


### PR DESCRIPTION
Improves the type hint for `util.py#config_custom_install_location`. Changes `dict[str, str]` to `dict[str, Any]`

As it is the case in https://github.com/DavidoTek/ProtonUp-Qt/pull/457, the following scenario would result in a type error:

```python
# Reminder: config_custom_install_location(install_dir=None, launcher='', remove=False)
>>> c = config_custom_install_location(remove=True)
>>> i = c.get("install_dir")
>>> print(i)
None
```

That is the case because when `remove=True`, `install_dir` will be returned unchanged. The default value for `install_dir` is `None`.

An alternative is to change the default value of `install_dir` from `None` to `''`.