### PR TITLE
test_util: Parametrize some tests

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -76,38 +76,44 @@ def test_get_dict_key_from_value(test_dict: dict[str | int | Launcher, str | str
         assert type(retrieved_key) is expected_type
 
 
-def test_get_launcher_from_installdir() -> None:
+@pytest.mark.parametrize(
+    'launcher_paths, expected_launcher', [
+        pytest.param(
+            [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'steam' ],
+            Launcher.STEAM,
+            id='Steam Launcher'
+        ),
+        pytest.param(
+            [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'lutris' ],
+            Launcher.LUTRIS,
+            id='Lutris Launcher'
+        ),
+        pytest.param(
+            [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] in ('heroicwine', 'heroicproton') ],
+            Launcher.HEROIC,
+            id='Heroic Wine / Heroic Proton Launcher'
+        ),
+        pytest.param(
+            [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'bottles' ],
+            Launcher.BOTTLES,
+            id='Bottles Launcher'
+        ),
+        pytest.param(
+            [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'winezgui' ],
+            Launcher.WINEZGUI,
+            id='WineZGUI Launcher'
+        ),
+    ]
+)
+def test_get_launcher_from_installdir(launcher_paths: list[str], expected_launcher: Launcher) -> None:
 
     """
     Test whether get_laucher_from_installdir returns the correct Launcher type Enum from the installdir path.
     """
 
-    # All possible Steam paths
-    steam_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'steam' ]
-    steam_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(steam_path) for steam_path in steam_install_paths ]
+    launcher_from_installdir: list[Launcher] = [ get_launcher_from_installdir(launcher_path) for launcher_path in launcher_paths ]
 
-    # All possible Lutris paths
-    lutris_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'lutris' ]
-    lutris_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(lutris_path) for lutris_path in lutris_install_paths ]
-
-    # All possible Heroic paths
-    heroic_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] in ['heroicwine', 'heroicproton'] ]
-    heroic_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(heroic_path) for heroic_path in heroic_install_paths ]
-
-    # All possible Bottles paths
-    bottles_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'bottles' ]
-    bottles_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(bottles_path) for bottles_path in bottles_install_paths ]
-
-    # All possible WineZGUI paths
-    winezgui_install_paths: list[str] = [ install_location['install_dir'] for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'winezgui' ]
-    winezgui_install_path_tests: list[Launcher] = [ get_launcher_from_installdir(winezgui_path) for winezgui_path in winezgui_install_paths ]
-
-
-    assert all(launcher == Launcher.STEAM for launcher in steam_install_path_tests)
-    assert all(launcher == Launcher.LUTRIS for launcher in lutris_install_path_tests)
-    assert all(launcher == Launcher.HEROIC for launcher in heroic_install_path_tests)
-    assert all(launcher == Launcher.BOTTLES for launcher in bottles_install_path_tests)
-    assert all(launcher == Launcher.WINEZGUI for launcher in winezgui_install_path_tests)
+    assert all(launcher == expected_launcher for launcher in launcher_from_installdir)
 
 
 def test_get_random_game_name() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pupgui2.util import *
 
 from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS
@@ -40,36 +42,38 @@ def test_build_headers_with_authorization() -> None:
     assert github_token_call.get('User-Agent', '') == user_agent
 
 
-def test_get_dict_key_from_value() -> None:
+@pytest.mark.parametrize(
+    'test_dict, expected_type', [
+        pytest.param(
+            { 'steam': 'Steam', 'lutris': 'Lutris' },
+            str,
+            id = 'Get string launcher keys from dict'
+        ),
+        pytest.param(
+            { 2: 'two', 4: 'four' },
+            int,
+            id = 'Get integer keys from string value'
+        ),
+        pytest.param(
+            { Launcher.WINEZGUI: True, Launcher.HEROIC: False },
+            Launcher,
+            id = 'Get Enum (Launcher) keys from boolean value'
+        ),
+    ],
+)
+def test_get_dict_key_from_value(test_dict: dict[str | int | Launcher, str | str | bool], expected_type: str | int | Launcher) -> None:
 
     """
-    Test whether get_dict_key_from_value can retrieve the expected key from a dict by a value,
-    where the key and value can be of any type.
+    Test whether get_dict_key_from_value can retrieve the expected key of an expected type from a given dictionary,
+    where the key-value pair can be of any type.
     """
 
-    dict_with_str_keys: dict[str, str] = {
-        'steam': 'Steam',
-        'lutris': 'Lutris',
-    }
+    for key, value in test_dict.items():
 
-    dict_with_int_keys: dict[int, str] = {
-        2: 'two',
-        4: 'four'
-    }
+        retrieved_key: str | int | Launcher = get_dict_key_from_value(test_dict, value)
 
-    dict_with_enum_keys: dict[Launcher, bool] = {
-        Launcher.WINEZGUI: True,
-        Launcher.HEROIC: False
-    }
-
-    test_dicts: list[dict[Any, Any]] = [
-        dict_with_str_keys,
-        dict_with_int_keys,
-        dict_with_enum_keys,
-    ]
-
-    for test_dict in test_dicts:
-        assert all( get_dict_key_from_value(test_dict, value) == key for key, value in test_dict.items() )
+        assert retrieved_key == key
+        assert type(retrieved_key) is expected_type
 
 
 def test_get_launcher_from_installdir() -> None:


### PR DESCRIPTION
This PR refactors two tests in `test_util` - `test_get_dict_key_from_value` and `test_get_launcher_from_installdir` - to use PyTest's `parametrize` feature. The rationale here is that instead of constructing test data inside of the tests for all different scenarios (in this case, many different launcher scenarios), we can instead pass in a list of scenarios to test.

For example in `test_get_launcher_from_installdir`, we pass in the Steam launcher list, then the Lutris launcher list, etc, and then for each of the scenarios passed in, the test will run against those without us having to define all of that logic. This allows the test itself to be lean and generic. This also makes it easy to add additional scenarios.

We can even name these scenarios using an `id`, so that when we run tests we can see the exact parametrized scenario. Previously we wouldn't have had any insight, whereas now if one parametrized test fails we can see the name (ID) of the failed test.

<hr>

Note that `test_get_random_game_name` was left out of this, as we'd probably want in future to have some kind of PyTest fixture for games from each launcher that we can re-use. So for now the implementation was left alone :-)

<hr>

I pushed for testing in general in ProtonUp-Qt, and I've been slacking. I've been trying to find the best pattern to go with for writing and thus submitting tests, and have been trying to learn as much as I can about writing "good" tests so that we can end up with a robust test suite that will give us confidence in that green "tick".

Hopefully this is a good first step in improving our tests and giving a good pattern on writing tests going forward. I'm already looking into writing some tests for the non-happy-path scenarios for the existing tests, and expanding the test suite. But that will come at a later date. :wink: 

Thanks!