### PR TITLE
test_util: Add test for `create_compatibilitytools_folder`

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -436,3 +436,40 @@ def test_get_combobox_index_by_value(combobox_values: list[str], value: str, exp
     assert result == expected_index
 
     QApplication.shutdown(app)
+
+
+def test_create_compatibilitytools_folder(fs: FakeFilesystem, mocker: MockerFixture) -> None:
+
+    """
+    Given a list of launcher install locations and compatibility tool folders,
+    When the parent directory for a given launcher's compatibility tool folder exists,
+    Then it should create the compatibility tool directory for that launcher.
+    """
+
+    for loc in POSSIBLE_INSTALL_LOCATIONS:
+        parent_dir = os.path.abspath(os.path.join(os.path.expanduser(loc['install_dir']), os.pardir))
+
+        fs.makedirs(parent_dir, exist_ok = True)
+
+    os_mkdir_spy = mocker.spy(os, 'mkdir')
+
+    create_compatibilitytools_folder()
+
+    assert os_mkdir_spy.call_count == len(POSSIBLE_INSTALL_LOCATIONS)
+    assert all(os.path.isdir(os.path.expanduser(loc['install_dir'])) for loc in POSSIBLE_INSTALL_LOCATIONS)
+
+
+def test_create_compatibilitytools_folder_no_parent_directory(fs: FakeFilesystem, mocker: MockerFixture) -> None:
+
+    """
+    Given a list of launcher install locations and compatibility tool folders,
+    When the parent directroy for a given launcher's compatibility tool folder does not exist,
+    Then it should not create the compatibility tool directory for that launcher.
+    """
+
+    os_mkdir_spy = mocker.spy(os, 'mkdir')
+
+    create_compatibilitytools_folder()
+
+    assert os_mkdir_spy.call_count == 0
+    assert all(not os.path.isdir(os.path.expanduser(loc['install_dir'])) for loc in POSSIBLE_INSTALL_LOCATIONS)


### PR DESCRIPTION
This PR adds two tests for `util#create_compatibilitytools_folder`.

The first test ensures that we can create the compatibility tools folder for every launcher in `POSSIBLE_INSTALL_LOCATIONS` by creating the launcher parent directory (i.e. the path for the launcher itself, such as `~/.local/share/Steam`) and then ensuring that the `create_compatibilitytools_folder` call will create the compatibility tools install directory (such as `~/.local/share/Steam/compatibilitytools.d`). We use `FakeFilesystem` for this from `pyfakefs` to create all the parent directroy launcher folders.

The second test is that we do not make any compatibility tool directory if the launcher directory does not exist. All we do for this one is call `create_compatibilitytools_folder` and make sure the folders still don't exist. We still use  the `fs` FakeFilesystem fixture here because it allows us to check in the fake in-memory filesystem from PyFakeFS and not in any real directory, so we stay in that controlled environment. This is more useful for tests from devs so that any existing launchers that they have to not conflict with the test results.

Thanks!