### PR TITLE
GE-Proton: Use `download_file` from `network_util`

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_00protonge.py
+++ b/pupgui2/resources/ctmods/ctmod_00protonge.py
@@ -6,10 +6,12 @@ import os
 import requests
 import hashlib
 
+from PySide6.QtWidgets import QMessageBox
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.util import ghapi_rlcheck, extract_tar
 from pupgui2.util import build_headers_with_authorization
+from pupgui2.networkutil import download_file
 
 
 CT_NAME = 'GE-Proton'
@@ -25,6 +27,7 @@ class CtInstaller(QObject):
 
     p_download_progress_percent = 0
     download_progress_percent = Signal(int)
+    message_box_message = Signal(str, str, QMessageBox.Icon)
 
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
@@ -48,35 +51,30 @@ class CtInstaller(QObject):
         self.p_download_progress_percent = value
         self.download_progress_percent.emit(value)
 
-    def __download(self, url, destination):
+    def __download(self, url: str, destination: str, known_size: int = 0) -> bool:
         """
         Download files from url to destination
         Return Type: bool
         """
         try:
-            file = self.rs.get(url, stream=True)
-        except OSError:
-            return False
+            return download_file(
+                url=url,
+                destination=destination,
+                progress_callback=self.__set_download_progress_percent,
+                download_cancelled=self.download_canceled,
+                buffer_size=self.BUFFER_SIZE,
+                stream=True,
+                known_size=known_size
+            )
+        except Exception as e:
+            print(f"Failed to download tool {CT_NAME} - Reason: {e}")
 
-        self.__set_download_progress_percent(1) # 1 download started
-        f_size = int(file.headers.get('content-length'))
-        c_count = int(f_size / self.BUFFER_SIZE)
-        c_current = 1
-        destination = os.path.expanduser(destination)
-        os.makedirs(os.path.dirname(destination), exist_ok=True)
-        with open(destination, 'wb') as dest:
-            for chunk in file.iter_content(chunk_size=self.BUFFER_SIZE):
-                if self.download_canceled:
-                    self.download_canceled = False
-                    self.__set_download_progress_percent(-2) # -2 download canceled
-                    return False
-                if chunk:
-                    dest.write(chunk)
-                    dest.flush()
-                self.__set_download_progress_percent(int(min(c_current / c_count * 98.0, 98.0))) # 1-98, 100 after extract
-                c_current += 1
-        self.__set_download_progress_percent(99) # 99 download complete
-        return True
+            self.message_box_message.emit(
+                self.tr("Download Error!"),
+                self.tr(
+                    "Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e)),
+                QMessageBox.Icon.Warning
+            )
 
     def __sha512sum(self, filename):
         """

--- a/pupgui2/resources/ctmods/ctmod_protoncachyos.py
+++ b/pupgui2/resources/ctmods/ctmod_protoncachyos.py
@@ -35,33 +35,6 @@ class CtInstaller(ProtonGECtInstaller):
     CT_URL = 'https://api.github.com/repos/CachyOS/proton-cachyos/releases'
     CT_INFO_URL = 'https://github.com/CachyOS/proton-cachyos/releases/tag/'
 
-    message_box_message = Signal(str, str, QMessageBox.Icon)
-
-    def __download(self, url: str, destination: str, known_size: int = 0) -> bool:
-        """
-        Download files from url to destination
-        Return Type: bool
-        """
-        try:
-            return download_file(
-                url=url,
-                destination=destination,
-                progress_callback=self.__set_download_progress_percent,
-                download_cancelled=self.download_canceled,
-                buffer_size=self.BUFFER_SIZE,
-                stream=True,
-                known_size=known_size
-            )
-        except Exception as e:
-            print(f"Failed to download tool {CT_NAME} - Reason: {e}")
-
-            self.message_box_message.emit(
-                self.tr("Download Error!"),
-                self.tr(
-                    "Failed to download tool '{CT_NAME}'!\n\nReason: {EXCEPTION}".format(CT_NAME=CT_NAME, EXCEPTION=e)),
-                QMessageBox.Icon.Warning
-            )
-
     def __fetch_github_data(self, tag: str, arch: str) -> Optional[Dict]:
         """
         Fetch GitHub release information


### PR DESCRIPTION
This PR moves the download logic of GE-Proton to use `download_file` from `network_util`. Like #490, the primary benefit here is consistency, but this also allows us to simpify the recently merged Proton-CachyOS support #486. It was brought up in that PR that GE-Proton doesn't use this function, and now it does :-)

In my tests, GE-Proton downloads correctly still. If there are any concerns with the approach taken, let me know :-) 

Thanks!