### PR TITLE
Proton-CachyOS: Override `__get_data` instead of `get_tool`

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_00protonge.py
+++ b/pupgui2/resources/ctmods/ctmod_00protonge.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import QMessageBox
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
 from pupgui2.datastructures import Launcher
-from pupgui2.util import fetch_project_releases, get_launcher_from_installdir, ghapi_rlcheck, extract_tar
+from pupgui2.util import fetch_project_releases, get_launcher_from_installdir, extract_tar
 from pupgui2.util import build_headers_with_authorization
 from pupgui2.networkutil import download_file
 


### PR DESCRIPTION
This PR makes a small refactor to the Proton-CachyOS Ctmod which removes the need to override all of the `GEProtonInstaller#get_tool` ctmod. Instead, we can just override `__get_data`, which was implemented as part of #498 - Long after this ctmod was implemented, this was not missed when this ctmod was implemented, but it is something we can take advantage of now.

In order to fully take advantage of this we did need to add an `__init__` definition which sets `self.release_format`, since the GE-Proton ctmod uses this to know how to extract the tarfile. In future, we may want an `__extract` method similar to what we do for DXVK, but the current implementation is fine. Even if it were moved to an `__extract` method, it should be fine to keep the current implementation so that ctmods which are standard tarfiles can continue to use the same extract logic.

There is probably still some simplification that can be done to this ctmod, I have my eye on `__fetch_github_data`, and `fetch_releases` may be able to be simplified if the approach to modifying `fetch_project_releases` in #518 is accepted. But for now, this is what I have :smile: 

As usual, all feedback is welcome! Thanks!