### PR TITLE
Proton-CachyOS: Remove deprecated Type Hinting

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_protoncachyos.py
+++ b/pupgui2/resources/ctmods/ctmod_protoncachyos.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2021 DavidoTek, partially based on AUNaseef's protonup
 
 import os
-from typing import override
 
 from PySide6.QtCore import QCoreApplication
 
@@ -33,7 +32,6 @@ class CtInstaller(ProtonGECtInstaller):
     CT_URL = 'https://api.github.com/repos/CachyOS/proton-cachyos/releases'
     CT_INFO_URL = 'https://github.com/CachyOS/proton-cachyos/releases/tag/'
 
-    @override
     def __fetch_github_data(self, tag: str, arch: str) -> dict | None:
         """
         Fetch GitHub release information
@@ -74,7 +72,6 @@ class CtInstaller(ProtonGECtInstaller):
             hwcaps.add('x86_64_v2')
         return hwcaps
 
-    @override
     def fetch_releases(self, count: int = 100, page: int = 1) -> list:
         """
         List available releases
@@ -94,7 +91,6 @@ class CtInstaller(ProtonGECtInstaller):
                         assets.append(name)
         return assets
 
-    @override
     def get_tool(self, version: str, install_dir: str, temp_dir: str):
         """
         Download and install the compatibility tool
@@ -139,7 +135,6 @@ class CtInstaller(ProtonGECtInstaller):
 
         return True
 
-    @override
     def get_info_url(self, version: str) -> str:
         """
         Get link with info about version (eg. GitHub release page)

--- a/pupgui2/resources/ctmods/ctmod_protoncachyos.py
+++ b/pupgui2/resources/ctmods/ctmod_protoncachyos.py
@@ -3,12 +3,10 @@
 # Copyright (C) 2021 DavidoTek, partially based on AUNaseef's protonup
 
 import os
-from typing import Dict, Optional, Set
+from typing import override
 
-from PySide6.QtCore import QCoreApplication, Signal
-from PySide6.QtWidgets import QMessageBox
+from PySide6.QtCore import QCoreApplication
 
-from pupgui2.networkutil import download_file
 from pupgui2.util import ghapi_rlcheck, extract_tar
 from .ctmod_00protonge import CtInstaller as ProtonGECtInstaller
 
@@ -35,7 +33,8 @@ class CtInstaller(ProtonGECtInstaller):
     CT_URL = 'https://api.github.com/repos/CachyOS/proton-cachyos/releases'
     CT_INFO_URL = 'https://github.com/CachyOS/proton-cachyos/releases/tag/'
 
-    def __fetch_github_data(self, tag: str, arch: str) -> Optional[Dict]:
+    @override
+    def __fetch_github_data(self, tag: str, arch: str) -> dict | None:
         """
         Fetch GitHub release information
         Return Type: dict
@@ -56,7 +55,7 @@ class CtInstaller(ProtonGECtInstaller):
                 values['size'] = asset['size']
         return values
 
-    def get_hwcaps(self) -> Set:
+    def get_hwcaps(self) -> set[str]:
         hwcaps = {'x86_64'}
         # flags according to https://gitlab.com/x86-psABIs/x86-64-ABI/-/blob/master/x86-64-ABI/low-level-sys-info.tex
         flags_v2 = {'sse4_1', 'sse4_2', 'ssse3'}
@@ -75,8 +74,8 @@ class CtInstaller(ProtonGECtInstaller):
             hwcaps.add('x86_64_v2')
         return hwcaps
 
-
-    def fetch_releases(self, count: int = 100, page: int = 1):
+    @override
+    def fetch_releases(self, count: int = 100, page: int = 1) -> list:
         """
         List available releases
         Return Type: str[]
@@ -95,6 +94,7 @@ class CtInstaller(ProtonGECtInstaller):
                         assets.append(name)
         return assets
 
+    @override
     def get_tool(self, version: str, install_dir: str, temp_dir: str):
         """
         Download and install the compatibility tool
@@ -139,6 +139,7 @@ class CtInstaller(ProtonGECtInstaller):
 
         return True
 
+    @override
     def get_info_url(self, version: str) -> str:
         """
         Get link with info about version (eg. GitHub release page)


### PR DESCRIPTION
This PR removes the deprecated type hints from the `typing` module. They exist sprinkled throughout the codebase, and should be removed, so I don't mean to single out this ctmod. I spotted this as I'm eyeing some changes to help it further inherit from the GE-Proton ctmod in the future, so I was in and around here and noticed it. I have also removed a couple of unused imports from this Ctmod.

I also added the `@override` annotation to methods we override from GE-Proton, which we currently don't do elsewhere in the codebase, although it is something I also did in #498. Like with removing the old deprecated type hints, I hope to go through and add these around the codebase where relevant (I think only the Ctmods, maybe there's a Qt component we subclass for the Shortcut Editor but I'm not 100% sure).

