### PR TITLE
Lutris-Wine: Fix double-assign for `protondir`

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_lutriswine.py
+++ b/pupgui2/resources/ctmods/ctmod_lutriswine.py
@@ -76,7 +76,7 @@ class CtInstaller(GEProtonInstaller):
             return (None, None)
 
         # Overwrite the Proton installation directory as the format we need for Lutris Wine
-        protondir = protondir = f'{install_dir}wine-{data["version"].lower()}-x86_64'
+        protondir = f'{install_dir}wine-{data["version"].lower()}-x86_64'
 
         return (data, protondir)
 


### PR DESCRIPTION
Fix a double assign for `protondir` that was almost certainly a typo. This mistake was introduced in [#498](https://github.com/DavidoTek/ProtonUp-Qt/pull/498/files#diff-d916515cda1a70b93f552eded09980921d90ca650dadbb3ccc9160873ba732a5R79), I guess I didn't have enough coffee that day :wink: 