### PR TITLE
test_util: Add test for `read_update_config_value`

### DIFF
--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -128,7 +128,7 @@ def apply_dark_theme(app: QApplication) -> None:
                 app.setPalette(QStyleFactory.create('fusion').standardPalette())
 
 
-def read_update_config_value(option: str, value = None, section: str = 'pupgui2', config_file: str = CONFIG_FILE) -> str | None:
+def read_update_config_value(option: str, value: str | None = None, section: str = 'pupgui2', config_file: str = CONFIG_FILE) -> str | None:
     """
     Uses ConfigParser to read a value with a given option from a given section from a given config file.
     By default, will read a option and a value from the 'pupgui2' section in CONFIG_FILE path in constants.py.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from pytest_mock.plugin import MockType
 
 import pytest
 import pytest_responses
@@ -12,7 +13,7 @@ from pyfakefs.fake_file import FakeFileWrapper
 from pytest_mock import MockerFixture
 
 from pupgui2.util import *
-from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS, AWACY_GAME_LIST_URL, LOCAL_AWACY_GAME_LIST, GITLAB_API, GITHUB_API
+from pupgui2.constants import HOME_DIR, POSSIBLE_INSTALL_LOCATIONS, AWACY_GAME_LIST_URL, LOCAL_AWACY_GAME_LIST, GITLAB_API, GITHUB_API
 from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame, Launcher, SteamUser
 
 
@@ -436,3 +437,107 @@ def test_get_combobox_index_by_value(combobox_values: list[str], value: str, exp
     assert result == expected_index
 
     QApplication.shutdown(app)
+
+
+@pytest.mark.parametrize(
+    'option, value, section, config_file', [
+        pytest.param(
+            'theme',
+            'dark',
+            'pupgui2',
+            CONFIG_FILE,
+
+            id = f'Writing "theme = \"dark\" into the "pupgui2" section of {CONFIG_FILE}'
+        ),
+        pytest.param(
+            'foo',
+            "",
+            'foobar',
+            CONFIG_FILE,
+
+            id = f'Writing "" (empty string) into the "foobar" section of ${CONFIG_FILE}'
+        ),
+
+        pytest.param(
+            'theme',
+            'dark',
+            'pupgui2',
+            '/tmp/config.ini',
+
+            id = f'Writing "theme = \"dark\" into the "pupgui2" section of /tmp/config.ini'
+        ),
+        pytest.param(
+            'foo',
+            "",
+            'foobar',
+            '/tmp/another-config.ini',
+
+            id = f'Writing "" (empty string) into the "foobar" /tmp/another-config.ini'
+        ),
+    ]
+)
+def test_read_update_config_value(fs: FakeFilesystem, mocker: MockerFixture, option: str, value: str, section: str, config_file: str) -> None:
+
+    """
+    Given a variable to store in a given section of a given config file,
+    When attempting to write the value to the config file,
+    Then it should update the config file with the expected result.
+    """
+
+    configparser_write_spy = mocker.spy(ConfigParser, 'write')
+
+    config_file_exists_before_call = os.path.isfile(config_file)
+    write_result = read_update_config_value(option, value, section, config_file)
+    
+    config_file_exists_after_call = os.path.isfile(config_file)
+    read_result = read_update_config_value(option, None, section, config_file)
+
+    assert write_result == read_result
+
+    assert not config_file_exists_before_call
+    assert config_file_exists_after_call
+
+    assert configparser_write_spy.call_count == 1
+
+
+@pytest.mark.parametrize(
+    'option, value, section, expected_error_message', [
+        pytest.param(
+            None,
+            "foo",
+            "foo",
+            "option keys must be strings",
+
+            id = '"option" is None'
+        ),
+
+        pytest.param(
+            "foo",
+            "foo",
+            None,
+            "section names must be strings",
+
+            id = '"section" is None'
+        ),
+
+        pytest.param(
+            "foo",
+            10,
+            "foo",
+            "option values must be strings",
+
+            id = '"value" is int'
+        )
+    ]
+)
+def test_read_update_config_type_error(fs: FakeFilesystem, option: str | None, value: str | None, section: str | None, expected_error_message: str) -> None:
+
+    """
+    Given a variable to store in a given section of a given config file,
+    When the option, section key, or config file are None,
+    Or when the option value we attempt to write is not a string and is not None,
+    Then it should throw a TypeError.
+    """
+
+    with pytest.raises(TypeError, match=f'{expected_error_message}'):
+        result = read_update_config_value(option, value, section)


### PR DESCRIPTION
This PR adds a test for `util#create_read_config_value`. We test that we can write a value to the config file in our constants file (`CONFIG_FILE`), as well as other config file paths, and that we can read our expected value back. The test also checks that the config file is created as needed, and that before reading that the file already exists.

There is a test case for non-happy-path scenarios as well. We have a test for checking that we raise the appropriate error if we try to call `read_update_config_value` with `None` values for `option` and `section` (calling it with a `None` value for section will read the value, and a `None` value for `config_file` will default to using the `CONFIG_FILE` constant).

Finally we have a small test for ensuring we raise an error when writing a non-string and non-None value. We cannot write values which aren't strings into our config files, so we ensure we raise an error in this scenario.

Using the `FakeFilesystem` fixture allows us to sanely test without using any real config values or interrupting any actual configs.

As usual, all feedback is welcome. Thanks!