### PR TITLE
Steam-Play-None: Fix extraction if tool already installed

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_steamplaynone.py
+++ b/pupgui2/resources/ctmods/ctmod_steamplaynone.py
@@ -7,7 +7,7 @@ import requests
 
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
-from pupgui2.util import extract_tar
+from pupgui2.util import extract_tar, remove_if_exists
 from pupgui2.util import build_headers_with_authorization
 
 
@@ -87,17 +87,21 @@ class CtInstaller(QObject):
         Return Type: bool
         """
         steam_play_none_tar = os.path.join(temp_dir, 'main.tar.gz')
-        dl_url = self.CT_URL
-
-        if not self.__download(url=dl_url, destination=steam_play_none_tar):
-            return False
-
-        if not extract_tar(steam_play_none_tar, install_dir, mode='gz'):
-            return False
 
         # Rename extracted Steam-Play-None-main to Steam-Play-None
         steam_play_none_main = os.path.join(install_dir, 'Steam-Play-None-main')
         steam_play_none_dir = os.path.join(install_dir, 'Steam-Play-None')
+
+        dl_url = self.CT_URL
+
+        remove_if_exists(steam_play_none_main)
+        if not self.__download(url=dl_url, destination=steam_play_none_tar):
+            return False
+
+        remove_if_exists(steam_play_none_dir)
+        if not extract_tar(steam_play_none_tar, install_dir, mode='gz'):
+            return False
+
         os.rename(steam_play_none_main, steam_play_none_dir)
 
         self.__set_download_progress_percent(100)


### PR DESCRIPTION
## Overview
This PR fixes installing Steam-Play-None over the top of an existing installation. Currently if we attempt to do this, installation will fail, and there will be an extracted `Steam-Play-None-main` folder in the `compatibilitytools.d` directory from the successful download and extraction but failed renaming of the folder.

[Screencast_20250302_193713.webm](https://github.com/user-attachments/assets/de5d8c78-2b5b-4d1e-a8bc-277ac8777936)

## Problem
When we download Steam-Play-None, we download and extract the tar which comes out as `Steam-Play-None-main`. After successful extraction, we rename this folder to `Steam-Play-None`.

Trying to download Steam-Play-None again if a folder with the name `Steam-Play-None` already exists in the `compatibilitytools.d` directory (i.e. from an existing installation), then while the tool will successfully download and extract, the renaming part will fail. Similarly, if `Steam-Play-None-main` already existed, we would end up with the same problem, but earlier in the process.

When trying to rename to `Steam-Play-None-main` in the problem outlined, the progress bar hangs at 99% but there is no other visual error to the user.

![image](https://github.com/user-attachments/assets/c9c6af07-07ef-4e1b-bb18-a86387dcb970)

Terminal output will be a bit more helpful and show `[Errno 39] Directory not empty: '/home/username/.local/share/Steam/compatibilitytools.d/Steam-Play-None-main' -> '/home/username/.local/share/Steam/compatibilitytools.d/Steam-Play-None'`.

ProtonUp-Qt allows you to download tools overtop of existing installations, which will overwrite them. The only exception are cases where there is a checksum that we compare against, such as GE-Proton.

## Solution
We can fix this problem by removing the `Steam-Play-None` folder if it exists after a successful extraction. We also remove `Steam-Play-None-main`, to prevent a similar issue that could be caused when trying to extract (as the folder extracted would be named `Steam-Play-None-main`).

## Concerns
There is a risk that we could remove `Steam-Play-None-main` but that our extraction fails following this, and the user loses their installation.

Similarly, there is also a risk that we would remove the `Steam-Play-None` folder but that our rename fails, and again the user would lose an existing installation.

I think these scenarios are fairly unlikely to occur and if they did, are minor enough that they could be easily resolved by just reinstalling (via ProtonUp-Qt or otherwise).

<hr>

First PR in a while, and should be a quick fix. As usual, all feedback is welcome!

Thanks!