### PR TITLE
DXVK Nightly: Simplify by Inheriting from DXVK Ctmod

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -102,14 +102,30 @@ class CtInstaller(QObject):
         """
         return fetch_project_releases(self.CT_URL, self.rs, count=count, page=page)
 
+    def __get_data(self, version: str, install_dir: str) -> tuple[dict | None, str | None]:
+
+        """
+        Get needed download data and path to extract directory.
+        Return Type: diple[dict | None, str | None]
+        """
+
+        data = self.__fetch_data(version)
+        if not data or 'download' not in data:
+            return (None, None)
+
+        dxvk_dir = self.get_extract_dir(install_dir)
+
+        return (data, dxvk_dir)
+
+
     def get_tool(self, version, install_dir, temp_dir):
         """
         Download and install the compatibility tool
         Return Type: bool
         """
 
-        data = self.__fetch_data(version)
-        if not data or 'download' not in data:
+        data, dxvk_dir = self.__get_data(version, install_dir)
+        if not data:
             return False
 
         # Should be updated to support Heroic, like ctmod_d8vk
@@ -117,8 +133,7 @@ class CtInstaller(QObject):
         if not self.__download(url=data['download'], destination=dxvk_tar, known_size=data.get('size', 0)):
             return False
 
-        dxvk_dir = self.get_extract_dir(install_dir)
-        if not extract_tar(dxvk_tar, dxvk_dir, mode='gz'):
+        if not dxvk_dir or not extract_tar(dxvk_tar, dxvk_dir, mode='gz'):
             return False
 
         self.__set_download_progress_percent(100)

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -21,20 +21,20 @@ CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_z0dxvk', ''
 
 class CtInstaller(QObject):
 
-    BUFFER_SIZE = 65536
-    CT_URL = 'https://api.github.com/repos/doitsujin/dxvk/releases'
-    CT_INFO_URL = 'https://github.com/doitsujin/dxvk/releases/tag/'
+    BUFFER_SIZE: int = 65536
+    CT_URL: str = 'https://api.github.com/repos/doitsujin/dxvk/releases'
+    CT_INFO_URL: str = 'https://github.com/doitsujin/dxvk/releases/tag/'
 
-    p_download_progress_percent = 0
-    download_progress_percent = Signal(int)
-    message_box_message = Signal((str, str, QMessageBox.Icon))
+    p_download_progress_percent: int = 0
+    download_progress_percent: Signal = Signal(int)
+    message_box_message: Signal = Signal((str, str, QMessageBox.Icon))
 
     def __init__(self, main_window = None):
         super(CtInstaller, self).__init__()
-        self.p_download_canceled = False
-        self.release_format = 'tar.gz'
+        self.p_download_canceled: bool = False
+        self.release_format: str = 'tar.gz'
 
-        self.rs = requests.Session()
+        self.rs: requests.Session = requests.Session()
         rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
         self.rs.headers.update(rs_headers)
 
@@ -95,7 +95,7 @@ class CtInstaller(QObject):
         """
         return True
 
-    def fetch_releases(self, count=100, page=1):
+    def fetch_releases(self, count: int = 100, page: int = 1):
         """
         List available releases
         Return Type: list[str]
@@ -139,7 +139,7 @@ class CtInstaller(QObject):
         # If unknown archive format, cannot extract, so default to fail
         return False
 
-    def get_tool(self, version, install_dir, temp_dir):
+    def get_tool(self, version: str, install_dir: str, temp_dir: str) -> bool:
         """
         Download and install the compatibility tool
         Return Type: bool
@@ -150,7 +150,7 @@ class CtInstaller(QObject):
             return False
 
         # Should be updated to support Heroic, like ctmod_d8vk
-        dxvk_archive = os.path.join(temp_dir, data['download'].split('/')[-1])
+        dxvk_archive: str = os.path.join(temp_dir, data['download'].split('/')[-1])
         if not self.__download(url=data['download'], destination=dxvk_archive, known_size=data.get('size', 0)):
             return False
 
@@ -161,7 +161,7 @@ class CtInstaller(QObject):
 
         return True
 
