### PR TITLE
test_util: Parametrize `get_random_game_name`

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -946,7 +946,7 @@ def get_random_game_name(games: list[SteamApp] | list[LutrisGame] | list[HeroicG
     elif type(random_game) is HeroicGame:
         tooltip_game_name = random_game.title
     
-    return tooltip_game_name
+    return str(tooltip_game_name)
 
 
 def detect_platform() -> HardwarePlatform:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,3 @@
-from typing_extensions import LiteralString
 import pytest
 
 from pupgui2.util import *
@@ -121,7 +120,7 @@ def test_get_random_game_name(game_list: list[SteamApp] | list[LutrisGame] | lis
     """ Test whether get_random_game_name returns a valid game name for each launcher game type. """
 
     names: list[str] = ["game", "A super cool game", "A game with a very long name that is very long", "0123456789"]
-    bad_names: list[LiteralString] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor".split(',')
+    bad_names: list[str] = list("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor".split(','))
 
     for i, game in enumerate(game_list):
         setattr(game, game_name_attr, names[i])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,10 @@
+from typing_extensions import LiteralString
+import pytest
+
 from pupgui2.util import *
 
 from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS
-from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame, Launcher
+from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame, Launcher, SteamUser
 
 
 def test_build_headers_with_authorization() -> None:
@@ -106,22 +109,68 @@ def test_get_launcher_from_installdir() -> None:
     assert all(launcher == Launcher.WINEZGUI for launcher in winezgui_install_path_tests)
 
 
-def test_get_random_game_name() -> None:
+@pytest.mark.parametrize(
+    'game_list, game_name_attr', [
+        pytest.param([SteamApp() for _ in range(3)], 'game_name', id = 'Steam Games'),
+        pytest.param([LutrisGame() for _ in range(3)], 'name', id = 'Lutris Games'),
+        pytest.param([HeroicGame() for _ in range(3)], 'title', id = 'Heroic Games'),
+    ]
+)
+def test_get_random_game_name(game_list: list[SteamApp] | list[LutrisGame] | list[HeroicGame], game_name_attr: str) -> None:
 
     """ Test whether get_random_game_name returns a valid game name for each launcher game type. """
 
     names: list[str] = ["game", "A super cool game", "A game with a very long name that is very long", "0123456789"]
+    bad_names: list[LiteralString] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor".split(',')
 
-    steam_app: list[SteamApp] = [SteamApp() for _ in range(len(names))]
-    lutris_game: list[LutrisGame] = [LutrisGame() for _ in range(len(names))]
-    heroic_game: list[HeroicGame] = [HeroicGame() for _ in range(len(names))]
+    for i, game in enumerate(game_list):
+        setattr(game, game_name_attr, names[i])
 
-    for i, name in enumerate(names):
-        steam_app[i].game_name = name
-        lutris_game[i].name = name
-        heroic_game[i].title = name
+    for i in range(len(names) * 2):
+        result: str = get_random_game_name(game_list)
 
-    for i in range(10):
-        assert get_random_game_name(steam_app) in names
-        assert get_random_game_name(lutris_game) in names
-        assert get_random_game_name(heroic_game) in names
+        assert isinstance(result, str)
+
+        assert result in names
+        assert result not in bad_names
+
+
+@pytest.mark.parametrize(
+    'game_list, game_name_attr', [
+        pytest.param([SteamApp() for _ in range(4)], 'game_name', id = 'Steam Games'),
+        pytest.param([LutrisGame() for _ in range(4)], 'name', id = 'Lutris Games'),
+        pytest.param([HeroicGame() for _ in range(4)], 'title', id = 'Heroic Games'),
+    ]
+)
+def test_get_random_game_name_returns_str(game_list: list[SteamApp] | list[LutrisGame] | list[HeroicGame], game_name_attr: str) -> None:
+
+    """ Test that get_random_game_name will always return a string. """
+
+    names: list[int | float] = [12, 3.14, [1, 734, 12112121][0], -85, 99999999999]
+    str_names: list[str] = [str(name) for name in names]
+
+    for i, game in enumerate(game_list):
+        setattr(game, game_name_attr, names[i])
+
+    for i in range(len(names) * 2):
+
+        result: str = get_random_game_name(game_list)
+
+        assert isinstance(result, str)
+        assert result in str_names
+
+
+@pytest.mark.parametrize(
+    'game_list', [
+        pytest.param([], id = 'Empty List'),
+        pytest.param((), id = 'Empty Tuple'),
+        pytest.param([[], []], id = 'Empty List of Lists'),
+        pytest.param([(), ()], id = 'Empty List of Tuples'),
+        pytest.param([SteamUser(), SteamUser()], id = 'Empty List of SteamUser object')
+    ]
+)
+def test_get_random_game_name_unknown(game_list) -> None:
+
+    """ Test that get_random_game_name returns an empty string when given a list that does not have a known game type. """
+
+    assert get_random_game_name(game_list) == ''


### PR DESCRIPTION
Related: #528 

Uses PyTest Parametrize for the `get_random_game_name` function. Also adds some more test scenarios for ensuring we always get a `str` back, and to ensure we properly handle unknown objects and empty lists :-)