### PR TITLE
test_util: Implement test for `is_gitlab_instance`

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,8 @@
+import pytest
+
 from pupgui2.util import *
 
-from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS
+from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS, GITLAB_API, GITHUB_API
 from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame, Launcher
 
 
@@ -125,3 +127,20 @@ def test_get_random_game_name() -> None:
         assert get_random_game_name(steam_app) in names
         assert get_random_game_name(lutris_game) in names
         assert get_random_game_name(heroic_game) in names
+
+
+@pytest.mark.parametrize(
+    'url, is_gitlab_api', [
+        *[pytest.param(api, True, id = api) for api in GITLAB_API],
+        pytest.param(GITHUB_API, False, id = GITHUB_API)
+    ]
+)
+def test_is_gitlab_instance(url: str, is_gitlab_api: bool) -> None:
+
+    """
+    Test that a given GitLab API URL is detected successfully.
+    """
+
+    result: bool = is_gitlab_instance(url)
+
+    assert result == is_gitlab_api


### PR DESCRIPTION
This PR implements a test for the `is_gitlab_instance` utility function.

We test against each element in our `GITLAB_API` list constant using [PyTest's Parametrize feature](https://docs.pytest.org/en/7.1.x/example/parametrize.html). Currently we only have one entry in this list, but if we had more in future, this would allow us to check to make sure if we add one that it this function should always work with all items in that list. We also then check a failing test case with the GitHub API to ensure that the function returns `False` when we expect it to.

Thanks!