### PR TITLE
GE-Proton: Use release_format

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_00protonge.py
+++ b/pupgui2/resources/ctmods/ctmod_00protonge.py
@@ -30,6 +30,8 @@ class CtInstaller(QObject):
         super(CtInstaller, self).__init__()
         self.p_download_canceled = False
 
+        self.release_format = 'tar.gz'
+
         self.rs = requests.Session()
         rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
         self.rs.headers.update(rs_headers)
@@ -108,7 +110,7 @@ class CtInstaller(QObject):
         for asset in data['assets']:
             if asset['name'].endswith('sha512sum'):
                 values['checksum'] = asset['browser_download_url']
-            elif asset['name'].endswith('tar.gz'):
+            elif asset['name'].endswith(self.release_format):
                 values['download'] = asset['browser_download_url']
                 values['size'] = asset['size']
         return values
@@ -159,7 +161,7 @@ class CtInstaller(QObject):
         if source_checksum and (download_checksum not in source_checksum):
             return False
 
-        if not extract_tar(proton_tar, install_dir, mode='gz'):
+        if not extract_tar(proton_tar, install_dir, mode=self.release_format.split('.')[-1]):
             return False
 
         if os.path.exists(checksum_dir):

--- a/pupgui2/resources/ctmods/ctmod_northstarproton.py
+++ b/pupgui2/resources/ctmods/ctmod_northstarproton.py
@@ -2,13 +2,11 @@
 # cyrv6737's NorthstarProton for TitanFall 2
 # Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
 
-import os
-import requests
-
 from PySide6.QtCore import QObject, Signal, Property, QCoreApplication
 
-from pupgui2.util import extract_tar
-from pupgui2.util import build_headers_with_authorization, fetch_project_release_data, fetch_project_releases
+from pupgui2.util import fetch_project_release_data, fetch_project_releases
+
+from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as GEProtonInstaller
 
 
 CT_NAME = 'Northstar Proton (Titanfall 2)'
@@ -16,69 +14,27 @@ CT_LAUNCHERS = ['steam', 'heroicproton', 'bottles', 'advmode']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_northstarproton', '''Proton build based on TKG's proton-tkg to run the Northstar client + TitanFall 2. By cyrv6737.<br/><br/><b style="color:orange;">Read the following before proceeding</b>:<br/><a href="https://github.com/R2NorthstarTools/NorthstarProton">https://github.com/R2NorthstarTools/NorthstarProton</a>''')}
 
 
-class CtInstaller(QObject):
+class CtInstaller(GEProtonInstaller):
 
     BUFFER_SIZE = 65536
     CT_URL = 'https://api.github.com/repos/R2NorthstarTools/NorthstarProton/releases'
     CT_INFO_URL = 'https://github.com/R2NorthstarTools/NorthstarProton/releases/tag/'
 
-    p_download_progress_percent = 0
-    download_progress_percent = Signal(int)
+    def __init__(self, main_window = None) -> None:
 
-    def __init__(self, main_window = None):
-        super(CtInstaller, self).__init__()
-        self.p_download_canceled = False
-        self.release_format = 'tar.gz'
+        super().__init__(main_window)
 
-        self.rs = requests.Session()
-        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
-        self.rs.headers.update(rs_headers)
+        self.release_format: str = 'tar.gz'
 
-    def get_download_canceled(self):
-        return self.p_download_canceled
-
-    def set_download_canceled(self, val):
-        self.p_download_canceled = val
-
-    download_canceled = Property(bool, get_download_canceled, set_download_canceled)
-
-    def __set_download_progress_percent(self, value : int):
-        if self.p_download_progress_percent == value:
-            return
-        self.p_download_progress_percent = value
-        self.download_progress_percent.emit(value)
-
-    def __download(self, url, destination):
+    def fetch_releases(self, count: int = 100, page: int = 1) -> list[str]:
         """
-        Download files from url to destination
-        Return Type: bool
+        List available releases
+        Return Type: str[]
         """
-        try:
-            file = self.rs.get(url, stream=True)
-        except OSError:
-            return False
 
-        self.__set_download_progress_percent(1) # 1 download started
-        f_size = int(file.headers.get('content-length'))
-        c_count = int(f_size / self.BUFFER_SIZE)
-        c_current = 1
-        destination = os.path.expanduser(destination)
-        os.makedirs(os.path.dirname(destination), exist_ok=True)
-        with open(destination, 'wb') as dest:
-            for chunk in file.iter_content(chunk_size=self.BUFFER_SIZE):
-                if self.download_canceled:
-                    self.download_canceled = False
-                    self.__set_download_progress_percent(-2) # -2 download canceled
-                    return False
-                if chunk:
-                    dest.write(chunk)
-                    dest.flush()
-                self.__set_download_progress_percent(int(min(c_current / c_count * 98.0, 98.0))) # 1-98, 100 after extract
-                c_current += 1
-        self.__set_download_progress_percent(99) # 99 download complete
-        return True
+        return fetch_project_releases(self.CT_URL, self.rs, count=count, page=page)
 
-    def __fetch_github_data(self, tag):
+    def __fetch_github_data(self, tag: str) -> dict:
         """
         Fetch GitHub release information
         Return Type: dict
@@ -87,46 +43,3 @@ class CtInstaller(QObject):
         """
 
         return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag)
-
-    def is_system_compatible(self):
-        """
-        Are the system requirements met?
-        Return Type: bool
-        """
-        return True
-
-    def fetch_releases(self, count=100, page=1):
-        """
-        List available releases
-        Return Type: str[]
-        """
-
-        return fetch_project_releases(self.CT_URL, self.rs, count=count, page=page)
-
-    def get_tool(self, version, install_dir, temp_dir):
-        """
-        Download and install the compatibility tool
-        Return Type: bool
-        """
-        data = self.__fetch_github_data(version)
-
-        if not data or 'download' not in data:
-            return False
-
-        northstar_tar = os.path.join(temp_dir, data['download'].split('/')[-1])
-        if not self.__download(url=data['download'], destination=northstar_tar):
-            return False
-
-        if not extract_tar(northstar_tar, install_dir, mode='gz'):
-            return False
-
-        self.__set_download_progress_percent(100)
-
-        return True
-
-    def get_info_url(self, version):
-        """
-        Get link with info about version (eg. GitHub release page)
-        Return Type: str
-        """
-        return self.CT_INFO_URL + version


### PR DESCRIPTION
This PR simplifies the NorthStar Proton Ctmod by subclassing the GE-Proton ctmod, removing a lot of overlapping code.

As part of some cleanup to achieve this, the GE-Proton Ctmod was refactored slightly to hold a `release_format`. NorthStar Proton and GE-Proton both use `.tar.gz` formats, but in future I hope to allow more Ctmods to inherit from GE-Proton. Since I was here I figured it would be good housekeeping to implement it now that we have a couple of Ctmods taking from GE-Proton :-)

I tested both GE-Proton and NorthStar Proton and they should still be downloading correctly.

![image](https://github.com/user-attachments/assets/2a45aada-5a35-4a8a-adc0-df15280e22d2)

<hr>

Let me know if there are any concerns with this, or if I have missed something. Thanks!