### PR TITLE
GE-Proton: Use correct extract path for Lutris

### DIFF
--- a/pupgui2/pupgui2.py
+++ b/pupgui2/pupgui2.py
@@ -242,9 +242,11 @@ class MainWindow(QObject):
         if install_loc.get('launcher') == 'lutris':
             dxvk_dir = os.path.join(install_directory(), '../../runtime/dxvk')
             vkd3d_dir = os.path.join(install_directory(), '../../runtime/vkd3d')
+            proton_dir = os.path.join(install_directory(), '../../runners/proton')
 
             self.get_installed_versions('dxvk', dxvk_dir)
             self.get_installed_versions('vkd3d', vkd3d_dir)
+            self.get_installed_versions('proton', proton_dir)
         # Launcher specific (Steam): Number of games using the compatibility tool
         elif install_loc.get('launcher') == 'steam' and 'vdf_dir' in install_loc:
             steam_app_list = get_steam_app_list(install_loc.get('vdf_dir'), cached=False)  # update app list cache

--- a/pupgui2/resources/ctmods/ctmod_00protonge.py
+++ b/pupgui2/resources/ctmods/ctmod_00protonge.py
@@ -9,7 +9,8 @@ import hashlib
 from PySide6.QtWidgets import QMessageBox
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
 
-from pupgui2.util import fetch_project_releases, ghapi_rlcheck, extract_tar
+from pupgui2.datastructures import Launcher
+from pupgui2.util import fetch_project_releases, get_launcher_from_installdir, ghapi_rlcheck, extract_tar
 from pupgui2.util import build_headers_with_authorization
 from pupgui2.networkutil import download_file
 
@@ -148,12 +149,17 @@ class CtInstaller(QObject):
         Download and install the compatibility tool
         Return Type: bool
         """
+
+        install_dir = self.get_extract_dir(install_dir)
+
         data, protondir = self.__get_data(version, install_dir)
         if not data:
             return False
 
+        # Note: protondir is only used for checksums
         if not protondir or  not os.path.exists(protondir):
-            protondir = os.path.join(install_dir, 'Proton-' + data['version'])
+            protondir = os.path.join(install_dir, 'Proton-' + data['version'])  # Check if we have an older Proton-GE folder name
+
         checksum_dir = f'{protondir}/sha512sum'
         source_checksum = self.rs.get(data['checksum']).text if 'checksum' in data else None
         local_checksum = open(checksum_dir).read() if os.path.exists(checksum_dir) else None
@@ -182,6 +188,26 @@ class CtInstaller(QObject):
         self.__set_download_progress_percent(100)
 
         return True
+
+    def get_extract_dir(self, install_dir: str) -> str:
+
+        """
+        Return the directory to extract GE-Proton archive based on the current launcher
+        Return Type: str
+        """
+
+        launcher = get_launcher_from_installdir(install_dir)
+        extract_dir: str = install_dir
+
+        if launcher == Launcher.LUTRIS:
+            # GE-Proton for Lutris needs to go into 'runners/proton' and not 'runners/wine'
+            extract_dir = os.path.abspath(os.path.join(install_dir, '../../runners/proton'))
+            
+            # Lutris may not be guaranteed to make this path, so ensure it exists
+            if not os.path.exists(extract_dir):
+                os.mkdir(extract_dir)
+
+        return extract_dir  # Default to install_dir
 
     def get_info_url(self, version: str) -> str:
         """

--- a/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
+++ b/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
@@ -56,3 +56,15 @@ class CtInstaller(GEProtonInstaller):
         ldd_min = int(ldd_ver.split(b'.')[1])
         return False if ldd_maj < 2 else ldd_min >= 27 or ldd_maj != 2
 
+    def get_extract_dir(self, install_dir: str) -> str:
+
+        """
+        Return the directory to extract Lutris-Wine archive based on the current launcher
+        Return Type: str
+        """
+
+        # GE-Proton ctmod figures out if it needs to into a different folder
+        #
+        # kron4ek can use default 'install_dir' always because it is Wine and not Proton,
+        # so override to return unmodified 'install_dir'
+        return install_dir

--- a/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
+++ b/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
@@ -7,7 +7,7 @@ import subprocess
 from PySide6.QtCore import QCoreApplication
 
 from pupgui2.constants import IS_FLATPAK
