### PR TITLE
test_util: Implement tests for `is_online`

### DIFF
--- a/.github/workflows/testing-ci.yml
+++ b/.github/workflows/testing-ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt install -y libegl1 libxkbcommon0
-        pip install pytest pytest-md pytest-emoji
+        pip install -r tests/requirements.txt
 
     - name: Install ProtonUp-Qt
       run: pip install -e .

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -587,7 +587,7 @@ def is_gitlab_instance(url: str) -> bool:
     return any(instance in url for instance in GITLAB_API)
 
 
-def is_online(host='https://api.github.com/rate_limit/', timeout=5) -> bool:
+def is_online(host: str = 'https://api.github.com/rate_limit/', timeout: int = 5) -> bool:
     """
     Attempts to ping a given host using `requests`.
     Returns False if `requests` raises a `ConnectionError` or `Timeout` exception, otherwise returns True 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-md
+pytest-emoji
+
+requests-mock

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,4 +2,4 @@ pytest
 pytest-md
 pytest-emoji
 
-requests-mock
+pytest-responses

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,6 @@
 import pytest
 import pytest_responses
+
 from responses import BaseResponse, RequestsMock
 
 from pupgui2.util import *

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -157,24 +157,19 @@ def test_is_online(requests_mock: requests_mock.Mocker) -> None:
     assert last_request.timeout == timeout
 
 
-def test_is_online_connection_error(requests_mock: requests_mock.Mocker) -> None:
+@pytest.mark.parametrize('expected_error', [
+    pytest.param(
+        requests.ConnectionError, id='ConnectionError'
+    ),
+        pytest.param(
+        requests.Timeout, id='Timeout'
+    )
+])
+def test_is_online_errors(requests_mock: requests_mock.Mocker, expected_error: requests.ConnectionError | requests.Timeout):
 
-    """ Test that is_online will return False when a ConnectionError is raised. """
+    """ Test that is_online will return False when an expected error is caught. """
 
-    connection_error_mock = requests_mock.register_uri('GET', github_api_ratelimit_url, exc=requests.ConnectionError)
-
-    result = is_online(host = github_api_ratelimit_url)
-
-    assert result == False
-
-    assert connection_error_mock.called_once
-
-
-def test_is_online_timeout_error(requests_mock: requests_mock.Mocker) -> None:
-
-    """ Test that is_online will return False when a Timeout error is raised. """
-
-    timeout_mock = requests_mock.register_uri('GET', github_api_ratelimit_url, exc=requests.Timeout)
+    timeout_mock = requests_mock.register_uri('GET', github_api_ratelimit_url, exc = expected_error)
 
     result = is_online(host = github_api_ratelimit_url)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -168,3 +168,16 @@ def test_is_online_connection_error(requests_mock: requests_mock.Mocker) -> None
     assert result == False
 
     assert connection_error_mock.called_once
+
+
+def test_is_online_timeout_error(requests_mock: requests_mock.Mocker) -> None:
+
+    """ Test that is_online will return False when a Timeout error is raised. """
+
+    timeout_mock = requests_mock.register_uri('GET', github_api_ratelimit_url, exc=requests.Timeout)
+
+    result = is_online(host = github_api_ratelimit_url)
+
+    assert result == False
+
+    assert timeout_mock.called_once

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,13 @@
+import pytest
+import requests_mock
+
 from pupgui2.util import *
 
 from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS
 from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame, Launcher
+
+
+github_api_ratelimit_url: str = 'https://api.github.com/rate_limit/'
 
 
 def test_build_headers_with_authorization() -> None:
@@ -125,3 +131,27 @@ def test_get_random_game_name() -> None:
         assert get_random_game_name(steam_app) in names
         assert get_random_game_name(lutris_game) in names
         assert get_random_game_name(heroic_game) in names
+
+
+def test_is_online(requests_mock: requests_mock.Mocker) -> None:
+
+    """
+    Test that is_online will succeed when sending a GET request to the provided host returns success response.
+    """
+
+    timeout: int = 5
+
+    get_mock = requests_mock.get(github_api_ratelimit_url)
+
+    result: bool = is_online(host = github_api_ratelimit_url, timeout = timeout)
+
+    last_request = get_mock.last_request
+
+    assert result
+    assert get_mock.called_once
+
+    assert last_request is not None
+
+    assert last_request.method == 'GET'
+    assert last_request.url == github_api_ratelimit_url
+    assert last_request.timeout == timeout

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -155,3 +155,16 @@ def test_is_online(requests_mock: requests_mock.Mocker) -> None:
     assert last_request.method == 'GET'
     assert last_request.url == github_api_ratelimit_url
     assert last_request.timeout == timeout
+
+
+def test_is_online_connection_error(requests_mock: requests_mock.Mocker) -> None:
+
+    """ Test that is_online will return False when a ConnectionError is raised. """
+
+    connection_error_mock = requests_mock.register_uri('GET', github_api_ratelimit_url, exc=requests.ConnectionError)
+
+    result = is_online(host = github_api_ratelimit_url)
+
+    assert result == False
+
+    assert connection_error_mock.called_once


### PR DESCRIPTION
This PR implements unit tests for the `is_online` util function. We test the "happy path" (a successful response where `is_online` returns `True` and the response we get matches a sane successful response) and the "error path" (`is_online` returns `False` when we catch a `requests.ConnectionError` or a `requests.Timeout` error, and the response matches an expected stubbed error response).

Initially, I had written these tests out using [`requests-mock`](https://github.com/jamielennox/requests-mock), but [it seems that library is unmaintained](https://github.com/jamielennox/requests-mock/issues/262). So I rewrote the tests to use the [Responses library](https://github.com/getsentry/responses) which is more actively maintained.

For convenience, I opted to use `pytest-responses` which is a dependency on top of `responses` for use with PyTest. It allows `responses` to be used as a fixture, which to my understanding means we don't have to do the setup/teardown of a Responses RequestMock ourselves.

So we use the Responses library in order to mock the responses of `requests.get` in our `is_online` tests. But in order for this to run in CI, I had to make a couple of extra changes:
- I created a `tests/requirements.txt` file that defines dependencies that are _only_ required for running tests. We already have a few of these, including PyTest itself. They're defined in [GitHub Actions](https://github.com/DavidoTek/ProtonUp-Qt/blob/0c418459dd0dc27d9b20fd3757371a54b2b0e3cf/.github/workflows/testing-ci.yml#L29). I took these dependencies and put them into the `tests/requirements.txt` file.
- Now that we have this file, we can replace the GitHub Actions step of installing PyTest and friends with `pip install -r tests/requirements.txt`, replacing the hardcoded list of requirements. This should also make it easier for contributors to install and get up to speed with the requirements needed to run and write unit tests for the project.

I realise this PR introduces a new dependency _and_ touches the CI, so feedback is welcome on what I've done and if anything should be done differently. I think using Responses is sane and will set us up nicely for testing and mocking other network calls (maybe even testing `ghapi_rlcheck` and `glapi_rlcheck`). But if there's a better way to make sure these dependencies are used in CI and/or having `tests/requirements.txt` is undesirable, I'm happy to look into other approaches :-) 

Thanks!