### PR TITLE
networkutil: Round up chunk_count to ensure it cannot be

### DIFF
--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -1,6 +1,8 @@
 import os
-from PySide6.QtCore import Property
 import requests
+import math
+
+from PySide6.QtCore import Property
 
 from typing import Callable
 
@@ -64,7 +66,7 @@ def download_file(url: str, destination: str, progress_callback: Callable[[int],
     #       Content-Length, or len(response.content) is 0), then then the progress bar will stall at 1% until
     #       the download finishes where it will jump to 99%, until extraction completes.
     try:
-        chunk_count = int(file_size / buffer_size)
+        chunk_count = math.ceil(file_size / buffer_size)
     except ZeroDivisionError as e:
         print(f'Error: Could not calculate chunk_count, {e}')
         print('Defaulting to chunk count of 1')


### PR DESCRIPTION
This PR fixes a bug in `networkutil#download_file` where our calculation for `current_chunk` could return `0`. Instead of `int`, we use `math.ceil` to make sure fractional results are rounded up.

An alternative solution could be to append `or 1` so that if the value is `0`, it is treated as Falsey and we default to `1`, but I think using `math.ceil` is a bit more elegant even if it means the extra import :-) But happy if we want to avoid the import to just use `int(...) or 1`.

I have tested with Luxtorpeda (Steam) and DXVK (Lutris), and this should not cause any regressions.

<hr>

This bug was discovered while I was working on porting `download_file` to Steam-Play-None, where the `current_chunk` calculation was returning `0` and causing a Division by Zero error. I have also confirmed that this PR fixes the issue.

All feedback is welcome. Thanks! :-)