### PR TITLE
test_util: Add test for `download_awacy_gamelist`

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -491,7 +491,7 @@ def download_awacy_gamelist() -> None:
     if not is_online():
         return
 
-    t = threading.Thread(target=_download_awacy_gamelist_thread)
+    t = threading.Thread(target = _download_awacy_gamelist_thread, name = '_download_awacy_gamelist')
     t.start()
 
 

--- a/tests/fixtures/util/awacy_game_list.json
+++ b/tests/fixtures/util/awacy_game_list.json
@@ -1,0 +1,377 @@
+[
+    {
+        "url": "",
+        "name": "Halo: The Master Chief Collection",
+        "logo": "",
+        "native": false,
+        "status": "Supported",
+        "reference": "",
+        "anticheats": [
+            "Easy Anti-Cheat"
+        ],
+        "notes": [
+            [
+                "All-modes enabled with minor caveats",
+                "https://www.gamingonlinux.com/2023/04/halo-the-master-chief-collection-gets-steam-deck-support/"
+            ],
+            [
+                "Singleplayer, co-op, and custom matches work",
+                "https://www.protondb.com/app/976730#s1M6yjsTt"
+            ]
+        ],
+        "updates": [
+            {
+                "name": "Tried to enable EAC",
+                "date": "Apr 12, 2022, 8:10 AM GMT+2",
+                "reference": "https://www.xda-developers.com/halo-mcc-broken-steam-deck/"
+            },
+            {
+                "name": "Updated Linux EAC Files",
+                "date": "Aug 31, 2022, 17:00:12 UTC",
+                "reference": "https://steamdb.info/patchnotes/9367265/"
+            },
+            {
+                "name": "Still actively working on it",
+                "date": "Dec 15, 2022, 4:15 PM GMT+1",
+                "reference": "https://www.theverge.com/23499215/valve-steam-deck-interview-late-2022"
+            },
+            {
+                "name": "Steam Deck Support",
+                "date": "Apr 6, 2023, 8:00 PM UTC",
+                "reference": "https://support.halowaypoint.com/hc/en-us/articles/14589112499348"
+            }
+        ],
+        "storeIds": {
+            "steam": "976730"
+        },
+        "slug": "halo-the-master-chief-collection",
+        "dateChanged": "2024-01-19T04:40:56.000Z"
+    },
+    {
+        "url": "https://www.fortnite.com/",
+        "name": "Fortnite",
+        "logo": "",
+        "native": false,
+        "status": "Denied",
+        "reference": "",
+        "anticheats": [
+            "Easy Anti-Cheat"
+        ],
+        "notes": [
+            [
+                "Works on Xbox-Cloud",
+                "https://news.xbox.com/en-us/2022/05/05/play-fortnite-with-xbox-cloud-gaming-for-free/"
+            ]
+        ],
+        "updates": [
+            {
+                "name": "Not confident in anti-cheat",
+                "date": "Feb 07, 2022, 6:59 AM GMT+2",
+                "reference": "https://twitter.com/TimSweeneyEpic/status/1490565925648715781"
+            },
+            {
+                "name": "Removed Hyperion",
+                "date": "Nov 1, 2022, 6:43 PM GMT+1",
+                "reference": "https://github.com/Starz0r/AreWeAntiCheatYet/issues/918"
+            },
+            {
+                "name": "Was running for a short period of time",
+                "date": "Nov 2, 2022, 8:04 AM GMT+1",
+                "reference": "https://github.com/Starz0r/AreWeAntiCheatYet/issues/918#issuecomment-1299673303"
+            },
+            {
+                "name": "Removed BattlEye",
+                "date": "Jun 11, 2024, 5:34 PM GMT+1",
+                "reference": "https://x.com/ShiinaBR/status/1800567329870537171"
+            }
+        ],
+        "storeIds": {
+            "epic": {
+                "namespace": "fn",
+                "slug": "fortnite"
+            }
+        },
+        "slug": "fortnite",
+        "dateChanged": "2024-10-04T17:23:46.000Z"
+    },
+    {
+        "url": "",
+        "name": "Battlefield™ 2042",
+        "logo": "",
+        "native": false,
+        "status": "Denied",
+        "reference": "https://www.protondb.com/app/1517290#atmpx3XrXL",
+        "anticheats": [
+            "EA anticheat"
+        ],
+        "notes": [],
+        "updates": [],
+        "storeIds": {
+            "steam": "1517290",
+            "epic": {
+                "namespace": "52f57f57120c440fad9bfa0e6c279317",
+                "slug": "battlefield-2042"
+            }
+        },
+        "slug": "battlefield-2042",
+        "dateChanged": "2024-11-04T00:18:17.181Z"
+    },
+    {
+        "url": "https://www.ea.com/games/apex-legends",
+        "name": "Apex Legends",
+        "logo": "",
+        "native": false,
+        "status": "Denied",
+        "reference": "",
+        "anticheats": [
+            "Easy Anti-Cheat",
+            "Hyperion"
+        ],
+        "notes": [],
+        "updates": [
+            {
+                "name": "Enabled Linux support shortly after SteamDeck launch",
+                "date": "2022-03-01T18:00:27+00:00",
+                "reference": "https://steamdb.info/patchnotes/8270674/"
+            },
+            {
+                "name": "Linux support disabled",
+                "date": "Oct 31, 2024, 4:07 PM UTC",
+                "reference": "https://x.com/PlayApex/status/1852019667315102151"
+            }
+        ],
+        "storeIds": {
+            "steam": "1172470"
+        },
+        "slug": "apex-legends",
+        "dateChanged": "2024-10-31T18:29:00.000Z"
+    },
+    {
+        "url": "https://playvalorant.com",
+        "name": "Valorant",
+        "logo": "",
+        "native": false,
+        "status": "Denied",
+        "reference": "https://playvalorant.com/en-gb/specs/",
+        "anticheats": [
+            "Vanguard"
+        ],
+        "notes": [],
+        "updates": [
+            {
+                "name": "Vanguard developer claims Linux has \"too much attack surface\".",
+                "date": "Fri, 26 Jan 2024 01:27:06 GMT",
+                "reference": "https://github.com/AreWeAntiCheatYet/AreWeAntiCheatYet/assets/33342705/266b364f-8964-4ae2-9cc4-58e2fd5f9947"
+            }
+        ],
+        "storeIds": {
+            "epic": {
+                "namespace": "cbd5b3d310a54b12bf3fe8c41994174f",
+                "slug": "valorant"
+            }
+        },
+        "slug": "valorant",
+        "dateChanged": "2024-09-02T22:22:14.140Z"
+    },
+    {
+        "url": "https://www.halowaypoint.com/de-de/halo-infinite",
+        "name": "Halo Infinite",
+        "logo": "",
+        "native": false,
+        "status": "Supported",
+        "reference": "https://www.gamingonlinux.com/2024/03/halo-infinite-added-easy-anti-cheat-enabled-for-linux-steam-deck/",
+        "anticheats": [
+            "Arbiter",
+            "Easy Anti-Cheat"
+        ],
+        "notes": [
+            [
+                "Requires Patched Mesa & Proton GE",
+                "https://github.com/ValveSoftware/Proton/issues/5030#issuecomment-1169003294"
+            ]
+        ],
+        "updates": [
+            {
+                "name": "No longer requires workaround",
+                "date": "Dec 18, 2022, 3:18 AM GMT+1",
+                "reference": "https://github.com/Starz0r/AreWeAntiCheatYet/issues/1022"
+            }
+        ],
+        "storeIds": {
+            "steam": "1240440"
+        },
+        "slug": "halo-infinite",
+        "dateChanged": "2024-04-11T19:24:20.671Z"
+    },
+    {
+        "url": "https://www.back4blood.com/",
+        "name": "Back 4 Blood",
+        "logo": "",
+        "native": false,
+        "status": "Supported",
+        "reference": "",
+        "anticheats": [
+            "Easy Anti-Cheat"
+        ],
+        "notes": [],
+        "updates": [
+            {
+                "name": "Back 4 Blood on Steam Deck, Linux PCs with WINE/Proton",
+                "date": "Apr 12, 2022, 0:00 AM",
+                "reference": "https://back4blood.com/en-us/patch-notes/april-2022-update"
+            }
+        ],
+        "storeIds": {
+            "steam": "924970",
+            "epic": {
+                "namespace": "57dfd95548214a138218e56cd9e5b9d8",
+                "slug": "back-4-blood"
+            }
+        },
+        "slug": "back-4-blood",
+        "dateChanged": "2024-01-19T04:40:56.000Z"
+    },
+    {
+        "url": "",
+        "name": "Paladins",
+        "logo": "",
+        "native": false,
+        "status": "Running",
+        "reference": "",
+        "anticheats": [
+            "Easy Anti-Cheat"
+        ],
+        "notes": [
+            [
+                "Make sure to check recent updates, the game is known to break often (And the status may not update to reflect that)",
+                ""
+            ]
+        ],
+        "updates": [
+            {
+                "name": "Hope to provide such support in the near future",
+                "date": "Nov 09, 2021, 5:55 PM EST",
+                "reference": "https://www.theverge.com/2021/10/5/22709918/valve-steam-deck-supported-games-anti-cheat-proton-eac-battleye-epic"
+            },
+            {
+                "name": "Running with Proton GE, Anti-Cheat may not be intentionally enabled",
+                "date": "Sat May 14 2022 23:57:51 GMT+0000",
+                "reference": "https://www.protondb.com/app/444090#7U2uy5DZzc"
+            },
+            {
+                "name": "Proton Experimental - Now Playable: Paladins",
+                "date": "Thu Jun 30 2022 16:00:00 GMT+0000",
+                "reference": "https://github.com/ValveSoftware/Proton/wiki/Changelog"
+            },
+            {
+                "name": "Reports of game not working",
+                "date": "Jul 13, 2022, 2:29 AM GMT+2",
+                "reference": "https://github.com/Starz0r/AreWeAntiCheatYet/issues/581"
+            },
+            {
+                "name": "Previously working most likely due to fluke in EAC Config",
+                "date": "Aug 05, 2022, 9:57 PM",
+                "reference": "https://github.com/ValveSoftware/Proton/issues/6062#issuecomment-1206809079"
+            },
+            {
+                "name": "No plans to dedicate time for steam deck / linux compatibility",
+                "date": "Feb 14, 2023, 02:13 AM",
+                "reference": "https://www.reddit.com/r/paladinsgame/comments/110mcuf/with_em_striving_to_do_better_how_about_some/j8g2nam/"
+            },
+            {
+                "name": "EAC updated, and Linux allowed after Evil Mojo layoffs",
+                "date": "April 1, 2025, 12:00 AM",
+                "reference": ""
+            }
+        ],
+        "storeIds": {
+            "steam": "444090",
+            "epic": {
+                "namespace": "badb0ee71b474ed591ec43212547cfc8",
+                "slug": "paladins"
+            }
+        },
+        "slug": "paladins",
+        "dateChanged": "2025-04-05T19:13:42.0000000-04:00"
+    },
+    {
+        "url": "https://pubg.com/",
+        "name": "PUBG: Battlegrounds",
+        "logo": "",
+        "native": false,
+        "status": "Broken",
+        "reference": "",
+        "anticheats": [
+            "Zakynthos",
+            "BattlEye",
+            "UNCHEATER"
+        ],
+        "notes": [],
+        "updates": [
+            {
+                "name": "The team does not have a comment for this",
+                "date": "Nov 09, 2021, 5:55 PM EST",
+                "reference": "https://www.theverge.com/2021/10/5/22709918/valve-steam-deck-supported-games-anti-cheat-proton-eac-battleye-epic"
+            }
+        ],
+        "storeIds": {
+            "steam": "578080"
+        },
+        "slug": "pubg-battlegrounds",
+        "dateChanged": "2024-01-19T04:40:56.000Z"
+    },
+    {
+        "url": "https://ubisoft.com/en-us/game/rainbow-six/siege",
+        "name": "Tom Clancy's Rainbow Six® Siege",
+        "logo": "",
+        "native": false,
+        "status": "Denied",
+        "reference": "https://r6fix.ubi.com/projects/RAINBOW6-SIEGE-LIVE/issues/LIVE-59642",
+        "anticheats": [
+            "FairFight",
+            "BattlEye"
+        ],
+        "notes": [
+            [
+                "Show your support!",
+                "https://r6fix.ubi.com/projects/RAINBOW6-SIEGE-LIVE/issues/LIVE-57005"
+            ]
+        ],
+        "updates": [
+            {
+                "name": "We don’t have anything to share at this time",
+                "date": "Nov 09, 2021, 5:55 PM EST",
+                "reference": "https://www.theverge.com/2021/10/5/22709918/valve-steam-deck-supported-games-anti-cheat-proton-eac-battleye-epic"
+            },
+            {
+                "name": "Show your support!",
+                "date": "Nov 30, 2021, 5:55 PM EST",
+                "reference": "https://www.gamingonlinux.com/2021/11/ubisoft-proton-support-rainbow-six-siege-linux/"
+            },
+            {
+                "name": "Show your support! (Thread moved)",
+                "date": "Oct 05, 2021, 10:21 PM EST",
+                "reference": "https://discussions.ubisoft.com/topic/111054/linux-support-for-r6s"
+            },
+            {
+                "name": "Show your support! (Bug tracker)",
+                "date": "May 16, 2023, 0:00 UTC",
+                "reference": "https://r6fix.ubi.com/projects/RAINBOW6-SIEGE-LIVE/issues/LIVE-49179"
+            },
+            {
+                "name": "Show your support! (Bug tracker)",
+                "date": "March 23, 2024, 0:00 UTC",
+                "reference": "https://r6fix.ubi.com/projects/RAINBOW6-SIEGE-LIVE/issues/LIVE-58221"
+            }
+        ],
+        "storeIds": {
+            "steam": "359550",
+            "epic": {
+                "namespace": "carnation",
+                "slug": "rainbow-six-siege"
+            }
+        },
+        "slug": "rainbow-six-siege",
+        "dateChanged": "2024-09-22T22:18:43.803Z"
+    }
+]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,34 @@
-from pupgui2.util import *
+import os
+import pathlib
 
