### PR TITLE
GE-Proton: Use `fetch_project_releases` util function

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_00protonge.py
+++ b/pupgui2/resources/ctmods/ctmod_00protonge.py
@@ -128,7 +128,7 @@ class CtInstaller(QObject):
 
         return (data, protondir)
 
-    def is_system_compatible(self):
+    def is_system_compatible(self) -> bool:
         """
         Are the system requirements met?
         Return Type: bool

--- a/pupgui2/resources/ctmods/ctmod_00protonge.py
+++ b/pupgui2/resources/ctmods/ctmod_00protonge.py
@@ -9,7 +9,7 @@ import hashlib
 from PySide6.QtWidgets import QMessageBox
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
-from pupgui2.util import ghapi_rlcheck, extract_tar
+from pupgui2.util import fetch_project_releases, ghapi_rlcheck, extract_tar
 from pupgui2.util import build_headers_with_authorization
 from pupgui2.networkutil import download_file
 
@@ -135,12 +135,13 @@ class CtInstaller(QObject):
         """
         return True
 
-    def fetch_releases(self, count=100, page=1):
+    def fetch_releases(self, count: int = 100, page: int = 1) -> list[str]:
         """
         List available releases
         Return Type: str[]
         """
-        return [release['tag_name'] for release in ghapi_rlcheck(self.rs.get(f'{self.CT_URL}?per_page={count}&page={page}').json()) if 'tag_name' in release]
+
+        return fetch_project_releases(self.CT_URL, self.rs, count=count)
 
     def get_tool(self, version, install_dir, temp_dir):
         """

--- a/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
+++ b/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
@@ -29,7 +29,7 @@ class CtInstaller(GEProtonInstaller):
 
         self.release_format = 'tar.xz'
     
-    def __fetch_github_data(self, tag):
+    def __fetch_github_data(self, tag: str) -> dict:
 
         """
         Fetch GitHub release information
@@ -56,11 +56,3 @@ class CtInstaller(GEProtonInstaller):
         ldd_min = int(ldd_ver.split(b'.')[1])
         return False if ldd_maj < 2 else ldd_min >= 27 or ldd_maj != 2
 
-    def fetch_releases(self, count: int = 100, page: int = 1) -> list[str]:
- 
-        """
-        List available releases
-        Return Type: str[]
-        """
-
-        return fetch_project_releases(self.CT_URL, self.rs, count=count, page=page)

--- a/pupgui2/resources/ctmods/ctmod_northstarproton.py
+++ b/pupgui2/resources/ctmods/ctmod_northstarproton.py
@@ -4,7 +4,7 @@
 
 from PySide6.QtCore import QObject, Signal, Property, QCoreApplication
 
-from pupgui2.util import fetch_project_release_data, fetch_project_releases
+from pupgui2.util import fetch_project_release_data
 
 from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as GEProtonInstaller
 
@@ -25,14 +25,6 @@ class CtInstaller(GEProtonInstaller):
         super().__init__(main_window)
 
         self.release_format: str = 'tar.gz'
-
-    def fetch_releases(self, count: int = 100, page: int = 1) -> list[str]:
-        """
-        List available releases
-        Return Type: str[]
-        """
-
-        return fetch_project_releases(self.CT_URL, self.rs, count=count, page=page)
 
     def __fetch_github_data(self, tag: str) -> dict:
         """


### PR DESCRIPTION
This PR moves the GE-Proton ctmod over to using the `fetch_project_releases` util function that other ctmods use. It also allows us to avoid unnecessarily overriding `fetch_releases` in ctmods that don't need to. This likely would have worked before (see RTSP-GE-Proton) but using relying on a generic util function is probably safer than custom logic specifically for GE-Proton's `fetch_releases`.

In my tests, there has been no difference between the releases displayed or any issues downloading releases following this change for GE-Proton, NorthStar Proton, or Kron4ek Wine.

We now have more commonality between ctmods and less repeated code. We were able to remove `fetch_releases` overrides for RTSP-GE-Proton and Kron4ek Vanilla Wine Builds.

Thanks!