### PR TITLE
test_steamutil: Add tests for `is_valid_steam_install`

### DIFF
--- a/pupgui2/steamutil.py
+++ b/pupgui2/steamutil.py
@@ -793,7 +793,7 @@ def determine_most_recent_steam_user(steam_users: list[SteamUser]) -> SteamUser:
     return None
 
 
-def is_valid_steam_install(steam_path) -> bool:
+def is_valid_steam_install(steam_path: str) -> bool:
 
     """
     Return whether required Steam data files actually exist to determine if 'steam_path' is a valid Steam installation.
@@ -805,9 +805,10 @@ def is_valid_steam_install(steam_path) -> bool:
     config_vdf = os.path.join(ct_dir, 'config.vdf')
     libraryfolders_vdf = os.path.join(ct_dir, 'libraryfolders.vdf')
 
-    is_valid_steam_install = os.path.exists(config_vdf) and os.path.exists(libraryfolders_vdf)
+    is_valid_steam_install = os.path.isfile(config_vdf) and os.path.isfile(libraryfolders_vdf)
 
     return is_valid_steam_install
+
 
 def vdf_safe_load(vdf_file: str) -> dict:
     """

--- a/tests/test_steamutil.py
+++ b/tests/test_steamutil.py
@@ -1,6 +1,14 @@
 import pytest
 
-from pupgui2.steamutil import calc_shortcut_app_id
+import os
+
+from pyfakefs.fake_filesystem import FakeFilesystem
+
+from pupgui2.steamutil import calc_shortcut_app_id, is_valid_steam_install
+from pupgui2.constants import HOME_DIR, POSSIBLE_INSTALL_LOCATIONS
+
+
+KNOWN_STEAM_INSTALL_LOCATIONS: list[dict[str, str]] = [install_location for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] == 'steam']
 
 
 @pytest.mark.parametrize(
@@ -15,3 +23,122 @@ def test_calc_shortcut_app_id(shortcut_dict: dict[str, str], expected_appid: int
     result: int = calc_shortcut_app_id(shortcut_dict.get('name', ''), shortcut_dict.get('exe', ''))
 
     assert result == expected_appid
+
+
+@pytest.mark.parametrize(
+    'steam_path', [
+        pytest.param(
+            os.path.expanduser(install_location['install_dir']),
+            id = f'{install_location["install_dir"]}'
+        ) for install_location in KNOWN_STEAM_INSTALL_LOCATIONS
+    ]
+)
+def test_is_valid_steam_install_happy_path(fs: FakeFilesystem, steam_path: str) -> None:
+
+    """
+    Given a path to a possible Steam installation,
+    When the folder exists as a known Steam path with the config.vdf and libraryfolders.vdf files inside,
+    Then it should return True.
+    """
+
+    config_dir: str = os.path.join(steam_path, 'config')
+
+    config_vdf_path: str = os.path.join(config_dir, 'config.vdf')
+    libraryfolders_vdf_path = os.path.join(config_dir, 'libraryfolders.vdf')
+
+    fs.create_dir(steam_path)
+
+    fs.create_file(config_vdf_path, create_missing_dirs = True)
+    fs.create_file(libraryfolders_vdf_path, create_missing_dirs = True)
+
+    result: bool = is_valid_steam_install(steam_path)
+
+    assert result
+
+
+@pytest.mark.parametrize(
+  'symlink_path, real_path', [
+    pytest.param(
+        os.path.join(HOME_DIR, '.steam/steam'),
+        os.path.join(HOME_DIR, '.local/share/Steam'),
+        id = '~/.steam/steam -> ~/.local/share/Steam'
+    ),
+    pytest.param(
+        os.path.join(HOME_DIR, '.steam/root'),
+        os.path.join(HOME_DIR, '.local/share/Steam'),
+        id = '~/.steam/steam -> ~/.local/share/Steam'
+    )
+  ]
+)
+def test_is_valid_steam_install_symlink(fs: FakeFilesystem, symlink_path: str, real_path: str):
+
+    """
+    Given a symlink path to a Steam installation,
+    When the pointed path is a valid Steam installation,
+    Then it should return True.
+    """
+
+    config_dir = os.path.join(real_path, 'config')
+
+    config_vdf_path: str = os.path.join(config_dir, 'config.vdf')
+    libraryfolders_vdf_path = os.path.join(config_dir, 'libraryfolders.vdf')
+
+    fs.create_dir(real_path)
+
+    fs.create_file(config_vdf_path, create_missing_dirs = True)
+    fs.create_file(libraryfolders_vdf_path, create_missing_dirs = True)
+
+    fs.create_symlink(symlink_path, real_path)
+
+    result: bool = is_valid_steam_install(symlink_path)
+
+    assert result
+
+
+@pytest.mark.parametrize(
+    'path, should_folder_exist', [
+        *[
+            pytest.param(
+                os.path.expanduser(install_location['install_dir']),
+                True,
+                id = f'Steam Path - {install_location["install_dir"]}'
+            ) for install_location in KNOWN_STEAM_INSTALL_LOCATIONS
+        ],
+
+        *[
+            pytest.param(
+                os.path.expanduser(install_location['install_dir']),
+                True,
+                id = f'Non-Steam Path - {install_location["install_dir"]}'
+            ) for install_location in POSSIBLE_INSTALL_LOCATIONS if install_location['launcher'] != 'steam'
+        ],
+
+        *[
+            pytest.param(
+                '/not/a/path',
+                False,
+                id = 'Invalid Path - Nested'
+            ),
+            pytest.param(
+                'not-a-path',
+                False,
+                id = 'Invalid Path - Single'
+            ),
+        ]
+    ]
+)
+def test_is_valid_steam_install_no_vdfs(fs: FakeFilesystem, path: str, should_folder_exist: bool) -> None:
+
+    """
+    Given a path to a possible Steam installation,
+    When the folder does not exist
+    Or the folder exists but without the config.vdf and libraryfolders.vdf files inside,
+    Then it should return False.
+    """
+
+    if should_folder_exist:
+        fs.create_dir(path)
+
+    result: bool = is_valid_steam_install(path)
+
+    assert not result


### PR DESCRIPTION
This PR creates a suite of tests for `steamutil#is_valid_steam_install`. A Steam installation is valid if the path the `config.vdf` file  and `libraryfolders.vdf` file exists.

We test three scenarios:
- Happy path with known Steam folder locations that contain the needed files.
- Symlinks that point to valid directories that contain the needed files.
    - Symlinks that point to directories that don't contain the needed files was **not** written as a scenario because I felt it is covered by the test cases for invalid paths.
- Paths, which may exist or may not exist, which do not contain the needed VDF files.

Given that we want to explicitly check files, I changed the logic in `is_valid_steam_install` to check for files specifically and not just that it exists as a file or a folder. This also makes the tests more robust as we mock creating the files in the tests.

As usual, all feedback is welcome! Unsure if we may want the last scenario to be separate, where the paths may exist or may not exist. But since the logic is so similar I decided to group them into one test with a parameter to control whether we create the folder or not.

Thanks!