### PR TITLE
GE-Proton: Use `page` parameter when calling `fetch_project_releases`

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_00protonge.py
+++ b/pupgui2/resources/ctmods/ctmod_00protonge.py
@@ -132,7 +132,7 @@ class CtInstaller(QObject):
         Return Type: str[]
         """
 
-        return fetch_project_releases(self.CT_URL, self.rs, count=count)
+        return fetch_project_releases(self.CT_URL, self.rs, count=count, page=page)
 
     def get_tool(self, version, install_dir, temp_dir):
         """

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -608,7 +608,6 @@ def is_online(host: str = 'https://api.github.com/rate_limit/', timeout: int = 5
         return False
 
 
-# Only used for dxvk and dxvk-async right now, but is potentially useful to more ctmods?
 def fetch_project_releases(releases_url: str, rs: requests.Session, count: int = 100, page: int = 1, include_extra_asset: Callable[..., list[str]] | None = None) -> list[str]:
 
     """


### PR DESCRIPTION
Fixes #554.

## Overview
Allows the "Load More" option on the Install dialog to work, as it relies on the `page` parameter.

(When trying to get a video to attach to this PR, the first recording didn't work, and I have been rate limited. I can attach a video later.)

Other tools may need this. I can tackle it in this PR as we should just pass `page` to any call to `fetch_project_releases`.

## Tests
I have not added a test to this PR because:
- We can't really test `util#fetch_project_releases` until we have `pytest-mock` in place as a dependency for PyTest.
- Implementing a test for this on its own isn't exactly what we'd need to catch a regression like this, we'd really want to test `PupguiInstallDialog#update_releases` with each compatibility tool type and a mocked out set of responses for calls to `fetch_project_releases`. I'm not sure if we can cleanly test this yet.
- In addition we'd probably also want to be testing each Ctmod's calls to `fetch_releases` to ensure the `page` parameter works, but that will also have to wait until we have `pytest-mock`.

Open to suggestions on implementing tests to catch issues like this in future!

Thanks!