### PR TITLE
Ctmod: Add Proton-EM

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_protonem.py
+++ b/pupgui2/resources/ctmods/ctmod_protonem.py
@@ -1,0 +1,24 @@
+# pupgui2 compatibility tools module
+# Etaash-mathamsetty's Proton-EM
+# Copyright (C) 2025 DavidoTek, partially based on AUNaseef's protonup
+
+
+from PySide6.QtCore import QCoreApplication
+
+from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as GEProtonInstaller
+
+
+CT_NAME = 'Proton-EM'
+CT_LAUNCHERS: list[str] = ['steam', 'lutris', 'heroicproton', 'bottles', 'advmode']
+CT_DESCRIPTION: dict[str, str] = {'en': QCoreApplication.instance().translate('ctmod_protonem', '''Fork of Valve's Proton with Wine-Wayland and AMD FidelityFX Super Resolution 4 patches.''',),}
+
+
+class CtInstaller(GEProtonInstaller):
+
+    CT_URL = 'https://api.github.com/repos/Etaash-mathamsetty/Proton/releases'
+    CT_INFO_URL = 'https://github.com/Etaash-mathamsetty/Proton/releases/tag/'
+
+    def __init__(self, main_window = None):
+        super().__init__(main_window)
+
+        self.release_format = 'tar.xz'


### PR DESCRIPTION
Implements #555.

This PR implements Proton-EM for Steam, Lutris, Heroic Proton, and Bottles. We do this by subclassing the GE-Proton Ctmod installer, updating the `CT_URL` and `CT_INFO_URL` variables, and setting the Release Format to `tar.xz` (GE-Proton uses `tar.gz`).

<img width="452" height="444" alt="Screenshot_20250806_173319" src="https://github.com/user-attachments/assets/42a35e16-cbd6-49b9-9f1c-37be558a94ef" />

This Ctmod is gated behind Advanced Mode, as the main benefits of using it probably appeals more to "Advanced" users (i.e. you need to use commandline options for the features like Wine-Wayland support and so on, otherwise it's more or less just like vanilla Proton).

Thanks!