### PR TITLE
fix: prevent version selection reset when loading more releases

### DIFF
--- a/pupgui2/pupgui2installdialog.py
+++ b/pupgui2/pupgui2installdialog.py
@@ -102,7 +102,9 @@ class PupguiInstallDialog(QDialog):
             # Stops install dialog UI elements from being enabled when rate-limited to prevent switching/installing tools
             if len(vers) > 0:
                 self.ui.comboCompatToolVersion.addItems(vers)
-                self.ui.comboCompatToolVersion.setCurrentIndex(0)
+                # Only set current index to 0 on initial load, not when loading more
+                if self.loaded_page == 1:
+                    self.ui.comboCompatToolVersion.setCurrentIndex(0)
 
                 if self.more_releases_loadable:
                     self.ui.comboCompatToolVersion.addItem(self.tr('Load more...'))


### PR DESCRIPTION
## Summary
- Fixed pagination issue where the selected version would reset to index 0 when loading more releases
- Now only sets the index to 0 on initial page load, preserving user selection during pagination

## Problem
When users clicked "Load more..." to fetch additional releases, the version dropdown would reset to the first item (index 0), losing the user's current selection. This was frustrating when browsing through multiple pages of releases.

## Solution
Added a check to only set `setCurrentIndex(0)` when `loaded_page == 1` (initial load). This preserves the user's selected version when loading additional pages.

## Test plan
- [ ] Open installer dialog and select a compatibility tool
- [ ] Select a version from the dropdown
- [ ] Click "Load more..." at the bottom of the version list
- [ ] Verify the selected version remains unchanged after loading more releases
- [ ] Verify the first version is still selected by default on initial load

🤖 Generated with [Claude Code](https://claude.ai/code)