### PR TITLE
fix: use correct ctmod configuration for Proton-RTSP

### DIFF
--- a/pupgui2/resources/ctmods/ctmod_rtspgeproton.py
+++ b/pupgui2/resources/ctmods/ctmod_rtspgeproton.py
@@ -1,22 +1,22 @@
 # pupgui2 compatibility tools module
-# SpookySkeleton's RTSP-GE-Proton
+# SpookySkeleton's Proton-RTSP
 # Copyright (C) 2021 DavidoTek, partially based on AUNaseef's protonup
 
 from PySide6.QtCore import QCoreApplication
 
-from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as GEProtonInstaller
+from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as ProtonGECTInstaller
 
 
-CT_NAME = 'RTSP Proton'
-CT_LAUNCHERS = ['steam', 'advmode']
-CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_rtspgeproton', '''Fork of GE-Proton with enhanced Windows Media Foundation support.''')}
+CT_NAME = 'Proton-RTSP'
+CT_LAUNCHERS = ['steam', 'heroicproton', 'bottles', 'lutris']
+CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_rtspgeproton', '''Compatibility tool for Steam Play based on Wine and additional components.''')}
 
 
-class CtInstaller(GEProtonInstaller):
+class CtInstaller(ProtonGECTInstaller):
 
     BUFFER_SIZE = 4096
-    CT_URL = 'https://api.github.com/repos/SpookySkeletons/proton-ge-rtsp/releases'
-    CT_INFO_URL = 'https://github.com/SpookySkeletons/proton-ge-rtsp/releases/tag/'
+    CT_URL = 'https://api.github.com/repos/SpookySkeletons/proton-rtsp/releases'
+    CT_INFO_URL = 'https://github.com/SpookySkeletons/proton-rtsp/releases/tag/'
 
     def __init__(self, main_window = None):
         super().__init__(main_window)

--- a/pupgui2/resources/ctmods/ctmod_rtspgeproton.py
+++ b/pupgui2/resources/ctmods/ctmod_rtspgeproton.py
@@ -4,15 +4,15 @@
 
 from PySide6.QtCore import QCoreApplication
 
-from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as ProtonGECTInstaller
+from pupgui2.resources.ctmods.ctmod_00protonge import CtInstaller as GEProtonInstaller
 
 
 CT_NAME = 'Proton-RTSP'
-CT_LAUNCHERS = ['steam', 'heroicproton', 'bottles', 'lutris']
+CT_LAUNCHERS = ['steam', 'heroicproton', 'bottles', 'lutris', 'advmode']
 CT_DESCRIPTION = {'en': QCoreApplication.instance().translate('ctmod_rtspgeproton', '''Compatibility tool for Steam Play based on Wine and additional components.''')}
 
 
-class CtInstaller(ProtonGECTInstaller):
+class CtInstaller(GEProtonInstaller):
 
     BUFFER_SIZE = 4096
     CT_URL = 'https://api.github.com/repos/SpookySkeletons/proton-rtsp/releases'


### PR DESCRIPTION
Due to an invalid ctmod configuration, the Proton-RTSP versions would not show up in the compatibility tool selector. This fixes it.