### PR TITLE
Bump version to 2.12.0

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -19,7 +19,7 @@ AppDir:
     id: net.davidotek.pupgui2
     name: ProtonUp-Qt
     icon: net.davidotek.pupgui2
-    version: 2.11.1
+    version: 2.12.0
     exec: usr/bin/python3
     exec_args: "-m pupgui2 $@"
 

--- a/pupgui2/constants.py
+++ b/pupgui2/constants.py
@@ -6,7 +6,7 @@ from PySide6.QtGui import QColor, QPalette
 
 
 APP_NAME = 'ProtonUp-Qt'
-APP_VERSION = '2.11.1'
+APP_VERSION = '2.12.0'
 APP_ID = 'net.davidotek.pupgui2'
 APP_THEMES = ( 'light', 'dark', 'system', 'steam', None )
 APP_ICON_FILE = os.path.join(xdg_config_home, 'pupgui/appicon256.png')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ProtonUp-Qt
-version = 2.11.1
+version = 2.12.0
 description = Install Wine- and Proton-based compatibility tools
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/share/metainfo/net.davidotek.pupgui2.appdata.xml
+++ b/share/metainfo/net.davidotek.pupgui2.appdata.xml
@@ -69,6 +69,18 @@
   <content_rating type="oars-1.0" />
 
   <releases>
+    <release version="2.12.0" date="2025-03-29">
+      <description>
+        <p>Changes/Improvements:</p>
+        <ul>
+          <li>Added the Proton-CachyOS compatibility tool</li>
+          <li>Added a new theme for the Steam Deck</li>
+          <li>Added a new dialog for configuring GitHub and GitLab API access tokens</li>
+          <li>Removed Wine-GE in favour of GE-Proton and UMU for Lutris</li>
+        </ul>
+        <p>Various improvements and bug fixes. See GitHub for more details. Thanks to sonic2kk and the other contributers!</p>
+      </description>
+    </release>
     <release version="2.11.1" date="2025-01-05">
       <description>
         <p>Changes/Improvements:</p>


### PR DESCRIPTION
- Added the Proton-CachyOS compatibility tool
- Added a new theme for the Steam Deck
- Added a new dialog for configuring GitHub and GitLab API access tokens
- Removed Wine-GE in favour of GE-Proton and UMU for Lutris