### PR TITLE
CtInfo: Remove deprecated `List` and `Dict` type hints

### DIFF
--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -15,7 +15,7 @@ from PySide6.QtUiTools import QUiLoader
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QShortcut, QKeySequence
 
-from typing import List, Union
+from typing import Union
 
 
 class PupguiCtInfoDialog(QObject):
@@ -26,7 +26,7 @@ class PupguiCtInfoDialog(QObject):
         super(PupguiCtInfoDialog, self).__init__(parent)
         self.parent = parent
         self.ctool = ctool
-        self.games: List[Union[SteamApp, LutrisGame, HeroicGame]] = []
+        self.games: list[Union[SteamApp, LutrisGame, HeroicGame]] = []
         self.install_loc = install_loc
         self.is_batch_update_available = False
 
@@ -111,7 +111,7 @@ class PupguiCtInfoDialog(QObject):
             self.ui.listGames.setItem(i, 0, QTableWidgetItem(game.runner))
             self.ui.listGames.setItem(i, 1, QTableWidgetItem(game.title))
 
-    def setup_game_list(self, row_count: int, header_labels: List[str]):
+    def setup_game_list(self, row_count: int, header_labels: list[str]):
         self.ui.listGames.clear()
         self.ui.listGames.setRowCount(row_count)
         self.ui.listGames.setHorizontalHeaderLabels(header_labels)

--- a/pupgui2/pupgui2ctinfodialog.py
+++ b/pupgui2/pupgui2ctinfodialog.py
@@ -15,8 +15,6 @@ from PySide6.QtUiTools import QUiLoader
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QShortcut, QKeySequence
 
-from typing import Union
-
 
 class PupguiCtInfoDialog(QObject):
 
@@ -26,7 +24,7 @@ class PupguiCtInfoDialog(QObject):
         super(PupguiCtInfoDialog, self).__init__(parent)
         self.parent = parent
         self.ctool = ctool
-        self.games: list[Union[SteamApp, LutrisGame, HeroicGame]] = []
+        self.games: list[SteamApp | LutrisGame | HeroicGame] = []
         self.install_loc = install_loc
         self.is_batch_update_available = False
 


### PR DESCRIPTION
I had to look up the replacement for the `Union` type hint just to be sure, and I think I got it right :-) 

Reference: https://www.blog.pythonlibrary.org/2021/09/11/python-3-10-simplifies-unions-in-type-annotations/