-from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS
+import pytest
+import pytest_responses
+
+from responses import BaseResponse, RequestsMock
+
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pyfakefs.fake_file import FakeFileWrapper
+
+from pytest_mock import MockerFixture
+
+from pupgui2.util import *
+from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS, AWACY_GAME_LIST_URL, LOCAL_AWACY_GAME_LIST
 from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame, Launcher
+
+
+@pytest.fixture(scope='function')
+def awacy_game_list(fs: FakeFilesystem):
+
+    """
+    Game List JSON for AreWeAntiCheatYet
+    """
+
+    awacy_game_list_fixture_path: str = f'{pathlib.Path(__file__).parent}/fixtures/util/awacy_game_list.json'
+
+    fs.add_real_file(awacy_game_list_fixture_path)
+
+    with open(awacy_game_list_fixture_path, 'r') as awacy_games_list:
+        yield awacy_games_list
 
 
 def test_build_headers_with_authorization() -> None:
@@ -125,3 +152,37 @@ def test_get_random_game_name() -> None:
         assert get_random_game_name(steam_app) in names
         assert get_random_game_name(lutris_game) in names
         assert get_random_game_name(heroic_game) in names
+
+
+def test_download_awacy_gamelist(responses: RequestsMock, fs: FakeFilesystem, mocker: MockerFixture, awacy_game_list: FakeFileWrapper) -> None:
+
+    """
+    Test that the AreWeAntiCheatYet game list JSON can be downloaded and written
+    to the expected location successfully.
+    """
+
+    is_online_mock = mocker.patch('pupgui2.util.is_online')
+    is_online_mock.return_value = True
+
+    get_mock_body = awacy_game_list.read()
+    get_mock: BaseResponse = responses.get(
+        AWACY_GAME_LIST_URL,
+        body=get_mock_body
+    )
+
+    fs.create_dir(TEMP_DIR)
+
+    download_awacy_gamelist()
+
+    # ensure the thread to write the gamelist to the file has finished
+    for thread in threading.enumerate():
+        if thread.name == '_download_awacy_gamelist':
+            thread.join()
+
+    file_content: str = ''
+    with open(LOCAL_AWACY_GAME_LIST, 'r') as awacy_file:
+        file_content = awacy_file.read()
+
+    assert os.path.exists(LOCAL_AWACY_GAME_LIST)
+    assert file_content == get_mock.body
+    assert is_online_mock.call_count == 1


