### PR TITLE
Kron4ek: Only download amd64 builds

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
+++ b/pupgui2/resources/ctmods/ctmod_kron4ekvanilla.py
@@ -38,7 +38,7 @@ class CtInstaller(GEProtonInstaller):
             'version', 'date', 'download', 'size'
         """
 
-        asset_condition = lambda asset: 'amd64' in asset.get('name', '') and 'staging' not in asset.get('name', '')
+        asset_condition = lambda asset: 'amd64' in asset.get('name', '') and not any(ignore in asset.get('name', '') for ignore in ['staging', 'wow64'])
         return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag, asset_condition=asset_condition)
 
     def is_system_compatible(self) -> bool:


### PR DESCRIPTION
Fixes #581.

This PR updates our `asset_condition` for Kron4ek Vanilla Wine builds so that it ignores the amd64-wow64 builds. When we search for assets we only check to include ones that have `amd64`, so `amd64-wow64` gets included and gets priority. Instead we should ignore these builds and only download `amd64` builds, as per #581.

Thanks!