### PR TITLE
test_dbusutil: Add tests for dbusutil functions

### DIFF
--- a/tests/test_dbusutil.py
+++ b/tests/test_dbusutil.py
@@ -1,3 +1,5 @@
+import pupgui2.dbusutil  # needed for spies
+
 import pytest
 
 from pytest_mock import MockerFixture
@@ -5,10 +7,8 @@ from pytest_mock import MockerFixture
 from PySide6.QtDBus import QDBusMessage, QDBusConnection
 
 from pupgui2.dbusutil import *
-from pupgui2.constants import DBUS_DOWNLOAD_OBJECT_BASEPATH
 
-
-# NOTE: WOOHOO this mostly works!
+from pupgui2.constants import DBUS_DOWNLOAD_OBJECT_BASEPATH, DBUS_APPLICATION_URI
 
 
 def test_create_and_send_dbus_message(mocker: MockerFixture) -> None:
@@ -20,11 +20,10 @@ def test_create_and_send_dbus_message(mocker: MockerFixture) -> None:
     """
 
     session_bus_mock = mocker.spy(QDBusConnection, 'sessionBus')
-    
+
     session_bus_send_mock = mocker.patch('PySide6.QtDBus.QDBusConnection.send')
     session_bus_send_mock.return_value = True
 
-    # TODO parametrize?
     dbus_args: dict[str, str | list[str | dict[str, str]]] = {
         'object': 'echo',
         'interface': 'net.davidotek.pupgui2.Test',
@@ -51,9 +50,9 @@ def test_create_and_send_dbus_message(mocker: MockerFixture) -> None:
     session_bus_mock.assert_called_once()
 
     session_bus_send_mock.assert_called_once()
-    
+
     assert session_bus_send_mock.return_value
-    
+
     assert isinstance(session_bus_send_mock_message_arg, QDBusMessage)
 
     assert session_bus_send_mock_message_arg.path() == os.path.join(DBUS_DOWNLOAD_OBJECT_BASEPATH, str(dbus_args['object']))
@@ -80,12 +79,72 @@ def test_create_and_send_dbus_message_bus_not_connected(mocker: MockerFixture) -
     result: bool = create_and_send_dbus_message('', '', '', [])
 
     assert not result
-    
+
     session_bus_isConnected_mock.assert_called_once()
 
     session_bus_send_mock.assert_not_called()
 
 
-def test_dbus_progress_message() -> None:
+@pytest.mark.parametrize(
+    'progress, count, should_progress_be_visible, should_count_be_visible', [
+        pytest.param(0.1, 1, True, True, id = 'Progress (1%) should be visible, Count (1) should be visible'),
+        pytest.param(1, 0, False, False, id = 'Progress (100%) should not be visible, Count (0) should not be visible'),
+        pytest.param(0, 0, True, False, id = 'Progress (0%) should be visible, Count (0) should not be visible'),
+        pytest.param(1, 1, False, True, id = 'Progress (100%) should not be visible, Count (1) should be visible'),
 
-    pass
+        pytest.param(100, 1, False, True, id = 'Progress (10,000%) should not be visible, Count (1) should be visible'),
+        pytest.param(-1, 1, False, True, id = 'Progress (-100%) should not be visible, Count (1) should be visible'),
+        pytest.param(1, -1, False, False, id = 'Progress (100%) should not be visible, Count (-1) should not be visible'),
+    ]
+)
+def test_dbus_progress_message(progress: float, count: int, should_count_be_visible: bool, should_progress_be_visible: bool, mocker: MockerFixture) -> None:
+
+    """
+    Given a valid DBus bus Connection,
+    When a progress message is sent with a given progress and count,
+    Then we should send a valid DBus message on the expected progress bus,
+    And it should contain the expected progress values
+    And the count and progress visibility should match the expected values
+    """
+
+    session_bus_mock = mocker.spy(QDBusConnection, 'sessionBus')
+
+    session_bus_send_mock = mocker.patch('PySide6.QtDBus.QDBusConnection.send')
+    session_bus_send_mock.return_value = True
+
+    create_and_send_dbus_message_spy = mocker.spy(pupgui2.dbusutil, 'create_and_send_dbus_message')
+
+    expected_dbus_message_attrs = {
+        'object': 'Update',
+        'interface': 'com.canonical.Unity.LauncherEntry',
+        'signal': 'Update',
+        'arguments': [
+            DBUS_APPLICATION_URI,
+            {
+                'progress': progress,
+                'progress-visible': should_progress_be_visible,
+                'count': count,
+                'count-visible': should_count_be_visible,
+            }
+        ]
+    }
+
+    result: bool = dbus_progress_message(
+        progress,
+        count
+    )
+
+    create_and_send_dbus_message_spy_call_args = create_and_send_dbus_message_spy.call_args[0][:4]
+
+    assert result
+
+    assert create_and_send_dbus_message_spy_call_args == (
+        expected_dbus_message_attrs['object'],
+        expected_dbus_message_attrs['interface'],
+        expected_dbus_message_attrs['signal'],
+        expected_dbus_message_attrs['arguments']
+    )
+
+    session_bus_mock.assert_called_once()
+
+    session_bus_send_mock.assert_called_once()

--- a/tests/test_dbusutil.py
+++ b/tests/test_dbusutil.py
@@ -1,0 +1,91 @@
+import pytest
+
+from pytest_mock import MockerFixture
+
+from PySide6.QtDBus import QDBusMessage, QDBusConnection
+
+from pupgui2.dbusutil import *
+from pupgui2.constants import DBUS_DOWNLOAD_OBJECT_BASEPATH
+
+
+# NOTE: WOOHOO this mostly works!
+
+
+def test_create_and_send_dbus_message(mocker: MockerFixture) -> None:
+
+    """
+    Given a valid DBus bus Connection,
+    When a message is constrtucted,
+    It should send the constructed message on the given bus.
+    """
+
+    session_bus_mock = mocker.spy(QDBusConnection, 'sessionBus')
+    
+    session_bus_send_mock = mocker.patch('PySide6.QtDBus.QDBusConnection.send')
+    session_bus_send_mock.return_value = True
+
+    # TODO parametrize?
+    dbus_args: dict[str, str | list[str | dict[str, str]]] = {
+        'object': 'echo',
+        'interface': 'net.davidotek.pupgui2.Test',
+        'signal_name': 'Test',
+        'arguments': [
+            'application://net.davidotek.pupgui2.Test',
+            {
+                'test-value': '1'
+            }
+        ]
+    }
+
+    result: bool = create_and_send_dbus_message(
+        str(dbus_args['object']),
+        str(dbus_args['interface']),
+        str(dbus_args['signal_name']),
+        dbus_args['arguments']
+    )
+
+    session_bus_send_mock_message_arg: QDBusMessage = session_bus_send_mock.call_args[0][0]
+
+    assert result
+
+    session_bus_mock.assert_called_once()
+
+    session_bus_send_mock.assert_called_once()
+    
+    assert session_bus_send_mock.return_value
+    
+    assert isinstance(session_bus_send_mock_message_arg, QDBusMessage)
+
+    assert session_bus_send_mock_message_arg.path() == os.path.join(DBUS_DOWNLOAD_OBJECT_BASEPATH, str(dbus_args['object']))
+    assert session_bus_send_mock_message_arg.interface() == dbus_args['interface']
+    assert session_bus_send_mock_message_arg.member() == dbus_args['signal_name']
+    assert session_bus_send_mock_message_arg.arguments() == dbus_args['arguments']
+
+
+def test_create_and_send_dbus_message_bus_not_connected(mocker: MockerFixture) -> None:
+
+    """
+    Given that `DBusConnection` fails to any event bus,
+    When the connection query for `isConnected()` is `False`,
+    Then we should return `False`,
+    And not send a message.
+    """
+
+    session_bus_isConnected_mock = mocker.patch('PySide6.QtDBus.QDBusConnection.isConnected')
+    session_bus_isConnected_mock.return_value = False
+
+    session_bus_send_mock = mocker.patch('PySide6.QtDBus.QDBusConnection.send')
+    session_bus_send_mock.return_value = False
+
+    result: bool = create_and_send_dbus_message('', '', '', [])
+
+    assert not result
+    
+    session_bus_isConnected_mock.assert_called_once()
+
+    session_bus_send_mock.assert_not_called()
+
+
+def test_dbus_progress_message() -> None:
+
+    pass


### PR DESCRIPTION
Depends on: #529 (this PR requires `pytest-mock` introduced in the linked PR).

## Overview
This PR implements unit tests for our dbusutil functions. This file consists of two utility functions: A generic one to create and send a DBus message on a given bus or the session bus, and a specific one to create a progress message to send to DBus to display an expected progress bar and count on supported Task Managers.

While coverage isn't always a metric to obsess over, `pytest-cov` indicates that this test gives us 100% coverage on `dbusutil.py`!

## Implementation
We test `create_and_send_dbus_message` to ensure it sends an expected constructed message. Since other tests will test multiple message variations, I didn't feel the need to Parametrize this test with multiple message cases. We build a DBus message to send and then we check that the `QDBusConnection.send` method was actually called and called with the values that we expect from our constructed message.

We check inside of `create_and_send_dbus_message` if it has a DBus connection and we only send the message if it does. If it doesn't have a connection, we will default to returning `False`. I implemented a test to cover this specific case, where we just mock the `isConnected` method of `QDBusConnection` to always return `False`. This means we never get to the point of calling `QDBusConnection.send`, so we check to make sure that `send` is not called and that we return `False` from our call (if `send` was not called, the only return value that we have should be from returning `False` ourselves).

Finally we test `dbus_progress_message` where we call it with an expected `count` and `progress`. This function is an abstraction on top of `create_and_send_dbus_message`. Since the progress message we want to send has a fixed structure and we don't need to care about the underlying manual message components. We just give it a `progress` value between `0` and `1`, and a `count` value, and it does the rest. For our test I decided to Parametrize it because I wanted to check that using different values for `progress` and `count` work as expected. When `progress >= 1` we don't display the progress anymore, and when `count <= 0` we don't display the count either. So I wanted to test these scenarios and uses Parametrization to do it.

## Gaps
The only gap in the test that I can see is that we don't have a test case to cover manually providing a `bus` object, but I don't think we need to test that case too much. Plus, coverage is already at 100%, so we should be fine :-)

We also don't check in `dbus_progress_message` that `create_and_send_dbus_message`'s call to `QDBusConnection.send` is sent with the expected parameters. I chose not to get this granular because I feel that testing that `create_and_send_dbus_message` here is unnecessary since it has its own test. 

<hr>

Like with #541, I opened this PR despite it having dependencies because this is all "net new". This also entirely covers the tests in dbusutil, so since the tests in this PR are also quite standalone I think it is worth opening separately :-)

As usual, all feedback is welcome. Thanks!