### PR TITLE
Kron4ek: Simplify by Inheriting GE-Proton

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_00protonge.py
+++ b/pupgui2/resources/ctmods/ctmod_00protonge.py
@@ -113,7 +113,7 @@ class CtInstaller(QObject):
                 values['size'] = asset['size']
         return values
 
-    def is_system_compatible(self):
+    def is_system_compatible(self) -> bool:
         """
         Are the system requirements met?
         Return Type: bool

--- a/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
+++ b/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
@@ -2,15 +2,14 @@
 # Kron4ek Wine-Builds Vanilla
 # Copyright (C) 2021 DavidoTek, partially based on AUNaseef's protonup
 
-import os
 import subprocess
-import requests
 
-from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
+from PySide6.QtCore import QCoreApplication
 
 from pupgui2.constants import IS_FLATPAK
-from pupgui2.util import extract_tar
-from pupgui2.util import build_headers_with_authorization, fetch_project_release_data, fetch_project_releases
+from pupgui2.util import fetch_project_release_data, fetch_project_releases
+
+from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as GEProtonInstaller
 
 
 CT_NAME = 'Kron4ek Wine-Builds Vanilla'
@@ -18,69 +17,20 @@ CT_LAUNCHERS = ['lutris', 'winezgui']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_kron4ekvanilla', '''Compatibility tool "Wine" to run Windows games on Linux. Official version from the WineHQ sources, compiled by Kron4ek.''')}
 
 
-class CtInstaller(QObject):
+class CtInstaller(GEProtonInstaller):
 
     BUFFER_SIZE = 65536
     CT_URL = 'https://api.github.com/repos/Kron4ek/Wine-Builds/releases'
     CT_INFO_URL = 'https://github.com/Kron4ek/Wine-Builds/releases/tag/'
 
-    p_download_progress_percent = 0
-    download_progress_percent = Signal(int)
+    def __init__(self, main_window = None) -> None:
 
-    def __init__(self, main_window = None):
-        super(CtInstaller, self).__init__()
-        self.p_download_canceled = False
+        super().__init__(main_window)
+
         self.release_format = 'tar.xz'
-
-        self.rs = requests.Session()
-        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
-        self.rs.headers.update(rs_headers)
-
-    def get_download_canceled(self):
-        return self.p_download_canceled
-
-    def set_download_canceled(self, val):
-        self.p_download_canceled = val
-
-    download_canceled = Property(bool, get_download_canceled, set_download_canceled)
-
-    def __set_download_progress_percent(self, value : int):
-        if self.p_download_progress_percent == value:
-            return
-        self.p_download_progress_percent = value
-        self.download_progress_percent.emit(value)
-
-    def __download(self, url, destination):
-        """
-        Download files from url to destination
-        Return Type: bool
-        """
-        try:
-            file = self.rs.get(url, stream=True)
-        except OSError:
-            return False
-
-        self.__set_download_progress_percent(1) # 1 download started
-        f_size = int(file.headers.get('content-length'))
-        c_count = int(f_size / self.BUFFER_SIZE)
-        c_current = 1
-        destination = os.path.expanduser(destination)
-        os.makedirs(os.path.dirname(destination), exist_ok=True)
-        with open(destination, 'wb') as dest:
-            for chunk in file.iter_content(chunk_size=self.BUFFER_SIZE):
-                if self.download_canceled:
-                    self.download_canceled = False
-                    self.__set_download_progress_percent(-2) # -2 download canceled
-                    return False
-                if chunk:
-                    dest.write(chunk)
-                    dest.flush()
-                self.__set_download_progress_percent(int(min(c_current / c_count * 98.0, 98.0))) # 1-98, 100 after extract
-                c_current += 1
-        self.__set_download_progress_percent(99) # 99 download complete
-        return True
-
+    
     def __fetch_github_data(self, tag):
+
         """
         Fetch GitHub release information
         Return Type: dict
@@ -91,11 +41,13 @@ class CtInstaller(QObject):
         asset_condition = lambda asset: 'amd64' in asset.get('name', '') and 'staging' not in asset.get('name', '')
         return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag, asset_condition=asset_condition)
 
-    def is_system_compatible(self):
+    def is_system_compatible(self) -> bool:
+
         """
         Are the system requirements met?
         Return Type: bool
         """
+
         proc_prefix = ['flatpak-spawn', '--host'] if IS_FLATPAK else []
         ldd = subprocess.run(proc_prefix + ['ldd', '--version'], capture_output=True)
         ldd_out = ldd.stdout.split(b'\n')[0].split(b' ')
@@ -104,38 +56,11 @@ class CtInstaller(QObject):
         ldd_min = int(ldd_ver.split(b'.')[1])
         return False if ldd_maj < 2 else ldd_min >= 27 or ldd_maj != 2
 
-    def fetch_releases(self, count=100, page=1):
+    def fetch_releases(self, count: int = 100, page: int = 1) -> list[str]:
+ 
         """
         List available releases
         Return Type: str[]
         """
 
         return fetch_project_releases(self.CT_URL, self.rs, count=count, page=page)
-
-    def get_tool(self, version, install_dir, temp_dir):
-        """
-        Download and install the compatibility tool
-        Return Type: bool
-        """
-
-        data = self.__fetch_github_data(version)
-        if not data or 'download' not in data:
-            return False
-
-        kron4ek_tar = os.path.join(temp_dir, data['download'].split('/')[-1])
-        if not self.__download(url=data['download'], destination=kron4ek_tar):
-            return False
-
-        if not extract_tar(kron4ek_tar, install_dir, mode='xz'):
-            return False
-
-        self.__set_download_progress_percent(100)
-
-        return True
-
-    def get_info_url(self, version):
-        """
-        Get link with info about version (eg. GitHub release page)
-        Return Type: str
-        """
-        return self.CT_INFO_URL + version


### PR DESCRIPTION
This PR simplifies the Kron4ek Ctmod by inheriting from the GE-Proton Ctmod. A lot of the logic between these Ctmods is shared, similar to Proton-CachyOS (#486) and NorthStar Proton (#491), so this PR reduces the duplicated code. This was not possible before #491, where we introduced the `release_format` variable into GE-Proton.

Note that like in #491, we override `fetch_releases` and `__fetch_github_data`. I think this is a clean enough approach as it makes sense that these ctmods would have their own conditions for fetching releases, but let me know if this just makes things messy.

I still envision eventually that we can move to some kind of "base" ctmod, but I think incrementally moving existing Ctmods over to inheriting where it makes sense and cuts code duplication already is a good approach. But please let me know if it's just noisy :-) I am mainly interested here in simplifying our existing ctmods where possible.

Thanks!

<hr>

P.S. - The most obvious candidate to do this with may seem like the Wine-GE Ctmod, and I haven't forgotten about that Ctmod ;-) It just needs a lil bit of extra work to... work. But I'm... working on it :smile: