### PR TITLE
test_heroicutil: Implement test for `is_heroic_launcher`

### DIFF
--- a/tests/test_heroicutil.py
+++ b/tests/test_heroicutil.py
@@ -1,0 +1,16 @@
+import pytest
+
+from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS
+
+from pupgui2.heroicutil import *
+
+KNOWN_HEROIC_LAUNCHERS = ['heroicwine', 'heroicproton']
+
+@pytest.mark.parametrize('launcher, expected_heroic_launcher', [
+    *[pytest.param(install_loc.get('launcher'), install_loc.get('launcher') in KNOWN_HEROIC_LAUNCHERS, id = install_loc.get('display_name')) for install_loc in POSSIBLE_INSTALL_LOCATIONS]
+])
+def test_is_heroic_launcher(launcher: str, expected_heroic_launcher: bool) -> None:
+
+    result: bool = is_heroic_launcher(launcher)
+
+    assert result == expected_heroic_launcher


### PR DESCRIPTION
This PR iimplements a test for the `is_heroic_launcher` util function, the first test for our `heroicutil.py` utility file. :smile: 

The test runs `is_heroic_launcher` against all of the launchers in our `POSSIBLE_INSTALL_LOCATIONS` constant. We do this using [PyTest's Parametrize functionality](https://docs.pytest.org/en/7.1.x/example/parametrize.html). The benefit of this is that if this variable ever changes and we need to check for a new Heroic install location, or a new entry will incorrectly cause `is_heroic_launcher` to return `True`, then this test will fail and we will catch that error.

Thanks!