-    def get_info_url(self, version):
+    def get_info_url(self, version: str) -> str:
         """
         Get link with info about version (eg. GitHub release page)
         Return Type: str

--- a/pupgui2/resources/ctmods/ctmod_z0dxvk.py
+++ b/pupgui2/resources/ctmods/ctmod_z0dxvk.py
@@ -9,7 +9,7 @@ import requests
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.networkutil import download_file
-from pupgui2.util import extract_tar, extract_zip, get_launcher_from_installdir, fetch_project_releases
+from pupgui2.util import extract_tar, get_launcher_from_installdir, fetch_project_releases
 from pupgui2.util import fetch_project_release_data, build_headers_with_authorization
 from pupgui2.datastructures import Launcher
 
@@ -128,16 +128,9 @@ class CtInstaller(QObject):
             return False
         
         # DXVK and DXVK Async are 'tar.gz'
-        if self.release_format.startswith('tar'):
-            tar_type = self.release_format.split('.')[-1]
+        tar_type = self.release_format.split('.')[-1]
 
-            return extract_tar(archive_path, extract_dir, mode=tar_type)
-        # DXVK Nightly is 'zip'
-        elif self.release_format == 'zip':
-            return extract_zip(archive_path, extract_dir)
-
-        # If unknown archive format, cannot extract, so default to fail
-        return False
+        return extract_tar(archive_path, extract_dir, mode=tar_type)
 
     def get_tool(self, version: str, install_dir: str, temp_dir: str) -> bool:
         """

--- a/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
+++ b/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
@@ -3,12 +3,12 @@
 # Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
 
 import os
-import requests
 
-from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
+from PySide6.QtCore import QCoreApplication
 
-from pupgui2.util import ghapi_rlcheck, extract_zip
-from pupgui2.util import build_headers_with_authorization
+from pupgui2.util import ghapi_rlcheck
+
+from pupgui2.resources.ctmods.ctmod_z0dxvk import CtInstaller as DXVKInstaller
 
 
 CT_NAME = 'DXVK (nightly)'
