### PR TITLE
test_util: Implement test for `compat_tool_available`

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -144,3 +144,57 @@ def test_is_gitlab_instance(url: str, is_gitlab_api: bool) -> None:
     result: bool = is_gitlab_instance(url)
 
     assert result == is_gitlab_api
+
+
+@pytest.mark.parametrize(
+    'compat_tool_name, ctobjs, expected', [
+        pytest.param(
+            'GE-Proton9-27',
+            [
+                { 'name': 'Luxtorpeda' },
+                { 'name': 'GE-Proton8-16' },
+                { 'name': 'GE-Proton9-27' },
+                { 'name': 'Proton-GE-5-2' },
+                { 'name': 'Proton-tkg.10.6.a34b12f' }
+            ],
+            True,
+            id = 'GE-Proton9-27 should be found'
+        ),
+        pytest.param(
+            'Wine-tkg',
+            [
+                { 'name': 'Luxtorpeda' },
+                { 'name': 'GE-Proton8-16' },
+                { 'name': 'GE-Proton9-27' },
+                { 'name': 'Proton-GE-5-2' },
+                { 'name': 'Proton-tkg.10.6.a34b12f' }
+            ],
+            False,
+            id = 'Wine-tkg should not be found'
+        ),
+        pytest.param(
+            'GE-Proton9-2',
+            [
+                { 'name': 'Luxtorpeda' },
+                { 'name': 'GE-Proton8-16' },
+                { 'name': 'GE-Proton9-27' },
+                { 'name': 'Proton-GE-5-2' },
+                { 'name': 'Proton-tkg.10.6.a34b12f' }
+            ],
+            False,
+            id = 'GE-Proton9-2 should not be found'
+        ),
+        
+    ]
+)
+def test_compat_tool_available(compat_tool_name: str, ctobjs: list[dict[str, str]], expected: bool) -> None:
+
+    """
+    Given a list of dictionaries containing compatibility tools,
+    When the name of the compatibility tool is in the list of dictionaries,
+    Then it should return whether the given compatibility tool name is in the list of dictionaries
+    """
+
+    result: bool = compat_tool_available(compat_tool_name, ctobjs)
+
+    assert result == expected


### PR DESCRIPTION
This PR implements a test for `util#compat_tool_available`. We give it a Parametrized list of dummy compatibility tool dictionaries containing only a `name` key (as that's all we need to test against), the string name of the tool we want to ensure is in a dictionary in the list of compatibility tool dictionaries, and the expected value of whether or not that name should be found.

The three cases we test are: A name that should be found, a distinct name that should not be found, and a substring name that should not be found (ensures cases where `GE-Proton9-27` is in the list but `GE-Proton9-2` is not, that the substring `GE-Proton9-2` is not flagged).

Thanks!