### PR TITLE
Ctmod: Add Proton-Sarek

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_protonsarek.py
+++ b/pupgui2/resources/ctmods/ctmod_protonsarek.py
@@ -2,6 +2,9 @@
 # pythonlover02's Proton-Sarek
 # Copyright (C) 2025 DavidoTek, partially based on AUNaseef's protonup
 
+from typing import Callable
+
+
 from PySide6.QtCore import QCoreApplication
 
 from pupgui2.util import fetch_project_release_data, fetch_project_releases
@@ -28,13 +31,13 @@ class CtInstaller(GEProtonInstaller):
         self.async_suffix = '-async'
 
     def fetch_releases(self, count: int = 100, page: int = 1) -> list[str]:
-        
+
         """
         List available releases
         Return Type: str[]
         """
 
-        include_extra_asset = lambda release: release['tag_name'] + self.async_suffix if any(self.async_suffix in asset['name'] for asset in release['assets']) else None
+        include_extra_asset: Callable[..., list[str]] = lambda release: [str(release.get('tag_name', '')) + self.async_suffix for asset in release.get('assets', {}) if self.async_suffix in asset.get('name', '')]
         return fetch_project_releases(self.CT_URL, self.rs, count=count, page=page, include_extra_asset=include_extra_asset)
 
     def __fetch_github_data(self, tag: str) -> dict:

--- a/pupgui2/resources/ctmods/ctmod_protonsarek.py
+++ b/pupgui2/resources/ctmods/ctmod_protonsarek.py
@@ -2,11 +2,9 @@
 # pythonlover02's Proton-Sarek
 # Copyright (C) 2025 DavidoTek, partially based on AUNaseef's protonup
 
-import os
-
 from PySide6.QtCore import QCoreApplication
 
-from pupgui2.util import fetch_project_release_data, ghapi_rlcheck
+from pupgui2.util import fetch_project_release_data, fetch_project_releases
 
 from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as GEProtonInstaller
 
@@ -36,21 +34,10 @@ class CtInstaller(GEProtonInstaller):
         Return Type: str[]
         """
 
-        tags: list[str] = []
-        for release in ghapi_rlcheck(self.rs.get(f'{self.CT_URL}?per_page={count}&page={page}').json()):
-            if not 'tag_name' in release:
-                continue
+        include_extra_asset = lambda release: release['tag_name'] + self.async_suffix if any(self.async_suffix in asset['name'] for asset in release['assets']) else None
+        return fetch_project_releases(self.CT_URL, self.rs, count=count, page=page, include_extra_asset=include_extra_asset)
 
-            tags.append(release['tag_name'])
-            if 'assets' not in release or len(release['assets']) <= 0:
-                continue
-
-            if any(self.async_suffix in asset['name'] for asset in release['assets']):
-                tags.append(release['tag_name'] + self.async_suffix)
-
-        return tags
-
-    def __fetch_github_data(self, tag: str, is_async: bool) -> dict:
+    def __fetch_github_data(self, tag: str) -> dict:
 
         """
         Fetch GitHub release information
