### PR TITLE
Test: CtLoader

### DIFF
--- a/pupgui2/ctloader.py
+++ b/pupgui2/ctloader.py
@@ -64,7 +64,7 @@ class CtLoader(QObject):
         Return Type: []
         """
         if launcher is None:
-            return self.ctmods
+            return [ctmod for ctmod in self.ctmods if ('advmode' not in ctmod.CT_LAUNCHERS or advanced_mode)]
 
         ctmods = [ctmod for ctmod in self.ctmods if launcher in ctmod.CT_LAUNCHERS and ('advmode' not in ctmod.CT_LAUNCHERS or advanced_mode)]
 

--- a/pupgui2/ctloader.py
+++ b/pupgui2/ctloader.py
@@ -15,7 +15,6 @@ class CtLoader(QObject):
 
     def __init__(self, main_window = None):
         self.main_window = main_window
-        self.load_ctmods()
 
     def load_ctmods(self) -> bool:
         """
@@ -56,7 +55,7 @@ class CtLoader(QObject):
                 icon=QMessageBox.Warning,
                 detailed_text=detailed_text
             )
-        return True
+        return len(failed_ctmods) == 0
 
     def get_ctmods(self, launcher=None, advanced_mode=True):
         """

--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -88,6 +88,7 @@ class MainWindow(QObject):
         }
 
         self.ct_loader = ctloader.CtLoader(main_window=self)
+        _ = self.ct_loader.load_ctmods()
 
         for ctobj in self.ct_loader.get_ctobjs():
             cti = ctobj.get('installer')

--- a/tests/test_ctmods.py
+++ b/tests/test_ctmods.py
@@ -1,0 +1,31 @@
+from PySide6.QtWidgets import QApplication
+
+from pupgui2.ctloader import CtLoader
+
+
+class DummyMainWindow:
+    """ Dummy MainWindow object for the CtLoader test. Works thanks to duck typing. """
+
+    def __init__(self, web_access_tokens: dict[str, str]) -> None:
+        self.web_access_tokens = web_access_tokens
+
+
+def test_ctmod_loader() -> None:
+    """
+    Test loading of ctmods using CtLoader.
+    """
+    QApplication()
+    
+    dummy_main_window = DummyMainWindow({})
+
+    ct_loader = CtLoader(main_window=dummy_main_window)
+
+    # Ensure that ctmods are loaded successfully
+    assert(ct_loader.load_ctmods() is True)
+
+    # Ensure that ctmods are loaded (assume at least one ctmod is exists)
+    assert(len(ct_loader.get_ctmods()) > 0)
+    assert(len(ct_loader.get_ctobjs()) > 0)
+
+    # Ensure that no advanced mode ctmods are loaded when advanced_mode is False
+    assert(all(["advmode" not in ctmod.CT_LAUNCHERS for ctmod in ct_loader.get_ctmods(launcher=None, advanced_mode=False)]))


### PR DESCRIPTION
Adds a test for loading ctmods using the CtLoader as ctmods are currently not tested in CI/CD:

- Check if all ctmods are loaded successfully
- Check if the advanced mode filter works
- Fix CtLoader: Return correct ctmod list if `launcher=None` and `advanced_mode=False`
- Fix CtLoader: `load_ctmods` will return `False` if not all ctmods were loaded successfully

The current tests do not verify that the ctmods are working, only whether they can be loaded successfully. This is especially interesting for testing for syntax errors and compatibility with the Python version of the test/build system.

@DavidoTek TODO for future PR: Test the functionality of individual ctmods (fetching releases, downloading, installing, ...)