### PR DESCRIPTION
Depends on #529, because we need to add `pyfakefs` and `pytest-mock` to `tests/requirements.txt` (or whatever solution we land on) so that CI can have access to these PyTest plugins. Since this test also makes use of `responses`, we also need access to that as it was implemented in that PR.

## Overview
This PR adds a test for the `download_awacy_gamelist` utility function.

To do this, we mock the response from a GET request to our `AWACY_GAME_LIST_URL` constant. Then we mocked out `is_online` to always return `True`. Finally we ensure the text written into the file from `download_awacy_gamelist()` matches the response we get back from our mocked GET request.

The purpose of this test is to ensure that we create a real file at the `LOCAL_AWACY_GAME_LIST` constant path, and that its contents match the response the way we would expect.

This PR is opened as a draft as it depends on a PR that is not yet merged and the outcome of that PR may impact this one, and because other test cases should be added before I take this out of draft. However I wanted to get this PR up as a proof-of-concept on how our test suite can evolve and begin to cover more complex test cases and functions.

## Implementation
Two new test dependencies were introduced in order to test this function: [`pyfakefs`](https://github.com/pytest-dev/pyfakefs) in order to mock calls to the filesystem, and `pytest-mock` which allows us to stub out functions ourselves. `pyfakefs` is particularly cool, as it allows _all filesystem operations_ (with some notable exceptions, such as `Pathlib`) to be done in an in-memory filesystem. This means no real filesystem operations are performed except where we explicitly tell `pyfakefs` to use the real filesystem. 

In PyTest, we can use the `fs` fixture to access the `pyfakefs` fake filesystem, and we can use `mocker` fixture to access mocking operations from `pytest-mocker`. Since these are fixtures, by default they are per-test, meaning any fake files created or any functions mocked should _only_ apply within the scope of the function being ran. So if we mock a function in our `test_download_awacy_gamelist`, it should not interfere with any other tests that depend on the "real" function. Likewise with `pyfakefs`, any fake files created only exist within the scope of the function that uses the `fs` fixture (if we ever needed other functionality, [`pyfakefs` provides fixtures with other scopes](https://pytest-pyfakefs.readthedocs.io/en/stable/usage.html#class-module-and-session-scoped-fixtures)).

A new JSON file was created at `tests/fixtures/util/awacy_game_list.json`. This is the first ten objects from [`AWACY_GAME_LIST_URL`](https://raw.githubusercontent.com/Starz0r/AreWeAntiCheatYet/master/games.json) stored in a local JSON file. In order to use this in a test, I set it up as a [PyTest Fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html), meaning that it is set up and torn down after each call, and available in our test function as a parameter. This fixture returns the File object. Since we're using `pyfakefs`, we have to tell it to load the real JSON file, otherwise it'll try to load it from its fake filesystem. To do this, we mount it with `fs.add_real_file`. Note the `fs` is one of the fixtures available to us from `pyfakefs` for use with PyTest.

When we mock the response from our GET request to `AWACY_GAME_LIST_URL`. This response is generated based on the contents of the `awacy_game_list` fixture described above.

Before calling `download_awacy_gamelist`, we need to mock our `is_online` function. For the happy path, we want to make sure that it always returns `True`. So we mock it to do just that, so that when we call `download_awacy_gamelist` we can ensure it runs.

Now we can call `download_awacy_gamelist`! One change I chose to make inside of `download_awacy_gamelist` was to name the thread that we create to call our inner function that actually makes the request and writes the response content to the AWACY JSON file. The reason I chose to do this was to make it easier to identify and wait on this thread finishing before continuing with the test. We need to ensure that this thread closes before we check the file contents, otherwise our test will run so fast that we run our `asserts` before the file has even been created. While we _could_ have done this against the thread count and waited until the thread count was at `1`, we really only care about this specific thread finishing and the simplest approach was to name this thread and identify it in a `for` loop in our test. This allows us to say "wait for the thread named `_download_awacy_gamelist` to finish before continuing with our test".

Once the thread has ended, we can read the file from our fake filesystem. Since we're using `pyfakefs` which mocks our standard file IO operations, the `LOCAL_AWACY_GAME_LIST` will exist in our fake filesystem (`pyfakefs` will always use the fake filesystem by default and can only access real files if we explicitly tell it to become aware of real files/directories/paths, as we did for our `awacy_game_list` fixture). We read the content of this file into a variable, because later on we will want to make sure it matches the response we wanted our mocked GET request to return; we want to make sure the content is being written to our expected value (the mocked response).

Finally we can do our assertions:
- The `LOCAL_AWACY_GAME_LIST` should exist.
- The content of this file should match the body of our `get_mock` (the data written to the file should be the content of the response body).
- `is_online` should have been called once, to ensure we don't make the request if we aren't online (since `is_online` will catch timeout and connection errors for us).

## Concerns
I think using a "real" JSON file that matches an expected response is a good idea. We may have to keep it in sync, but running our tests against "real" data in a local file should give us confidence that they are performing as expected when given the data we expect. We can do similar stuff with other responses, like GitHub API responses.

My concern, however, is the location, structure, and naming that I've gone with. From what I've seen, `fixtures` tends to be a generic directory name for these kinds of files, but I'm happy with any other directory name that might be preferred. Similarly, would we want this to be in a `utils` folder, a `responses` folder, or a `utils/responses` or maybe even `responses/utils` folder? Essentially, I think having this file and other files like it for our tests is a good idea, but I don't know what the best structure for storing it is. :sweat_smile: 

<hr>

Since we do a lot of filesystem work in ProtonUp-Qt, I think `pyfakefs` is a very useful tool for us to use in our tests, and hopefully this PR outlines a way that we can use it to begin writing some neat tests!

All feedback is welcome! And if I didn't explain any of the libraries or how we use them properly, I'm happy to clarify. Also, I spent a lot of time on and off bashing my head against the wall trying to figure out a pattern for how to begin writing tests like this. I finally figured it out a couple days ago and finally got to work expanding the tests we have for ProtonUp-Qt, hence the massive number of PRs for tests. But it took me a while to get up to speed, so if I've done anything wrong or similarly if there's something I can explain better, please ask!

Thanks!