-from pupgui2.util import fetch_project_release_data, fetch_project_releases
+from pupgui2.util import fetch_project_release_data
 
 from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as GEProtonInstaller
 

--- a/pupgui2/resources/ctmods/ctmod_lutriswine.py
+++ b/pupgui2/resources/ctmods/ctmod_lutriswine.py
@@ -97,5 +97,7 @@ class CtInstaller(GEProtonInstaller):
         """
 
         # GE-Proton ctmod figures out if it needs to into a different folder
-        # Lutris-Wine can use default 'install_dir' always, so override to return unmodified 'install_dir'
+        #
+        # Lutris-Wine can use default 'install_dir' always because it is Wine and not Proton,
+        # so override to return unmodified 'install_dir'
         return install_dir

--- a/pupgui2/resources/ctmods/ctmod_lutriswine.py
+++ b/pupgui2/resources/ctmods/ctmod_lutriswine.py
@@ -88,3 +88,14 @@ class CtInstaller(GEProtonInstaller):
         """
 
         return super().get_info_url(version.replace('fshack-', ''))
+
+    def get_extract_dir(self, install_dir: str) -> str:
+
+        """
+        Return the directory to extract Lutris-Wine archive based on the current launcher
+        Return Type: str
+        """
+
+        # GE-Proton ctmod figures out if it needs to into a different folder
+        # Lutris-Wine can use default 'install_dir' always, so override to return unmodified 'install_dir'
+        return install_dir


### PR DESCRIPTION
See also: #527

## Overview
This PR changes the extract directory for GE-Proton, extracting it into Lutris' `runners/proton` folder instead of into `runners/wine`. Lutris expects Proton-based compatibility tools that run with UMU to be installed into `runners/proton` (this path being relative to the Lutris install location, i.e. `~/.local/share/lutris/runners/proton`).

Note that this is **one** approach, and I will detail an alternative approach at the bottom of this PR.

## Implementation
### Use Correct Extract Dir for GE-Proton
I added a \`get_extract_dir\` method to the GE-Proton Ctmod to set the value of `install_dir` to the expected extract dir for the launcher. Since for every other launcher we want to trust `install_dir`, we can return that as the default value from `get_extract_dir`. However if we're using Lutris then we need to tell it to use the `runners/proton` folder, so we return that.

This pattern of using `os.path.abspath(os.path.join(install_dir, ...))` is used by other ctmods as well, such as [DXVK](https://github.com/DavidoTek/ProtonUp-Qt/blob/0c418459dd0dc27d9b20fd3757371a54b2b0e3cf/pupgui2/resources/ctmods/ctmod_z0dxvk.py#L164-L176).

A nice benefit of this approach is that if we enable downloading other Proton-based compatibility tools for Lutris, if they subclass GE-Proton, they will use the correct extract directory for free! However, if Wine-based compatibility tools inherit from GE-Proton (such as Lutris-Wine), then they will **not** and they would need to override `get_extract_dir`.

### Use Correct Extract Dir for Lutris-Wine and Kron4ek Wine
Lutris-Wine inherits from the GE-Proton ctmod, as does Kron4ek Wine. Since now when GE-Proton detects a Lutris `install_dir` it tries to extract into `runners/proton`, this breaks these two Wine-based compatibility tools  that should instead go into the default `install_dir` path, which is `runners/wine`. Therefore, we override the `get_extract_dir` method in these Ctmods and just return `install_dir` always. Since they are Wine-based, they can always use the default path.

We would probably instead at some point want a higher level ctmod base class that by default extracts into `install_dir`, and tools like GE-Proton, DXVK, and vkd3d can all inherit from this and override the install path as needed, rather than the Wine-based Lutris tools inheriting from GE-Proton and needing to override its default.

## Testing
I thought about implementing a test suite for this, to test that the correct install directory is used for GE-Proton and all Ctmods that inherit from it. However, I ran into a couple of snags.

The overall conclusion I came to was that writing tests for ctmods can wait for now. :sweat_smile: There are probably some wider design questions of our ctmod classes that would need revisiting before we start writing tests for methods that we shouldn't directly test.

### Displaying Proton versions on Main Menu Tool List
Since GE-Proton is not installed into the standard Lutris `install_dir`, it is not visible by default on the Main Menu tool list. We had the same problem for DXVK and vkd3d-proton, and to address it, we have a pattern in place to fetch tools in a given directory if their their display name contains a substring. For example, for DXVK we search `runtime/dxvk` and list all directories in that folder that have `dxvk` in their name. We do the same for vkd3d.

The same pattern can be re-used here for GE-Proton, and it was a straightforward enough change to re-use the `MainWindow#get_installed_versions` method to do it.

