### PR TITLE
test_util: Add test for `get_install_location_from_directory_name`

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -12,7 +12,7 @@ from pyfakefs.fake_file import FakeFileWrapper
 from pytest_mock import MockerFixture
 
 from pupgui2.util import *
-from pupgui2.constants import POSSIBLE_INSTALL_LOCATIONS, AWACY_GAME_LIST_URL, LOCAL_AWACY_GAME_LIST, GITLAB_API, GITHUB_API
+from pupgui2.constants import HOME_DIR, POSSIBLE_INSTALL_LOCATIONS, AWACY_GAME_LIST_URL, LOCAL_AWACY_GAME_LIST, GITLAB_API, GITHUB_API
 from pupgui2.datastructures import SteamApp, LutrisGame, HeroicGame, Launcher, SteamUser
 
 
@@ -436,3 +436,78 @@ def test_get_combobox_index_by_value(combobox_values: list[str], value: str, exp
     assert result == expected_index
 
     QApplication.shutdown(app)
+
+
+@pytest.mark.parametrize(
+    'install_loc', [
+        pytest.param(install_loc, id = f'{install_loc["display_name"]} ({install_loc["install_dir"]})') for install_loc in POSSIBLE_INSTALL_LOCATIONS
+    ]
+)
+def test_get_install_location_from_directory_name(install_loc: dict[str, str]) -> None:
+
+    """
+    Given an install location string path,
+    When the path corresponds to a known `install_dir from `POSSIBLE_INSTALL_LOCATIONS`,
+    Then it should return the dictionary from `POSSIBLE_INSTALL_LOCATION`.
+    """
+
+    result: dict[str, str] = get_install_location_from_directory_name(install_loc['install_dir'])
+
+    assert result == install_loc
+
+
+def test_get_install_location_from_directory_name_custom_install_location(mocker: MockerFixture) -> None:
+
+    """
+    Given an install location string path,
+    When the path corresponds to a custom install location written out to the config file,
+    And given the custom install location has a valid launcher associated with it,
+    Then it should return the custom install location dictionary.
+    """
+
+    path: str = f'${HOME_DIR}/.local/share/custom_Steam'
+
+    config_custom_install_location_mock = mocker.patch('pupgui2.util.config_custom_install_location')
+    config_custom_install_location_mock.return_value = { 'install_dir': path, 'display_name': '', 'launcher': 'steam' }
+
+    result: dict[str, str] = get_install_location_from_directory_name(path)
+
+    assert result == config_custom_install_location_mock.return_value
+
+
+def test_get_install_location_from_directory_name_custom_install_location_no_launcher(mocker: MockerFixture) -> None:
+
+    """
+    Given an install location string path,
+    When the path corresponds to a custom install location written out to the config file,
+    And given the custom install location does not have a valid launcher associated with it,
+    Then it should return the default invalid path dictionary.
+    """
+
+    path: str = f'${HOME_DIR}/.local/share/custom_Steam'
+
+    config_custom_install_location_mock = mocker.patch('pupgui2.util.config_custom_install_location')
+    config_custom_install_location_mock.return_value = { 'install_dir': path, 'display_name': '' }
+
+    unknown_install_location_dict = {'install_dir': path, 'display_name': 'unknown', 'launcher': ''}
+
+    result: dict[str, str] = get_install_location_from_directory_name(path)
+
+    assert config_custom_install_location_mock.call_count == 1
+    assert result == unknown_install_location_dict
+
+
+def test_get_install_location_from_directory_name_unknown() -> None:
+
+    """
+    Given an install location string path,
+    When the path does not correspond to a known `install_dir` from `POSSIBLE_INSTALL_LOCATIONS` or a custom install location,
+    Then it should return the default invalid path dictionary.
+    """
+
+    path: str = f'/this/is/not/a/real/path'
+    unknown_install_location_dict = {'install_dir': path, 'display_name': 'unknown', 'launcher': ''}
+    
+    result: dict[str, str] = get_install_location_from_directory_name(path)
+
+    assert result == unknown_install_location_dict


### PR DESCRIPTION
This PR adds a suite of tests for `util#get_install_location_from_directory_name`.

We test the following scenarios:
- Every known install location from our `POSSIBLE_INSTALL_LOCATIONS` constant. This also means if we add a new path we should have confidence that we'll be able to find the install path based on this test.
- A test for custom install directories.
- A test for returning the default invalid install location dictionary when a custom install directory does not have a launcher.
- A test for returning the default invalid install location dictionary when the given path does not correspond to a known path in `POSSIBLE_INSTALL_LOCATION` or a custom install directory.

For testing the Custom Install Directory, I opted to mock the return value from `config_custom_install_location` instead of writing out a value to a mocked file in a fake filesystem. I felt this was a simpler approach than working with a file and reduces the points of failure for the test (i.e. we're not directly relying on the functionality from `config_custom_install_location`).

As usual, all feedback is welcome. Thanks!