### PR TITLE
test_steamutil: Implement test for `calc_shortcut_app_id`

### DIFF
--- a/tests/test_steamutil.py
+++ b/tests/test_steamutil.py
@@ -1,0 +1,17 @@
+import pytest
+
+from pupgui2.steamutil import calc_shortcut_app_id
+
+
+@pytest.mark.parametrize(
+    'shortcut_dict, expected_appid', [
+        pytest.param({ 'name': 'Half-Life 3', 'exe': 'hl3.exe' }, -758629442, id = 'Half-Life 3 (-758629442)'),
+        pytest.param({ 'name': 'Twenty One', 'exe': '21.exe' }, -416959852, id = 'Twenty One (-416959852)'),
+        pytest.param({ 'name': 'ProtonUp-Qt', 'exe': 'pupgui2' }, -1763982845, id = 'ProtonUp-Qt (-1763982845)')
+    ]
+)
+def test_calc_shortcut_app_id(shortcut_dict: dict[str, str], expected_appid: int) -> None:
+
+    result: int = calc_shortcut_app_id(shortcut_dict.get('name', ''), shortcut_dict.get('exe', ''))
+
+    assert result == expected_appid


### PR DESCRIPTION
This PR implements a test for the `calc_shortcut_app_id` utility function, the first unit test for our `steamutil.py` utility file!

To test this, we generate a Shortcut AppID based on a dict with a `name` and `exe`. We then compare the result of calling `calc_shortcut_app_id` with the expected Shortcut AppID for this `name` and `exe` combination. To find this out, I just copied the utility function and ran it locally to generate some AppIDs for test data.

Thanks!