@@ -60,30 +47,8 @@ class CtInstaller(GEProtonInstaller):
         """
 
         # Exclude async builds by default -- Maybe 'get_download_url_from_asset' needs to be stricter?
-        asset_condition = lambda asset: self.async_suffix not in asset['name']
-        if is_async:
-            asset_condition = lambda asset: self.async_suffix in asset['name']
-
-        return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag, asset_condition=asset_condition)
-
-    def __get_data(self, version: str, install_dir: str) -> tuple[dict | None, str | None]:
-
-        """
-        Get needed download data and path to extract directory.
-        Return Type: tuple[dict | None, str | None]
-        """
-
-        is_async = self.async_suffix in version
-        if is_async:
-            version = version.replace(self.async_suffix, '')
-
-        data = self.__fetch_github_data(version, is_async)
-        if not data or 'download' not in data:
-            return (None, None)
-
-        protondir = os.path.join(install_dir, data['version'])
-
-        return (data, protondir)
+        asset_condition = lambda asset: self.async_suffix in asset['name'] if self.async_suffix in tag else self.async_suffix not in asset['name']
+        return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag.replace(self.async_suffix, ''), asset_condition=asset_condition)
 
     def get_info_url(self, version: str) -> str:
 

--- a/pupgui2/resources/ctmods/ctmod_protonsarek.py
+++ b/pupgui2/resources/ctmods/ctmod_protonsarek.py
@@ -13,7 +13,7 @@ from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as GEProtonIns
 
 
 CT_NAME = 'Proton-Sarek'
-CT_LAUNCHERS = ['steam', 'heroicproton', 'bottles', 'advmode']
+CT_LAUNCHERS = ['steam', 'lutris', 'heroicproton', 'bottles', 'advmode']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_protonsarek', '''A custom Proton build with <a href="https://github.com/pythonlover02/DXVK-Sarek">DXVK-Sarek</a> for users with GPUs that support Vulkan 1.1+ but not Vulkan 1.3, or for those with non-Vulkan support who want a plug-and-play option featuring personal patches.''')}
 
 

--- a/pupgui2/resources/ctmods/ctmod_protonsarek.py
+++ b/pupgui2/resources/ctmods/ctmod_protonsarek.py
@@ -1,0 +1,47 @@
+# pupgui2 compatibility tools module
+# pythonlover02's Proton-Sarek
+# Copyright (C) 2025 DavidoTek, partially based on AUNaseef's protonup
+
+from PySide6.QtCore import QCoreApplication
+
+from pupgui2.util import fetch_project_release_data, fetch_project_releases
+
+from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as GEProtonInstaller
+
+
+CT_NAME = 'Proton-Sarek'
+CT_LAUNCHERS = ['steam', 'heroicproton', 'bottles', 'advmode']
+CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_protonsarek', '''A custom Proton build with <a href="https://github.com/pythonlover02/DXVK-Sarek">DXVK-Sarek</a> for users with GPUs that support Vulkan 1.1+ but not Vulkan 1.3, or for those with non-Vulkan support who want a plug-and-play option featuring personal patches.''')}
+
+
+class CtInstaller(GEProtonInstaller):
+
+    BUFFER_SIZE = 65536
+    CT_URL = 'https://api.github.com/repos/pythonlover02/Proton-Sarek/releases'
+    CT_INFO_URL = 'https://github.com/pythonlover02/Proton-Sarek/releases/tag/'
+
+    def __init__(self, main_window = None) -> None:
+
+        super().__init__(main_window)
+
+        self.release_format: str = 'tar.gz'
+
+    def fetch_releases(self, count: int = 100, page: int = 1) -> list[str]:
+        
+        """
+        List available releases
+        Return Type: str[]
+        """
+
+        return fetch_project_releases(self.CT_URL, self.rs, count=count, page=page)
+
+    def __fetch_github_data(self, tag: str) -> dict:
+        
+        """
+        Fetch GitHub release information
+        Return Type: dict
+        Content(s):
+            'version', 'date', 'download', 'size'
+        """
+
+        return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag)

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -609,7 +609,7 @@ def is_online(host: str = 'https://api.github.com/rate_limit/', timeout: int = 5
 
 
 # Only used for dxvk and dxvk-async right now, but is potentially useful to more ctmods?
-def fetch_project_releases(releases_url: str, rs: requests.Session, count=100, page=1) -> list[str]:
+def fetch_project_releases(releases_url: str, rs: requests.Session, count: int = 100, page: int = 1, include_extra_asset: Callable | None = None) -> list[str]:
 
     """
     List available releases for a given project URL hosted using requests.
