### PR TITLE
lutrisutil: Remove deprecated `List` type hint

### DIFF
--- a/pupgui2/lutrisutil.py
+++ b/pupgui2/lutrisutil.py
@@ -1,5 +1,4 @@
 import os
-from typing import List
 import sqlite3
 
 from pupgui2.datastructures import LutrisGame
@@ -8,10 +7,10 @@ from pupgui2.datastructures import LutrisGame
 LUTRIS_PGA_GAMELIST_QUERY = 'SELECT slug, name, runner, installer_slug, installed_at, directory FROM games'
 
 
-def get_lutris_game_list(install_loc) -> List[LutrisGame]:
+def get_lutris_game_list(install_loc) -> list[LutrisGame]:
     """
     Returns a list of installed games in Lutris
-    Return Type: List[LutrisGame]
+    Return Type: list[LutrisGame]
     """
     install_dir = os.path.expanduser(install_loc.get('install_dir'))
     lutris_data_dir = os.path.join(install_dir, os.pardir, os.pardir)


### PR DESCRIPTION
I kept meaning to do this one, but not sure why I never got around to it :sweat_smile:

Figure it's best to do these file-by-file at best, and if any bigger files (like the utils) need this, function-by-function or something around as granular as that. :-)