### PR TITLE
test_util: Implement test for `get_combobox_index_by_value`

### DIFF
--- a/tests/test_ctmods.py
+++ b/tests/test_ctmods.py
@@ -14,7 +14,7 @@ def test_ctmod_loader() -> None:
     """
     Test loading of ctmods using CtLoader.
     """
-    QApplication()
+    app = QApplication()
     
     dummy_main_window = DummyMainWindow({})
 
@@ -29,3 +29,5 @@ def test_ctmod_loader() -> None:
 
     # Ensure that no advanced mode ctmods are loaded when advanced_mode is False
     assert(all(["advmode" not in ctmod.CT_LAUNCHERS for ctmod in ct_loader.get_ctmods(launcher=None, advanced_mode=False)]))
+
+    QApplication.shutdown(app)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pupgui2.util import *
 
 from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS
@@ -125,3 +127,22 @@ def test_get_random_game_name() -> None:
         assert get_random_game_name(steam_app) in names
         assert get_random_game_name(lutris_game) in names
         assert get_random_game_name(heroic_game) in names
+
+
+@pytest.mark.parametrize(
+    'combobox_values, value, expected_index', [
+        pytest.param(['a', 'b', 'c', 'd', 'e'], 'c', 2),
+        pytest.param(['Steam', 'Lutris',' Heroic'], 'Lutris', 1),
+        pytest.param(['GE-Proton', 'Proton-tkg', 'SteamTinkerLaunch'], 'SteamTinkerLaunch', 2),
+    ]
+)
+def test_get_combobox_index_by_value(combobox_values: list[str], value: str, expected_index: int) -> None:
+
+    combobox: QComboBox = QComboBox()
+
+    combobox.addItems(combobox_values)
+
+    result: int = get_combobox_index_by_value(combobox, value)
+
+    assert combobox_values[result] == value
+    assert result == expected_index

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -131,12 +131,14 @@ def test_get_random_game_name() -> None:
 
 @pytest.mark.parametrize(
     'combobox_values, value, expected_index', [
-        pytest.param(['a', 'b', 'c', 'd', 'e'], 'c', 2),
-        pytest.param(['Steam', 'Lutris',' Heroic'], 'Lutris', 1),
-        pytest.param(['GE-Proton', 'Proton-tkg', 'SteamTinkerLaunch'], 'SteamTinkerLaunch', 2),
+        pytest.param(['a', 'b', 'c', 'd', 'e'], 'c', 2, id = 'Simple list'),
+        pytest.param(['Steam', 'Lutris',' Heroic'], 'Lutris', 1, id = 'List of Launcher Names'),
+        pytest.param(['GE-Proton', 'Proton-tkg', 'SteamTinkerLaunch'], 'SteamTinkerLaunch', 2, id = 'List of Compatibility Tool names'),
     ]
 )
 def test_get_combobox_index_by_value(combobox_values: list[str], value: str, expected_index: int) -> None:
+
+    app = QApplication()
 
     combobox: QComboBox = QComboBox()
 
@@ -146,3 +148,5 @@ def test_get_combobox_index_by_value(combobox_values: list[str], value: str, exp
 
     assert combobox_values[result] == value
     assert result == expected_index
+
+    QApplication.shutdown(app)


### PR DESCRIPTION
This PR implements a unit test for the `get_combobox_index_by_value` utility function.

I tested this test with and without the `QT_QPA_PLATFORM=offset` environment variable. It's worth noting that [we set this environment variable in CI](https://github.com/DavidoTek/ProtonUp-Qt/blob/0c418459dd0dc27d9b20fd3757371a54b2b0e3cf/.github/workflows/testing-ci.yml#L37).

When running multiple tests that use a `QApplication`, I was running into an error along the lines of `Please destroy the QApplication singleton before creating a new QApplication instance.` This would happen if a test created a `QApplication()` and then another test tried to do the same thing.

Trying to fix this took a bit of research. I stumbled across [this comment on a thread](https://forum.qt.io/topic/153620/please-destroy-the-qapplication-singleton-before-creating-a-new-qapplication-instance/6?_=1744426079662&lang=en-US) that suggested using `QApplication.shutdown()`. This resolved the problem.

Thanks!