@@ -628,7 +628,21 @@ def fetch_project_releases(releases_url: str, rs: requests.Session, count=100, p
     else:
         return []  # Unknown API, cannot fetch releases!
 
-    return [release[tag_key] for release in releases if tag_key in release]
+    releases_list: list[str] = []
+    for release in releases:
+        if tag_key in release:
+            releases_list.append(release[tag_key])
+
+        if 'assets' not in release or len(release['assets']) <= 0:
+            continue
+
+        if not include_extra_asset:
+            continue
+
+        if extra_asset := include_extra_asset(release):
+            releases_list.append(extra_asset)
+
+    return releases_list
 
 
 def get_assets_from_release(release_url: str, release: dict) -> dict:

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -609,7 +609,7 @@ def is_online(host: str = 'https://api.github.com/rate_limit/', timeout: int = 5
 
 
 # Only used for dxvk and dxvk-async right now, but is potentially useful to more ctmods?
-def fetch_project_releases(releases_url: str, rs: requests.Session, count: int = 100, page: int = 1, include_extra_asset: Callable | None = None) -> list[str]:
+def fetch_project_releases(releases_url: str, rs: requests.Session, count: int = 100, page: int = 1, include_extra_asset: Callable[..., list[str]] | None = None) -> list[str]:
 
     """
     List available releases for a given project URL hosted using requests.
@@ -639,8 +639,7 @@ def fetch_project_releases(releases_url: str, rs: requests.Session, count: int =
         if not include_extra_asset:
             continue
 
-        if extra_asset := include_extra_asset(release):
-            releases_list.append(extra_asset)
+        releases_list.extend([asset for asset in include_extra_asset(release)])
 
     return releases_list
 


### PR DESCRIPTION
Implements #464.

~~**NOTE**: [Proton-Sarek has regular and `-async` releases](https://github.com/pythonlover02/Proton-Sarek/releases/tag/Proton-Sarek9-27) for each of its tags, similar to what [Lutris-Wine does with fshack builds](https://github.com/lutris/wine/releases/tag/lutris-wine-7.2).~~

~~This PR does **not** currently display these, and will be in draft until I can implement this. Right now it seems to default to downloading the "-async" builds, but ideally we'd want to display "-async" as a separate tag just like we do for Lutris-Wine fshack builds. A similar approach may be a possible drop-in but I will work on it :-)~~

Support for downloading async and non-async builds was added in 517cdc0. The above note has been fully addressed :slightly_smiling_face: 

## Overview
This PR implements [Proton-Sarek](https://github.com/pythonlover02/Proton-Sarek) as a Ctmod (gated behind Advanced Mode, as per https://github.com/DavidoTek/ProtonUp-Qt/issues/464#issuecomment-2399641754) for Steam, Heroic Proton, and Bottles.

I tested that the ctmod downloaded and extracted with the expected file structure. The compatibility tool displays inside of Steam as expected and I tested using it with "Hammerwatch: Anniversary Edition". The game loaded fine using "Proton-Sarek9-27-async".

## Implementation
This is implemented by subclassing the GE-Proton ctmod and overriding the methods to fetch releases and fetch GitHub data, as they use different logic. A lot of this borrows from how we do things with Lutris-Wine, where we need to support fshack and non-fshack builds (see "Concerns" for more details).

Most of this ctmod is largely copy-pasted from NorthStar Proton, as it also subclasses GE-Proton. However I didn't believe it was good practice to subclass NorthStar Proton, in case any changes were made to that ctmod that made it no longer compatible. In other words, it just happens that they both take the same approach (and maybe eventually we'll have a better ctmod "type" that this Proton version and others can base themselves on).

## Concerns
The logic we use in `fetch_releases`, `__fetch_github_data`, `__get_data`, and `get_info_url` is almost identical to what we use for Lutris Wine, except with Lutris Wine we use `fshack` instead of `-async` as our identifier for  the rogue releases. We also need an extra `asset_condition` by default for Proton-Sarek to make sure we don't download the `-async` builds when we aren't using an `-async` tag.

My primary concern with this PR is that I would like to get rid of this duplication. I would like a way for us to keep this PR lean without the duplicated logic. I don't think tweaking and subclassing LutrisWine so that we can have a generic extra tag identifier (i.e. `fshack` for LutrisWine, `-async` for Proton-Sarek) is the solution. Maybe I need to sleep on it and think about it some more but in my head this smells of coupling the Proton-Sarek ctmod too "low down".

It is worth noting that if we do go the road of adding DXVK-Sarek, then it would hit the same issue as it has -async and non-async builds. It can likely be solved in the exact same manner, just subclassing the main DXVK Ctmod instead of GE-Proton, but we would again end up with a bunch of repeated code that I'd like to avoid if possible.

Perhaps there is just not a better solution for now. But I would like to discuss finding one before merging this PR!

I left a note about the behaviour requiring `asset_condition` in both cases of `is_async` being `True` and `False`, as I wonder if we should be stricter in [`get_download_url_from_asset`](https://github.com/DavidoTek/ProtonUp-Qt/blob/a82eeabea2714ea9f3b8031b70593f2d1c0ec517/pupgui2/util.py#L651) in the tag name that we check against to use exact matches by default, but I'm not sure if this would break anything. I haven't tested, but i have a hunch that it will cause problems. Then again, an `asset_condition` when this is needed does suffice, so it may not be worth the extra effort.

## Future Work
I wonder if it is worth exposing [DXVK-Sarek](https://github.com/pythonlover02/DXVK-Sarek) for Lutris and Heroic Wine. If so, that  may be better suited to wait for #509 to be merged.

Lastly, I wonder if this should be made available for Lutris. Now that we make GE-Proton available for Lutris, since Proton itself is more broadly compatible with Non-Steam environments thanks to UMU (discussion in #191, implementation in #496), should all of our Proton forks be made available for installation into Lutris, or even Heroic Proton? In my opinion, making these available for Lutris makes sense, but for Heroic Proton I'm not sure as I don't know if it uses UMU / Steam Linux Runtime (iirc it did maybe have some integration to use the Steam Linux Runtime, but I'm not sure of the current state).

<hr>

As usual, all feedback is welcome. Thanks!