### PR TITLE
Ctmod: Add Proton-tkg (Wine Master NTSYNC)

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_protontkg_ntsync.py
+++ b/pupgui2/resources/ctmods/ctmod_protontkg_ntsync.py
@@ -1,0 +1,23 @@
+# pupgui2 compatibility tools module
+# Proton-Tkg https://github.com/Frogging-Family/wine-tkg-git
+# Copyright (C) 2022 DavidoTek, partially based on AUNaseef's protonup
+
+from PySide6.QtCore import QCoreApplication
+
+from pupgui2.resources.ctmods.ctmod_protontkg import CtInstaller as TKGCtInstaller  # Use ProtonTKg Ctmod as base
+
+
+CT_NAME = 'Proton Tkg (Wine Master NTSYNC)'
+CT_LAUNCHERS = ['steam', 'heroicproton', 'advmode']
+CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_protontkg_winemaster_ntsync', '''Custom Proton build for running Windows games, built with the Wine-tkg build system.
+<br/>
+<br/>
+This build is based on <b>Wine Master</b> and includes the <b>NTSYNC</b> patches (Requires a Kernel with NTSYNC support).''')}
+
+
+class CtInstaller(TKGCtInstaller):
+
+    PROTON_PACKAGE_NAME = 'proton-arch-ntsync-nopackage.yml'
+
+    def __init__(self, main_window = None):
+        super().__init__(main_window)


### PR DESCRIPTION
Close #516.

This PR implements a Ctmod for downloading Proton-tkg with the NTSYNC patches for Wine Master.

I have tested that this successfully downloads and extracts a Proton-tkg version that is the same size as a manually downloaded archive. I also tested that the workflow ID in the dropdown matches that of the same verified Proton-tkg (Wine Master NTSYNC) ctmod (https://github.com/Frogging-Family/wine-tkg-git/actions/runs/14285965734).

However, I don't have a Kernel with the NTSYNC patches yet. I believe this is only included in Kernel 6.14+, and I am also not sure how to verify if NTSYNC is being used. But I have taken steps to verify that the archive downloaded is sane and matches what would be downloaded manually.

Note: It takes an absolute _age_ to download these archives from ProtonUp-Qt, probably because of `nightly.link` (as it is faster direct from GitHub, but not much we can do there :sweat_smile:).

Thanks!