### PR TITLE
Fix GE-Proton download

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_00protonge.py
+++ b/pupgui2/resources/ctmods/ctmod_00protonge.py
@@ -5,6 +5,7 @@
 import os
 import requests
 import hashlib
+import platform
 
 from PySide6.QtWidgets import QMessageBox
 from PySide6.QtCore import QObject, QCoreApplication, Signal, Property
@@ -102,7 +103,19 @@ class CtInstaller(QObject):
             'version', 'date', 'download', 'size', 'checksum'
         """
 
-        return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag, checksum_suffix='.sha512sum')
+        return fetch_project_release_data(self.CT_URL, self.release_format, self.rs, tag=tag, checksum_suffix='.sha512sum', asset_condition=self.__asset_condition, checksum_condition=self.__asset_condition)
+
+    def __asset_condition(self, asset):
+        # Proton-GE is only on Github so we short-circuit here
+        if not "browser_download_url" in asset:
+            return False
+
+        is_aarch64 = platform.machine().lower() in ("arm64", "aarch64")
+        if is_aarch64:
+            return "aarch64" in asset["browser_download_url"]
+
+        # x86_64 builds are nor marked as such
+        return "aarch64" not in asset["browser_download_url"]
 
     def __get_data(self, version: str, install_dir: str) -> tuple[dict | None, str | None]:
 

--- a/pupgui2/util.py
+++ b/pupgui2/util.py
@@ -697,7 +697,7 @@ def get_download_url_from_asset(release_url: str, asset: dict, release_format: s
     return ''
 
 
-def fetch_project_release_data(release_url: str, release_format: str, rs: requests.Session, tag: str = '', checksum_suffix: str = '', asset_condition: Callable | None = None) -> dict:
+def fetch_project_release_data(release_url: str, release_format: str, rs: requests.Session, tag: str = '', checksum_suffix: str = '', asset_condition: Callable | None = None, checksum_condition: Callable | None = None) -> dict:
 
     """
     Fetch information about a given release based on its tag, with an optional condition lambda.
@@ -730,7 +730,7 @@ def fetch_project_release_data(release_url: str, release_format: str, rs: reques
             values['size'] = asset.get('size', None)
 
         if bool(checksum_suffix) and not 'checksum' in values:
-            checksum_url = get_download_url_from_asset(release_url, asset, release_format=checksum_suffix)
+            checksum_url = get_download_url_from_asset(release_url, asset, release_format=checksum_suffix, asset_condition=checksum_condition)
 
             if not bool(checksum_url):
                 continue


### PR DESCRIPTION
fixes #623

The x86_64 builds don't mark themselves as such so its not possible to solve this in a nice way, instead we check if the release contains `aarch64` or not.

The logic is a bit primitive and could be simplifed into this:
```py
is_aarch64 = platform.machine().lower() in ("arm64", "aarch64")
is_aarch64_download = "aarch64" in asset["browser_download_url"]
return is_aarch64 == is_aarch64_download
```

but what this PR has is more readable.