### Needing to Stub `MainWindow`
We need a `main_window` parameter to initialise the ctmod. We could create one as a fixture to pass around many of our tests, which probably makes sense. But I'm not sure if there are parts we'd want to stub out. We would maybe want a `DummyMainWindow` fixture. We do have a `DummyMainWindow` in our `test_ctmods` but we may need something more thorough than that in future, something closer to a real instance of `MainWindow`, or a stubbed-out instance of `MainWindow` where required. We could even have a "`MainWindow`-ish" fixture only for ctmod tests by using a `conftest.py` inside of a `tests/ctmods` directory.

The only time we may not want a fixture is if we're testing the `MainWindow` itself. So setting up the tests could be a bit of legwork that might be better served as a separate endeavour.

### Visibility of `CtInstaller#get_extract_dir`
However, even supposing that we do that legwork in this PR, we run into a problem. Should we be directly testing `get_extract_dir`, and more to the point, should `get_extract_dir` be "public"? It's "public" in other classes but it should probably not be, since it shouldn't be used by outside classes. Access in Python is of course not as strict as in other languages, it's convention, but we still use `__method_name` for other methods in Ctmods.

If it should be "private", then even though we _can_  test this method, whether or not we _should_ test "private" methods up for debate. In other languages while you _can_ do it you usually don't want to, and instead want to test it implicitly through methods that would use it. So in our case we'd want to test `get_tool`.

Trying to figure this out led me down a rabbit hole of, _should private methods be overridden_. This is not something I got a good answer to in the context of Python. In other languages like Java, private methods can't be overridden afaik. Python is probably more flexible, but I still don't know what the best practice is.

## Alternative Approach
This PR is a little... _hacky_. A more sustainable approach may be to take inspiration from what we do with Heroic and have a `lutriswine` and `lutrisproton` install location. For `lutrisproton` we would add new entries into our `POSSIBLE_INSTALL_LOCATIONS` constant, something like `{'install_dir': '~/.local/share/lutris/runners/proton/', 'display_name': 'Lutris Proton', 'launcher': 'lutrisproton', 'type': 'native', 'icon': 'lutris', 'config_dir': '~/.config/lutris'}`. Equivalent for Flatpak as well. Then for the existing Lutris entries, we would refactor them to be `lutriswine` instead of just `lutris`.

If we implement such a thing, right now there would only be one Proton-based Ctmod. However we could easily then add a bunch of Proton-based compatibility tools, since they could just use `install_dir`. We also wouldn't need any implementation of `get_extract_dir` for GE-Proton, and we wouldn't need.

This approach is one that I thought of after implementing this PR. It would be a fairly significant refactor as well. If we want, we can go with this PR for now, and maybe create an issue detailing breaking Lutris out into two separate launcher types. Maybe we'd want to wait until we have tests in place for ctmods before doing such a refactor to give us a bit more confidence that our refactor won't screw something up. Or perhaps we want to scrap this PR's approach, prioritise Ctmod unit tests, and then look at a refactor without having this throwaway work.

Taking this approach also means we wouldn't need to do the `self.get_installed_versions('proton', proton_dir)` call, since a `lutrisproton` ctmod would have its `install_dir` as `runners/proton` already and would be able to find these tools.

I guess if we wanted to make a release quickly with a fix for using the correct extract dir, we could use this PR to do it as a quick-fix and then spend time looking at a solution like having `lutriswine` and `lutrisproton`.

<hr>

If we want to go with the alternative approach, I'm happy to close this PR and we can discuss how we want to approach breaking Lutris out into `lutriswine` and `lutrisproton`.

Either way, all feedback is welcome on this PR. Thanks!