### PR TITLE
test_networkutil: Implement tests for `download_file`

### DIFF
--- a/pupgui2/networkutil.py
+++ b/pupgui2/networkutil.py
@@ -66,7 +66,7 @@ def download_file(url: str, destination: str, progress_callback: Callable[[int],
     #       Content-Length, or len(response.content) is 0), then then the progress bar will stall at 1% until
     #       the download finishes where it will jump to 99%, until extraction completes.
     try:
-        chunk_count = math.ceil(file_size / buffer_size)
+        chunk_count = math.ceil(file_size / buffer_size) or 1
     except ZeroDivisionError as e:
         print(f'Error: Could not calculate chunk_count, {e}')
         print('Defaulting to chunk count of 1')

--- a/tests/fixtures/networkutil/example_file.txt
+++ b/tests/fixtures/networkutil/example_file.txt
@@ -1,0 +1,1 @@
+This is an example text file to test networkutil#download_file.

--- a/tests/test_networkutil.py
+++ b/tests/test_networkutil.py
@@ -38,15 +38,6 @@ def sample_file(fs: FakeFilesystem) -> Generator[TextIOWrapper]:
         yield example_response_file
 
 
-# TODO parametrize with different streams, buffer sizes, and mocked request headers?
-# TODO test buffer size expected behaviour
-#
-#
-# TODO test with other types of `progress_callbacks` (None and one that takes any number of arguments?)
-# TODO test with `stream` as argument and in headers as `True` and `False` in a Parametrize'd test
-# TODO test file_size as zero (can go in base test and test expected chunk count / calls to progress callback?)
-# TODO test buffer_size as zero  (can go in base test and test expected chunk count / calls to progress callback?)
-#
 # TODO test incorrect known_size of file? i.e. give 64 bytes but file is actually 128?
 #
 # TODO Want to test the print logs as well in various scenarios (should be separate test I think?)

--- a/tests/test_networkutil.py
+++ b/tests/test_networkutil.py
@@ -1,0 +1,133 @@
+from io import TextIOWrapper
+import pathlib
+import requests
+
+import pytest
+import pytest_responses
+
+from collections.abc import Generator
+
+from responses import BaseResponse, RequestsMock
+
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pyfakefs.fake_file import FakeFileWrapper
+
+from pupgui2.constants import PROTONUPQT_GITHUB_URL, TEMP_DIR
+from pupgui2.networkutil import *
+
+
+@pytest.fixture(scope='function')
+def sample_file(fs: FakeFilesystem) -> Generator[TextIOWrapper]:
+
+    """
+    Example file as a `GET` response for `download_file`.
+    """
+
+    parent_directory_path: pathlib.Path = pathlib.Path(__file__).parent
+
+    example_response_file_path: str = os.path.join(parent_directory_path, 'fixtures', 'networkutil', 'example_file.txt')
+
+    fs.add_real_file(example_response_file_path)
+
+    with open(example_response_file_path, 'r') as example_response_file:
+        yield example_response_file
+        
+
+# TODO parametrize with different streams, buffer sizes, and mocked request headers?
+# Want to test the print logs as well
+def test_download_file(responses: RequestsMock, sample_file: FakeFileWrapper, fs: FakeFilesystem):
+
+    """
+    Given a valid URL and destination,
+    When download_file attempts to download the data from a `GET` request,
+    It should successfully download and write the file to the given destination.
+    """
+
+    request_url: str = 'https://example.com'
+
+    destination_file_path: str = os.path.join(TEMP_DIR, sample_file.file_object.name)
+
+    progress_callback: Callable[[int], None] = lambda progress: print(f'Progress is {progress}')
+
+    get_mock_body: str = sample_file.read()
+    get_mock: BaseResponse = responses.get(
+        request_url,
+        body = get_mock_body,
+    )
+
+    fs.create_dir(TEMP_DIR)
+
+    result: bool = download_file(
+        request_url,
+        destination_file_path,
+        buffer_size = 2
+    )
+
+    file_content: str = ''
+    with open(destination_file_path, 'r') as downloaded_file:
+        file_content = downloaded_file.read()
+
+    assert result
+
+    assert os.path.isfile(destination_file_path)
+
+    assert get_mock.call_count == 1
+    assert file_content == get_mock.body
+
+# TODO test with other types of `progress_callbacks` (None and one that takes any number of arguments?)
+# TODO test with `stream` as argument and in headers as `True` and `False` in a Parametrize'd test
+# TODO test file_size as zero (can go in base test and test expected chunk count / calls to progress callback?)
+# TODO test buffer_size as zero  (can go in base test and test expected chunk count / calls to progress callback?)
+
+@pytest.mark.parametrize(
+    'expected_error', [
+        pytest.param(requests.ConnectionError('Connection Error'), id = 'ConnectionError'),
+        pytest.param(requests.Timeout('Timed Out'), id = 'Timeout'),
+        pytest.param(OSError('OS Error'), id = 'OSError'),
+    ]
+)
+def test_download_file_request_failed(responses: RequestsMock, expected_error: requests.ConnectionError | requests.Timeout | OSError) -> None:
+
+    """
+    Given a URL,
+    When the `GET` request to the URL fails,
+    It should raise the given exception.
+    """
+
+    get_file_mock = responses.get(PROTONUPQT_GITHUB_URL, body = expected_error)
+
+    with pytest.raises(type(expected_error)) as raised_exception:
+        _ = download_file(url = PROTONUPQT_GITHUB_URL, destination = '')
+
+    # TODO assert against the print response too
+
+    assert raised_exception.type is type(expected_error)
+    assert raised_exception.value.args[0] == expected_error.args[0]  # Check error message
+
+    assert get_file_mock.call_count == 1
+    assert get_file_mock.body == expected_error
+
+
+def test_download_file_cannot_create_destination(responses: RequestsMock, fs: FakeFilesystem) -> None:
+
+    """
+    Given that we have successfully fetched a file to download,
+    When we cannot create the directory path to write the file,
+    It should raise an `OSError`.
+    """
+
+    pass
+
+
+def test_download_file_download_cancelled() -> None:
+
+    """
+    Given a file is successfully fetched and is being downloaded,
+    When the download is cancelled,
+    We should return cancelled to the `progress_callback` (`-2`)
+    And return False.
+    """
+
+    # TODO check that we return false
+    # TODO check that progress_callback is called last with '-2'
+    pass

--- a/tests/test_networkutil.py
+++ b/tests/test_networkutil.py
@@ -38,9 +38,6 @@ def sample_file(fs: FakeFilesystem) -> Generator[TextIOWrapper]:
         yield example_response_file
 
 
-# TODO test incorrect known_size of file? i.e. give 64 bytes but file is actually 128?
-#
-# TODO Want to test the print logs as well in various scenarios (should be separate test I think?)
 @pytest.mark.parametrize(
     'progress_callback, buffer_size, stream, known_size, headers', [
         pytest.param(
@@ -243,8 +240,6 @@ def test_download_file_request_failed(responses: RequestsMock, expected_error: r
 
     with pytest.raises(type(expected_error)) as raised_exception:
         _ = download_file(url = PROTONUPQT_GITHUB_URL, destination = '')
-
-    # TODO assert against the print response too
 
     assert raised_exception.type is type(expected_error)
     assert raised_exception.value.args[0] == expected_error.args[0]  # Check error message


### PR DESCRIPTION
Depends on #529 for the same reason as #535; we need `pyfakefs`, `responses`, and `pytest-mock`,

## Overview
This PR implements tests for `download_file`. We test what I believe are all of the non-happy-path scenarios, and most of the permutations of the happy-path scenario.

Since we're moving more of our ctmods over to use `download_file`, I think it's useful to have tests for this function to give us confidence that various cases work and behave as expected beyond "it works for other ctmods". :smile: 

With these tests, we have 88% coverage of `networkutil.py` (which only has `download_file` util function at this time) according to `pytest-cov`.

## Implementation
To test the happy path scenarios we make extensive use of [PyTest's Parametrize functionality](https://docs.pytest.org/en/7.1.x/example/parametrize.html). If I have missed a test scenario, let me know and it can be added.

In order to test downloading a file, we have some steps:
- Use `pyfakefs` to load a sample file as a PyTest Fixture that can be used across tests. This is used as an example response from a `GET` request. This also allows `download_file` to write to a real file at our destination path that we can load and compare against. We can simulate real filesystem operations and compare them against our real file.
    - `pyfakefs` mocks out the `os` module but not `Pathlib`, so it's safe to use `Pathlib` to load the file.
    - While the `FakeFilesystem` fixture `fs` does have some wrapper methods for our `os` functions, since it mocks out `os` it's safe to use the regular methods. This is also what our tested components would do anyway :-)
- Use `pytest-mock`'s `MockerFixture` to force certain operations inside of `download_file` to raise exceptions. We use this to raise an `OSError` when calling `os.makedirs` , and we also use it to spy on our `progress_callback` to check that it was called a given number of times and with expected arguments (the progress of the download).
- Use `responses` to mock our `GET` requests, since we don't want to make any real network calls. In combination with `pyfakefs` this allows us to load a file and set its contents as the returned body from the request to the given URL we call with `download_file`.

## Structure
For the docstrings in these tests, I decided to experiment with "Given-When-Then" syntax to describe the tests. I'm a fan, and happy to revise other tests to use this structure as well if we want to use it as a go-forward and think it's a useful way to describe our tests!

## Concerns
There is duplicated logic to send a mocked request across a couple of test scenarios. For example in `test_download_file_cannot_create_destination` we have to do the same set up as we do in `test_download_file`, because we still want to send a request but we want to check that it fails right before trying to write the file.

Maybe this isn't a huge deal, but it is something I wanted to call out.

## Future Work
This PR only adds a few test functions, but because we use Parametrize, we end up with this PR effectively adding 19 tests. This on top of our existing tests, and the opened PRs that also use Parametrize, we could end up with a fair amount of tests. It may be worth looking into parallelizing some of our tests.

We should be able to do this fairly easily with [`pytest-xdist`](https://github.com/pytest-dev/pytest-xdist) :-)

<hr>

Opening as draft as this PR is dependent on another to be merged, but since it's standalone in a new `test_networkutil.py` file and since `download_file` is the only function in that file, I thought it was worth working on in parallel.

As always, all feedback is welcome. Thanks! :smile: 