@@ -16,85 +16,61 @@ CT_LAUNCHERS = ['lutris', 'advmode']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_z2dxvknightly', '''Nightly version of DXVK (master branch), a Vulkan based implementation of Direct3D 8, 9, 10 and 11 for Linux/Wine.<br/><br/><b>Warning: Nightly version is unstable, use with caution!</b>''')}
 
 
-class CtInstaller(QObject):
+class CtInstaller(DXVKInstaller):
 
-    BUFFER_SIZE = 65536
-    CT_URL = 'https://api.github.com/repos/doitsujin/dxvk/actions/artifacts'
-    CT_INFO_URL = 'https://github.com/doitsujin/dxvk/commit/'
-
-    p_download_progress_percent = 0
-    download_progress_percent = Signal(int)
+    BUFFER_SIZE: int = 65536
+    CT_URL: str = 'https://api.github.com/repos/doitsujin/dxvk/actions/artifacts'
+    CT_INFO_URL: str = 'https://github.com/doitsujin/dxvk/commit/'
 
     def __init__(self, main_window = None):
-        super(CtInstaller, self).__init__()
-        self.p_download_canceled = False
 
-        self.rs = requests.Session()
-        rs_headers = build_headers_with_authorization({}, main_window.web_access_tokens, 'github')
-        self.rs.headers.update(rs_headers)
+        super().__init__(main_window)
 
-    def get_download_canceled(self):
-        return self.p_download_canceled
+        self.release_format: str = 'zip'
 
-    def set_download_canceled(self, val):
-        self.p_download_canceled = val
+    def fetch_releases(self, count: int = 100, page: int = 1):
 
-    download_canceled = Property(bool, get_download_canceled, set_download_canceled)
-
-    def __set_download_progress_percent(self, value : int):
-        if self.p_download_progress_percent == value:
-            return
-        self.p_download_progress_percent = value
-        self.download_progress_percent.emit(value)
-
-    def __download(self, url, destination, f_size):
-        # f_size in argumentbecause artifacts don't have Content-Length.
         """
-        Download files from url to destination
-        Return Type: bool
+        List available releases
+        Return Type: str[]
         """
-        try:
-            file = requests.get(url, stream=True)
-        except OSError:
-            return False
 
-        self.__set_download_progress_percent(1) # 1 download started
-        c_count = int(f_size / self.BUFFER_SIZE)
-        c_current = 1
-        destination = os.path.expanduser(destination)
-        os.makedirs(os.path.dirname(destination), exist_ok=True)
-        with open(destination, 'wb') as dest:
-            for chunk in file.iter_content(chunk_size=self.BUFFER_SIZE):
-                if self.download_canceled:
-                    self.download_canceled = False
-                    self.__set_download_progress_percent(-2) # -2 download canceled
-                    return False
-                if chunk:
-                    dest.write(chunk)
-                    dest.flush()
-                self.__set_download_progress_percent(int(min(c_current / c_count * 98.0, 98.0))) # 1-98, 100 after extract
-                c_current += 1
-        self.__set_download_progress_percent(99) # 99 download complete
-        return True
+        # TODO no longer correct because DXVK has two workflows, see #500
+        tags = []
 
-    def __get_artifact_from_commit(self, commit):
+        for artifact in ghapi_rlcheck(self.rs.get(f'{self.CT_URL}?per_page={count}&page={page}').json()).get("artifacts", {}):
+            workflow = artifact['workflow_run']
+            if workflow["head_branch"] != "master" or artifact["expired"]:
+                continue
+            tags.append(workflow['head_sha'][:7])
+
+        return tags
+
+    def __get_artifact_from_commit(self, commit: str):
+
         """
         Get artifact from commit
         Return Type: str
         """
+
+        # TODO this may also need changed as a result of #500
         for artifact in self.rs.get(f'{self.CT_URL}?per_page=100').json()["artifacts"]:
             if artifact['workflow_run']['head_sha'][:len(commit)] == commit:
                 artifact['workflow_run']['head_sha'] = commit
+
                 return artifact
+
         return None
 
-    def __fetch_github_data(self, tag):
+    def __fetch_github_data(self, tag: str):
+
         """
         Fetch GitHub release information
         Return Type: dict
         Content(s):
-            'version', 'date', 'download', 'size', 'checksum'
+            'version', 'date', 'download', 'size'
         """
+
         # Tag in this case is the commit hash.
         data = self.__get_artifact_from_commit(tag)
         if not data:
@@ -105,50 +81,26 @@ class CtInstaller(QObject):
         values['size'] = data['size_in_bytes']
         return values
 
-    def is_system_compatible(self):
-        """
-        Are the system requirements met?
-        Return Type: bool
-        """
-        return True
+    def __get_data(self, version: str, install_dir: str) -> tuple[dict | None, str | None]:
 
-    def fetch_releases(self, count=100, page=1):
         """
-        List available releases
-        Return Type: str[]
+        Get needed download data and path to extract directory.
+        Return Type: diple[dict | None, str | None]
         """
-        tags = []
-        for artifact in ghapi_rlcheck(self.rs.get(f'{self.CT_URL}?per_page={count}&page={page}').json()).get("artifacts", {}):
-            workflow = artifact['workflow_run']
-            if workflow["head_branch"] != "master" or artifact["expired"]:
-                continue
-            tags.append(workflow['head_sha'][:7])
-        return tags
 
-    def get_tool(self, version, install_dir, temp_dir):
-        """
-    Download and install the compatibility tool
-        Return Type: bool
-        """
         data = self.__fetch_github_data(version)
-        if not data or 'download' not in data:
-            return False
+        if not data or not 'download' in data:
+            return (None, None)
 
-        dxvk_zip = os.path.join(temp_dir, data['download'].split('/')[-1])
-        if not self.__download(url=data['download'], destination=dxvk_zip, f_size=data['size']):
-            return False
-
+        # TODO This is hardcoded to Lutris as DXVK Nightly currently doesn't support any other launchers -- Could possibly add support for Heroic in future
         dxvk_dir = os.path.join(install_dir, '../../runtime/dxvk', 'dxvk-git-' + data['version'])
-        if not extract_zip(dxvk_zip, dxvk_dir):
-            return False
 
-        self.__set_download_progress_percent(100)
+        return (data, dxvk_dir)
 
-        return True
-
-    def get_info_url(self, version):
+    def get_info_url(self, version: str) -> str:
         """
         Get link with info about version (eg. GitHub release page)
         Return Type: str
         """
+
         return self.CT_INFO_URL + version

--- a/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
+++ b/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
@@ -6,7 +6,7 @@ import os
 
 from PySide6.QtCore import QCoreApplication
 
-from pupgui2.util import ghapi_rlcheck
+from pupgui2.util import extract_zip, ghapi_rlcheck
 
 from pupgui2.resources.ctmods.ctmod_z0dxvk import CtInstaller as DXVKInstaller
 
@@ -136,6 +136,18 @@ class CtInstaller(DXVKInstaller):
         dxvk_dir = os.path.join(install_dir, '../../runtime/dxvk', 'dxvk-git-' + data['version'])
 
         return (data, dxvk_dir)
+
+    def __extract(self, archive_path: str, extract_dir: str) -> bool:
+
+        """
+        Extract the tool archive at the given path.
+        Return Type: bool
+        """
+
+        if not archive_path or not extract_dir:
+            return False
+
+        return extract_zip(archive_path, extract_dir)
 
     def get_info_url(self, version: str) -> str:
 

--- a/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
+++ b/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
@@ -21,9 +21,10 @@ class CtInstaller(DXVKInstaller):
     BUFFER_SIZE: int = 65536
     CT_WORKFLOW_URL: str = 'https://api.github.com/repos/doitsujin/dxvk/actions/workflows'
     CT_ARTIFACT_URL: str = 'https://api.github.com/repos/doitsujin/dxvk/actions/runs/{}/artifacts'
+    CT_ALL_ARTIFACTS_URL: str = 'https://api.github.com/repos/doitsujin/dxvk/actions/artifacts'
     CT_INFO_URL: str = 'https://github.com/doitsujin/dxvk/commit/'
 
-    DXVK_WORKFLOW_NAME = 'artifacts'
+    DXVK_WORKFLOW_NAME: str = 'artifacts'
 
     def __init__(self, main_window = None):
 
@@ -31,36 +32,45 @@ class CtInstaller(DXVKInstaller):
 
         self.release_format: str = 'zip'
 
-    # TODO break out into separate util function and unit test with:
-    #      * happy path
-    #      * 30 successful workflows across pages (expired artifacts that spread them across pages)
-    #      * successful workflows but not enough to mmatch the count (say 15 successful workflows)
-    #      * 0 successful workflows (all failed) 
-    def __fetch_workflows(self, count: int = 30) -> list:
+    def __fetch_workflows(self, count: int = 30) -> list[str]:
 
         """
         Get all active, successful runs in the DXVK Linux-compatible workflow.
         Return Type: list
         """
 
-        tags: list = []
-        for workflow in self.rs.get(f'{self.CT_WORKFLOW_URL}?per_page={str(count)}').json().get("workflows", {}):
+        workflow_request_url: str = f'{self.CT_WORKFLOW_URL}?per_page={str(count)}'
+        workflow_response_json: dict = self.rs.get(workflow_request_url).json()
+
+        tags: list[str] = []
+        for workflow in workflow_response_json.get('workflows', {}):
             if workflow['state'] != "active" or self.DXVK_WORKFLOW_NAME not in workflow['path']:
                 continue
 
             page = 1
-            while page != -1 and page < 5:  # fetch more (up to 5 pages) if first releases all failed
+            while page != -1 and page <= 5:  # fetch more (up to 5 pages) if first releases all failed
                 at_least_one_failed = False  # ensure the reason that len(tags)=0 is that releases failed
-                for run in self.rs.get(workflow['url'] + f'/runs?per_page={str(count)}&page={page}').json()['workflow_runs']:
-                    if run['conclusion'] == "success":
-                        tags.append(str(run['id']))
-                    elif run['conclusion'] == "failure":
+
+                workflow_runs_request_url: str = f'{workflow["url"]}/runs?per_page={count}&page={page}'
+                workflow_runs_response_json: dict = self.rs.get(workflow_runs_request_url).json()
+
+                for run in workflow_runs_response_json.get('workflow_runs', {}):
+                    if run['conclusion'] == "failure":
                         at_least_one_failed = True
+
+                        continue
+
+                    # TODO can make this generic so that i.e. this DXVK Ctmod can use commmit SHAs but Proton-tkg can use workflow IDs?
+                    #      then this could be a generic function shared between ctmods and could be in a util file, unit tested, etc
+                    commit_hash: str = str(run['head_commit']['id'][:7])
+                    tags.append(commit_hash)
 
                 if len(tags) == 0 and at_least_one_failed:
                     page += 1
-                else:
-                    page = -1
+
+                    continue
+
+                page = -1
 
         return tags
 
@@ -73,19 +83,21 @@ class CtInstaller(DXVKInstaller):
 
         return self.__fetch_workflows(count=count)
 
-    # TODO break out into separate util functio and unit test
-    def __get_artifact_url_from_id(self, id: str):
+    def __get_artifact_from_commit(self, commit):
+
         """
-        Get artifact by the workflow run ID.
+        Get artifact from commit
         Return Type: str
         """
-        print(f'{self.CT_ARTIFACT_URL.format(id)}?per_page=100')
 
-        artifact_info = self.rs.get(f'{self.CT_ARTIFACT_URL.format(id)}?per_page=100').json()
-        if artifact_info.get("total_count") != 1:
-            return None
-
-        return artifact_info["artifacts"][0]
+        for artifact in self.rs.get(f'{self.CT_ALL_ARTIFACTS_URL}?per_page=100').json()["artifacts"]:
+            # DXVK appends '-msvc-output' to Windows builds
+            # See: https://github.com/doitsujin/dxvk/blob/20a6fae8a7f60e7719724b229552eba1ae6c3427/.github/workflows/test-build-windows.yml#L80
+            if artifact['workflow_run']['head_sha'][:len(commit)] == commit and not artifact['name'].endswith('-msvc-output'):
+                artifact['workflow_run']['head_sha'] = commit
+                return artifact
+        
+        return None
 
     def __fetch_github_data(self, tag: str):
 
@@ -96,8 +108,8 @@ class CtInstaller(DXVKInstaller):
             'version', 'date', 'download', 'size'
         """
 
-        # Tag in this case is the workflow run ID
-        data = self.__get_artifact_url_from_id(tag)
+        # Tag in this case is the commit hash
+        data = self.__get_artifact_from_commit(tag)
         if not data:
             return
         values = {'version': data['workflow_run']['head_sha'][:7], 'date': data['updated_at'].split('T')[0]}

--- a/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
+++ b/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
@@ -19,8 +19,11 @@ CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_z2dxvknight
 class CtInstaller(DXVKInstaller):
 
     BUFFER_SIZE: int = 65536
-    CT_URL: str = 'https://api.github.com/repos/doitsujin/dxvk/actions/artifacts'
+    CT_WORKFLOW_URL: str = 'https://api.github.com/repos/doitsujin/dxvk/actions/workflows'
+    CT_ARTIFACT_URL: str = 'https://api.github.com/repos/doitsujin/dxvk/actions/runs/{}/artifacts'
     CT_INFO_URL: str = 'https://github.com/doitsujin/dxvk/commit/'
+
+    DXVK_WORKFLOW_NAME = 'artifacts'
 
     def __init__(self, main_window = None):
 
@@ -28,39 +31,61 @@ class CtInstaller(DXVKInstaller):
 
         self.release_format: str = 'zip'
 
-    def fetch_releases(self, count: int = 100, page: int = 1):
+    # TODO break out into separate util function and unit test with:
+    #      * happy path
+    #      * 30 successful workflows across pages (expired artifacts that spread them across pages)
+    #      * successful workflows but not enough to mmatch the count (say 15 successful workflows)
+    #      * 0 successful workflows (all failed) 
+    def __fetch_workflows(self, count: int = 30) -> list:
 
         """
-        List available releases
-        Return Type: str[]
+        Get all active, successful runs in the DXVK Linux-compatible workflow.
+        Return Type: list
         """
 
-        # TODO no longer correct because DXVK has two workflows, see #500
-        tags = []
-
-        for artifact in ghapi_rlcheck(self.rs.get(f'{self.CT_URL}?per_page={count}&page={page}').json()).get("artifacts", {}):
-            workflow = artifact['workflow_run']
-            if workflow["head_branch"] != "master" or artifact["expired"]:
+        tags: list = []
+        for workflow in self.rs.get(f'{self.CT_WORKFLOW_URL}?per_page={str(count)}').json().get("workflows", {}):
+            if workflow['state'] != "active" or self.DXVK_WORKFLOW_NAME not in workflow['path']:
                 continue
-            tags.append(workflow['head_sha'][:7])
+
+            page = 1
+            while page != -1 and page < 5:  # fetch more (up to 5 pages) if first releases all failed
+                at_least_one_failed = False  # ensure the reason that len(tags)=0 is that releases failed
+                for run in self.rs.get(workflow['url'] + f'/runs?per_page={str(count)}&page={page}').json()['workflow_runs']:
+                    if run['conclusion'] == "success":
+                        tags.append(str(run['id']))
+                    elif run['conclusion'] == "failure":
+                        at_least_one_failed = True
+
+                if len(tags) == 0 and at_least_one_failed:
+                    page += 1
+                else:
+                    page = -1
 
         return tags
 
-    def __get_artifact_from_commit(self, commit: str):
+    def fetch_releases(self, count: int = 30, page: int = 1) -> list[str]:
 
         """
-        Get artifact from commit
+        List available releases.
+        Return Type: str[]
+        """
+
+        return self.__fetch_workflows(count=count)
+
+    # TODO break out into separate util functio and unit test
+    def __get_artifact_url_from_id(self, id: str):
+        """
+        Get artifact by the workflow run ID.
         Return Type: str
         """
+        print(f'{self.CT_ARTIFACT_URL.format(id)}?per_page=100')
 
-        # TODO this may also need changed as a result of #500
-        for artifact in self.rs.get(f'{self.CT_URL}?per_page=100').json()["artifacts"]:
-            if artifact['workflow_run']['head_sha'][:len(commit)] == commit:
-                artifact['workflow_run']['head_sha'] = commit
+        artifact_info = self.rs.get(f'{self.CT_ARTIFACT_URL.format(id)}?per_page=100').json()
+        if artifact_info.get("total_count") != 1:
+            return None
 
-                return artifact
-
-        return None
+        return artifact_info["artifacts"][0]
 
     def __fetch_github_data(self, tag: str):
 
@@ -71,8 +96,8 @@ class CtInstaller(DXVKInstaller):
             'version', 'date', 'download', 'size'
         """
 
-        # Tag in this case is the commit hash.
-        data = self.__get_artifact_from_commit(tag)
+        # Tag in this case is the workflow run ID
+        data = self.__get_artifact_url_from_id(tag)
         if not data:
             return
         values = {'version': data['workflow_run']['head_sha'][:7], 'date': data['updated_at'].split('T')[0]}
@@ -98,6 +123,7 @@ class CtInstaller(DXVKInstaller):
         return (data, dxvk_dir)
 
     def get_info_url(self, version: str) -> str:
+
         """
         Get link with info about version (eg. GitHub release page)
         Return Type: str

--- a/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
+++ b/pupgui2/resources/ctmods/ctmod_z2dxvknightly.py
@@ -55,6 +55,9 @@ class CtInstaller(DXVKInstaller):
                 workflow_runs_response_json: dict = self.rs.get(workflow_runs_request_url).json()
 
                 for run in workflow_runs_response_json.get('workflow_runs', {}):
+                    if run['head_branch'] != 'master':
+                        continue
+
                     if run['conclusion'] == "failure":
                         at_least_one_failed = True
 


### PR DESCRIPTION
Fixes #500.

## Overview
This PR refactors the DXVK Nightly Ctmod to inherit from the DXVK Ctmod, as there is quite a bit of shared logic between these Ctmods.

This PR also fixes #500 by refactoring the logic of how we fetch releases. Much of the complexity in this PR comes from fixing #500, not from the refactor itself. This complexity would have arisen regardless of the refactor.

### Before (`main` @ 44ec5917f6c5096795d9e6455e262048b9ce6935)

#### CtInstaller Dialog Contains Invalid Versions

![image](https://github.com/user-attachments/assets/5034fdd6-2da0-4e82-96df-4dbe8068e4aa)

#### Expected Folder Structure

![image](https://github.com/user-attachments/assets/1ae4d2d3-693e-4b3a-b99c-cd1ab3f72b5e)

### After (This PR)

#### CtInstaller Dialog Contains Only Valid Versions

![image](https://github.com/user-attachments/assets/36a47b08-fea5-4412-bc40-a8c1c8aa11fd)

#### Expected Folder Structure Preserved

![image](https://github.com/user-attachments/assets/7a7ac0e1-08f4-4fa9-a275-98aa16f98634)

## Implementation
### Ctmod Refactoring
In order for DXVK Nightly to inherit from the main DXVK Ctmod, a slight rework was needed to the main DXVK Ctmod.
- We needed to create a `__get_data` method in order to allow the DXVK Nightly child class to override this method.
    - It needs to override the `data` that comes back, so that it returns the data from `__fetch_github_data` (which works with `__fetch_artifact_from_commit` to get the GitHub Actions workflow artifact information from the given commit the user selects in the version dropdown) instead of `__fetch_data`. This ultimately allows us to use the `nightly.link` link that gets set on `data` and then is downloaded via the DXVK main class's `get_tool` when it calls the overridden `__get_data`.
    - This is essentially the same idea as what we did in #498.
- For cleanliness, I broke out the extraction logic for the downloaded archive into an `__extract` method. This puts all of the conditional checks for if we're working with a ZIP or a tarball into this method.
    - However, since this is broken out as a separate method, we could let the DXVK Nightly ctmod handle overriding the extract logic as well. Instead of the main DXVK Ctmod handling this, Ctmods that inherit and need different functionality can override this method. Happy to discuss this, and will leave a comment about this after posting the PR :-)

I have tested the main DXVK Ctmod, DXVK Async (which also inherits from the main DXVK Ctmod), and of course DXVK Nightly, and the extracted folder (name and directory structure) works just how it does on `main` @ 44ec5917f6c5096795d9e6455e262048b9ce6935 right now.

### Fixing Workflow Fetching Logic
Onto how #500 was solved: Previously, we were fetching all releases from all workflows. That is, going to `https://api.github.com/repos/doitsujin/dxvk/actions/artifacts?per_page=50&page=1` and taking all of the Commit SHAs from the runs. This worked before, when DXVK only had one workflow, and so each commit only had one artifact. However now DXVK has two workflows: `artifacts.yml` for our Linux DXVK DLLs (and DXVK Native, which is an archive inside of these workflows) and `test-build-windows.yml` which builds DXVK with MSVC. This results in two workflows per commit, so we end up with DXVK versions being listed twice most of the time.

To fix this:
- **When fetching releases**, we need to instead only fetch runs that occurred in the `artifacts.yml` workflow. This means we will only populate the releases dropdown with valid commit hashes.
    - This unfortunately adds a little bit of overhead to the length of time it takes to fetch releases that is imo noticeable, but I don't think we can avoid it.
    - **I encountered some segfaults in initial development**, but have not been able to reproduce it in the extensive testing that has followed. 
- **When downloading**, we want to make sure the artifact we select does not end in `-msvc-output`. This means when we select a commit to download, instead of just picking the first one that matches the commit, we will pick the one that does not end in `-msvc-output` which should currently always correspond to the valid `artifacts.yml` workflow.
    - This is needed in addition to only fetching releases from a corresponding workflow to ensure we fetch the correct amount of artifacts. More on this in "[Checking For `-msvc-output` Suffix](#checking-for-msvc-output-suffix)".
    - In future, if other workflows were added or if this suffix changed, we would need to also ignore these. It may be sufficient to just check if our package ends with the expected commit hash and nothing else, we can discuss this though :-) I will leave a comment about this after posting this PR.

#### Using Commit Hashes
The solution of fetching runs from only a specific workflow comes from the solution we used for the Proton-tkg ctmod, as outlined in #500. In the DXVK Nightly Ctmod I have implemented a `__get_workflows` method [very similar to what we used for Proton-tkg](https://github.com/DavidoTek/ProtonUp-Qt/blob/7264188f6475016fc1e348092334f11945e05a1a/pupgui2/resources/ctmods/ctmod_protontkg.py#L146-L164), but the main difference is that I chose to return Commit SHAs instead of Workflow Run IDs. There are benefits to this:
- It preserves the existing behaviour for DXVK Nightly, which displays Commit SHAs.
- It preserves the functionality of `get_info_url` method which will allow the "info" button on the CtInstaller dialog to open at that commit.

#### Reusing `__fetch_workflows`
I would really like `__fetch_workflows` to be a generic function, inside of a `githubutils.py` file. The ultimate goal here would be to allow this to be re-used between DXVK Nightly, Proton-tkg, and anything else that might require it. In addition, it would allow us to create unit tests for this function that we could test against pre-defined JSON files of test data. We _could_ write unit tests eventually for our Ctmods (and hopefully will do this) that would cover this, but I would also like if this was a standalone function that could be tested.

I had actually refactored this method out into a standalone function, inside of a `githubutils.py` file, but I scrapped that because I realised that in its current state we cannot re-use it between DXVK Nightly and Proton-tkg because DXVK Nightly works with commit hashes but Proton-tkg works with Workflow IDs. If we want to make this function generic, we would need a way to define what it should return in its `tags` list (`tags` is not the best name, either, and is likely a holdover from working with release tags for tagged, non-nightly artifacts).

I decided not to tackle that in this PR, as I feel a separate PR could cover making the function generic and reusable between DXVK Nightly and Proton-tkg, and also that same PR could handle writing the unit tests.

#### Checking For `-msvc-output` Suffix
We check for the suffix to ensure we only download artifacts with commits that correspond to the artifact we want to use. Since we aren't working with Workflow IDs like with Proton-tkg, which are unique, we are getting all workflow runs with the commit. In this case there are usually two: One for `artifacts.yml`, and one for `test-windows-build.yml`. We can tell these builds apart based on a suffix that is appended to the MSVC builds, `-msvc-output`. This output comes from the [`test-windows-build.yml`](https://github.com/doitsujin/dxvk/blob/20a6fae8a7f60e7719724b229552eba1ae6c3427/.github/workflows/test-build-windows.yml#L80) GitHub Actions workflow file.

When I discovered this, I did consider that just checking the artifact name for `.endswith('-msvc-output')` would be enough, however this would result in returning fewer artifacts than we should. If a page returns 50 artifacts, and each commit has two artifacts (one for `artifacts.yml`, one for `test-windows-build.yml`), and we then filter to exclude the artifacts that end with `-msvc-output`, we end up with only 25 artifacts. This is why checking _all_ the artifacts in the `count` variable is important: We want to make sure we count all artifacts that we know are in a workflow that is valid, in this case checking all workflows in `artifacts.yml`.

Also, as a result of using `__fetch_workflows`, we are able to skip expired artifacts and move backwards through pages to make sure we collect as many artifacts as we can.

**Side Note**: It is conceivable (though not observed in my testing) that a DXVK `test-build-windows.yml` build would be the only present artifact for a commit (i.e. no Linux-compatible artifact at all), therefore even if only one version was listed, that listed version would always be invalid. With the current approach I have taken in this PR by only fetching commit SHAs for runs inside of the `artifacts.yml` workflow, and filtering out workflow runs that have `-msvc-output` in the name, we can guarantee that the versions we list are only successfully built artifacts from the `artifacts.yml` workflow, and we will never get Windows downloads (unless the `-msvc-output` suffix changes for MSVC builds).

<hr>

Some significant changes here with fixing DXVK Nightly to only download artifacts from the correct workflow. Let me know if any of the rationale here or justification was not explained properly, happy to elaborate however I can! And as usual, all feedback is welcome :-)

Thanks!