### PR TITLE
Add a 3px padding to the main list and combobox items

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -142,6 +142,7 @@ class MainWindow(QObject):
         self.ui.btnClose.clicked.connect(self.btn_close_clicked)
         self.ui.listInstalledVersions.itemDoubleClicked.connect(self.list_installed_versions_item_double_clicked)
         self.ui.listInstalledVersions.itemSelectionChanged.connect(self.list_installed_versions_item_selection_changed)
+        self.ui.listInstalledVersions.setStyleSheet('QListWidget::item { padding: 3px; }')
         self.ui.btnShowCtInfo.clicked.connect(self.btn_show_ct_info_clicked)
         self.ui.btnSteamFlatpakCtools.clicked.connect(self.btn_steam_flatpak_ctools_clicked)
 

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -1,14 +1,13 @@
 import os
-import threading
 import pkgutil
+import threading
 
 from PySide6.QtCore import Signal, QLocale, QDataStream, QByteArray
-from PySide6.QtGui import QIcon, QPixmap
-from PySide6.QtWidgets import QDialog
+from PySide6.QtGui import QIcon, QPixmap, Qt
 from PySide6.QtUiTools import QUiLoader
+from PySide6.QtWidgets import QDialog
 
 from pupgui2.util import open_webbrowser_thread, config_advanced_mode, get_combobox_index_by_value
-
 
 RELEASES_PER_PAGE = 50  # Number of releases to fetch per page
 
@@ -47,15 +46,19 @@ class PupguiInstallDialog(QDialog):
         self.ui.btnInstall.clicked.connect(self.btn_install_clicked)
         self.ui.btnCancel.clicked.connect(lambda: self.ui.close())
         self.ui.comboCompatTool.currentIndexChanged.connect(self.combo_compat_tool_current_index_changed)
-        self.ui.comboCompatTool.setStyleSheet('QComboBox QAbstractItemView::item { padding: 3px; }')
+        self.ui.comboCompatTool.view().setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self.ui.comboCompatToolVersion.currentIndexChanged.connect(self.combo_compat_tool_version_current_index_changed)
+        self.ui.comboCompatToolVersion.view().setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self.is_fetching_releases.connect(lambda x: self.ui.comboCompatTool.setEnabled(not x))
         self.is_fetching_releases.connect(lambda x: self.ui.comboCompatToolVersion.setEnabled(not x))
         self.is_fetching_releases.connect(lambda x: self.ui.btnInfo.setEnabled(not x))
         self.is_fetching_releases.connect(lambda x: self.ui.btnInstall.setEnabled(not x))
 
+        combobox_style = 'QComboBox { combobox-popup: 0; } QComboBox QAbstractItemView::item { padding: 3px; }'
+        self.ui.comboCompatTool.setStyleSheet(combobox_style)
+        self.ui.comboCompatToolVersion.setStyleSheet(combobox_style)
+
         self.ui.comboCompatTool.addItems([ctobj['name'] for ctobj in self.ct_objs])
-        self.ui.comboCompatToolVersion.setStyleSheet('QComboBox { combobox-popup: 0; } QComboBox QAbstractItemView::item { padding: 3px; }')
 
     def btn_info_clicked(self):
         for ctobj in self.ct_objs:

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -47,6 +47,7 @@ class PupguiInstallDialog(QDialog):
         self.ui.btnInstall.clicked.connect(self.btn_install_clicked)
         self.ui.btnCancel.clicked.connect(lambda: self.ui.close())
         self.ui.comboCompatTool.currentIndexChanged.connect(self.combo_compat_tool_current_index_changed)
+        self.ui.comboCompatTool.setStyleSheet('QComboBox QAbstractItemView::item { padding: 3px; }')
         self.ui.comboCompatToolVersion.currentIndexChanged.connect(self.combo_compat_tool_version_current_index_changed)
         self.is_fetching_releases.connect(lambda x: self.ui.comboCompatTool.setEnabled(not x))
         self.is_fetching_releases.connect(lambda x: self.ui.comboCompatToolVersion.setEnabled(not x))
@@ -54,7 +55,7 @@ class PupguiInstallDialog(QDialog):
         self.is_fetching_releases.connect(lambda x: self.ui.btnInstall.setEnabled(not x))
 
         self.ui.comboCompatTool.addItems([ctobj['name'] for ctobj in self.ct_objs])
-        self.ui.comboCompatToolVersion.setStyleSheet('QComboBox { combobox-popup: 0; }')
+        self.ui.comboCompatToolVersion.setStyleSheet('QComboBox { combobox-popup: 0; } QComboBox QAbstractItemView::item { padding: 3px; }')
 
     def btn_info_clicked(self):
         for ctobj in self.ct_objs:

--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -1,13 +1,14 @@
 import os
-import pkgutil
 import threading
+import pkgutil
 
 from PySide6.QtCore import Signal, QLocale, QDataStream, QByteArray
 from PySide6.QtGui import QIcon, QPixmap, Qt
-from PySide6.QtUiTools import QUiLoader
 from PySide6.QtWidgets import QDialog
+from PySide6.QtUiTools import QUiLoader
 
 from pupgui2.util import open_webbrowser_thread, config_advanced_mode, get_combobox_index_by_value
+
 
 RELEASES_PER_PAGE = 50  # Number of releases to fetch per page
 


### PR DESCRIPTION
Adds a padding of 3px to the installed compat tool list in the main window and the installation dialog to help with mouse navigation.