### PR TITLE
Batch Update: Remove Unused Import and add Type Hints

### DIFF
--- a/pupgui2/pupgui2ctbatchupdatedialog.py
+++ b/pupgui2/pupgui2ctbatchupdatedialog.py
@@ -1,7 +1,7 @@
 import pkgutil
 
 from PySide6.QtCore import Signal, Qt, QObject, QDataStream, QByteArray
-from PySide6.QtWidgets import QLabel, QFormLayout
+from PySide6.QtWidgets import QFormLayout, QLabel
 from PySide6.QtUiTools import QUiLoader
 
 from pupgui2.steamutil import is_steam_running, steam_update_ctool
@@ -23,12 +23,12 @@ class PupguiCtBatchUpdateDialog(QObject):
         self.setup_ui(current_ctool_name)
         self.ui.show()
 
-    def load_ui(self):
+    def load_ui(self) -> None:
         data = pkgutil.get_data(__name__, 'resources/ui/pupgui2_ctbatchupdatedialog.ui')
         ui_file = QDataStream(QByteArray(data))
         self.ui = QUiLoader().load(ui_file.device())
 
-    def setup_ui(self, current_ctool_name: str):
+    def setup_ui(self, current_ctool_name: str) -> None:
         # Doing ctool checks here instead of before showing the batch update button on ctinfo dialog covers case where
         # compatibility tool may have been available but then was removed (maybe manually?) -- Is potentially just more robust
         combobox_ctools = [ctool for ctool in self.ctools if 'Proton' in ctool and current_ctool_name not in ctool]
@@ -50,13 +50,13 @@ class PupguiCtBatchUpdateDialog(QObject):
         else:  # Spacer label
             self.ui.formLayout.addRow(QLabel())
 
-    def add_warning_message(self, msg: str, layout, stylesheet: str = 'QLabel { color: orange; }'):
+    def add_warning_message(self, msg: str, layout: QFormLayout, stylesheet: str = 'QLabel { color: orange; }'):
         """
         Add a QLabel warning message with a default Orange stylesheet to display a warning message in a Layout.
         """
 
         lblWarning = QLabel(msg)
-        lblWarning.setAlignment(Qt.AlignCenter)
+        lblWarning.setAlignment(Qt.AlignmentFlag.AlignCenter)
         lblWarning.setStyleSheet(stylesheet)
         layout.addRow(lblWarning)
 


### PR DESCRIPTION
Small PR to remove an unused import, and while I was in here I added a couple of type hints I want to call out a type hint added for `layout` which should make it clearer when reading which layout we're referring to, which is why I specifically singled it out.

We may want to expand this in future, but I just added a couple that are low hanging fruit. For example we may want to actually validate and handle cases where `pkgutil.get_data` returns `None` (would apply to many other files that use UI files). The remaining typing changes will really come down to what kind of standards we want to set for the codebase, which is why I held off for now. It can be done at a later date :-) 